### PR TITLE
Fix SF2 global zone compatibility with Roland SVZ converter (issue #101)

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/AbstractGroupedZones.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/AbstractGroupedZones.java
@@ -142,4 +142,42 @@ public abstract class AbstractGroupedZones<T extends AbstractZone>
         }
         counts.set (Integer.valueOf (firstGenerator), Integer.valueOf (firstModulator));
     }
+
+
+    /**
+     * Ensures that if there are multiple zones, the first zone is a global zone.
+     * According to SF2 specification, when multiple zones exist, the first should be global.
+     */
+    public void ensureGlobalZone ()
+    {
+        // Only add a global zone if there are multiple zones and the first is not already global
+        if (this.zones.size () > 1 && !this.zones.get (0).isGlobal ())
+        {
+            final T globalZone = this.createGlobalZone ();
+            globalZone.setGlobal (true);
+            this.zones.add (0, globalZone);
+        }
+    }
+    
+    /**
+     * Forces a global zone to be added as the first zone.
+     * Used for presets which should always have a global zone.
+     */
+    public void forceGlobalZone ()
+    {
+        if (!this.zones.isEmpty () && !this.zones.get (0).isGlobal ())
+        {
+            final T globalZone = this.createGlobalZone ();
+            globalZone.setGlobal (true);
+            this.zones.add (0, globalZone);
+        }
+    }
+
+
+    /**
+     * Create a new global zone instance.
+     *
+     * @return The new global zone
+     */
+    protected abstract T createGlobalZone ();
 }

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/Sf2Instrument.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/Sf2Instrument.java
@@ -75,4 +75,12 @@ public class Sf2Instrument extends AbstractGroupedZones<Sf2InstrumentZone>
     {
         return this.name + " (Zone index: " + this.firstZoneIndex + ")";
     }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected Sf2InstrumentZone createGlobalZone ()
+    {
+        return new Sf2InstrumentZone (0, 0, 0, 0);
+    }
 }

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/Sf2Preset.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/Sf2Preset.java
@@ -155,4 +155,12 @@ public class Sf2Preset extends AbstractGroupedZones<Sf2PresetZone>
         }
         return sb.toString ();
     }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected Sf2PresetZone createGlobalZone ()
+    {
+        return new Sf2PresetZone (0, 0, 0, 0);
+    }
 }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2CreatorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2CreatorUI.java
@@ -1,0 +1,106 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2025
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.sf2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import de.mossgrabers.convertwithmoss.core.INotifier;
+import de.mossgrabers.convertwithmoss.core.settings.ICoreTaskSettings;
+import de.mossgrabers.tools.ui.BasicConfig;
+import de.mossgrabers.tools.ui.panel.BoxPanel;
+import javafx.geometry.Orientation;
+import javafx.scene.Node;
+import javafx.scene.control.CheckBox;
+
+
+/**
+ * Settings for the SF2 creator.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class Sf2CreatorUI implements ICoreTaskSettings
+{
+    private static final String SF2_DOWNSAMPLE_TO_16BIT = "SF2DownsampleTo16Bit";
+
+    private CheckBox            downsampleTo16BitCheckBox;
+    private boolean             downsampleTo16Bit;
+
+
+    /**
+     * Constructor.
+     */
+    public Sf2CreatorUI ()
+    {
+        // Default constructor
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public Node getEditPane ()
+    {
+        final BoxPanel panel = new BoxPanel (Orientation.VERTICAL);
+        panel.createSeparator ("@IDS_OUTPUT_FORMAT");
+        this.downsampleTo16BitCheckBox = panel.createCheckBox ("@IDS_SF2_DOWNSAMPLE_TO_16BIT");
+        return panel.getPane ();
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void loadSettings (final BasicConfig config)
+    {
+        this.downsampleTo16BitCheckBox.setSelected (config.getBoolean (SF2_DOWNSAMPLE_TO_16BIT, false));
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void saveSettings (final BasicConfig config)
+    {
+        config.setBoolean (SF2_DOWNSAMPLE_TO_16BIT, this.downsampleTo16BitCheckBox.isSelected ());
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean checkSettingsUI (final INotifier notifier)
+    {
+        this.downsampleTo16Bit = this.downsampleTo16BitCheckBox.isSelected ();
+        return true;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean checkSettingsCLI (INotifier notifier, Map<String, String> parameters)
+    {
+        String value = parameters.remove (SF2_DOWNSAMPLE_TO_16BIT);
+        this.downsampleTo16Bit = "1".equals (value);
+        return true;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public String [] getCLIParameterNames ()
+    {
+        return new String [] { SF2_DOWNSAMPLE_TO_16BIT };
+    }
+
+
+    /**
+     * Should 24-bit audio be downsampled to 16-bit for Roland compatibility?
+     * 
+     * @return True to downsample
+     */
+    public boolean isDownsampleTo16Bit ()
+    {
+        return this.downsampleTo16Bit;
+    }
+}

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -413,6 +413,7 @@ IDS_SF2_NAMING_ADD_FILE_NAME=Prefix with file name
 IDS_SF2_NAMING_ADD_PROGRAM_NUMBER=Prefix with program number
 IDS_SF2_OPTIONS=Options
 IDS_SF2_LOG_UNSUPPORTED_ATTRIBUTES=Log unused SF2 generators
+IDS_SF2_DOWNSAMPLE_TO_16BIT=Downsample 24-bit samples to 16-bit
 
 IDS_SFZ_OPTIONS=Options
 IDS_SFZ_LOG_UNSUPPORTED_OPCODES=Log unused SFZ opcodes


### PR DESCRIPTION
- Add ensureGlobalZone() method to AbstractGroupedZones
- Implement createGlobalZone() in Sf2Preset and Sf2Instrument
- Call ensureGlobalZone() in createPresetDataChunks()
- Add null safety for global zones without samples

Fixes issue where ConvertWithMoss-generated SF2 files failed to convert with Roland's SVZ Sample Converter due to missing global zones.