### PR TITLE
Fix Elektron Tonverk creator producing presets the device rejects

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 18.0.0
 
-* Added support for Elektron Tonverk emulti.
+* Added support for Elektron Tonverk elmulti.
 * Added support for Omnisphere 3.
 * Added support for reading Roland S-50, S-330, S-550, W-30.
 * Added support for reading Roland S-750, S-770, S-760, DJ-70, DJ-70 MkII, and SP-700.
@@ -19,6 +19,16 @@
   * New: Added support to read JSON based .xpm files.
 * Akai S1000/S3000
   * Fixed: Loops were not imported.
+* Elektron Tonverk
+  * Fixed: The preset file is now written with the correct '.elmulti' extension (was '.emulti') which the Tonverk requires.
+  * Fixed: Samples are now physically trimmed to the zone start/end instead of writing 'trim-start'/'trim-end' which the Tonverk only supports for single-file multi-samples and rejected the preset otherwise.
+  * Fixed: Loop positions written to the preset file were not updated for re-sampling and trimming. Loops are also clamped into the sample boundaries and short single-cycle loops keep their exact length when re-sampling to prevent pitch drift.
+  * Fixed: A velocity layer with velocity 0.0 made the Tonverk reject the whole preset and import the WAV files as loose samples. The factory default velocity is used instead.
+  * Fixed: The key-center was written with an inverted tuning direction.
+  * Fixed: Sample file references in the preset file could differ from the written WAV file names if a zone name contained characters which needed to be replaced. Samples are now named following the Elektron factory convention 'Name-VVV-NNN-note.wav'.
+  * Fixed: 'keep-looping-on-release' is now written for looped samples (the Tonverk otherwise stops looping on key release).
+  * Fixed: Preset names containing a single quote produced an invalid preset file.
+  * New: Sample chunks are only written when a loop is present and instrument/broadcast audio chunks are off by default since the Tonverk WAV parser is strict (factory files only contain 'fmt ', 'data' and 'smpl' chunks).
 * ISO File
   * New: Added detection of Ensoniq EPS/ASR ISOs.
   * New: Added detection of Roland images.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -252,7 +252,7 @@ Both the program (.zbp) as well as the bank (.zbb) are stored as monoliths (zipp
 ## Elektron Tonverk
 
 The Elektron Tonverk is a dedicated hardware sampler that marks an important milestone for Elektron as its first instrument to support multi-samples. This allows users to map multiple sampled sounds across keys or velocity ranges, creating more expressive and realistic instruments than single-sample playback alone.
-Sadly, the emulti format is very basic and limited. It only supports the basic multi-sample layout does not contain any synthesizer parameters like envelopes or filter settings.
+Sadly, the elmulti format is very basic and limited. It only supports the basic multi-sample layout does not contain any synthesizer parameters like envelopes or filter settings.
 Furthermore, even this basic setup has some limitations:
 
 * There are no key ranges, the Tonverk always plays the sample with the closest root note. This can lead to different key-ranges than in the source multi-sample.

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/creator/AbstractWavCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/creator/AbstractWavCreator.java
@@ -136,7 +136,13 @@ public abstract class AbstractWavCreator<T extends WavChunkSettingsUI> extends A
     }
 
 
-    private static void updateInstrumentChunk (final ISampleZone zone, final WaveFile wavFile)
+    /**
+     * Updates all parameters of a WAV instrument chunk.
+     *
+     * @param zone The zone from which to read the parameters
+     * @param wavFile The WAV file to update
+     */
+    protected static void updateInstrumentChunk (final ISampleZone zone, final WaveFile wavFile)
     {
         InstrumentChunk instrumentChunk = wavFile.getInstrumentChunk ();
         if (instrumentChunk == null)
@@ -155,7 +161,13 @@ public abstract class AbstractWavCreator<T extends WavChunkSettingsUI> extends A
     }
 
 
-    private static void updateBroadcastAudioChunk (final IMetadata metadata, final WaveFile wavFile)
+    /**
+     * Updates all parameters of a WAV broadcast audio extension chunk.
+     *
+     * @param metadata The metadata from which to read the parameters
+     * @param wavFile The WAV file to update
+     */
+    protected static void updateBroadcastAudioChunk (final IMetadata metadata, final WaveFile wavFile)
     {
         BroadcastAudioExtensionChunk broadcastAudioChunk = wavFile.getBroadcastAudioExtensionChunk ();
         if (broadcastAudioChunk == null)

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/ElektronMultiCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/ElektronMultiCreator.java
@@ -6,6 +6,7 @@ package de.mossgrabers.convertwithmoss.format.elektron;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
@@ -18,26 +19,48 @@ import de.mossgrabers.convertwithmoss.core.INotifier;
 import de.mossgrabers.convertwithmoss.core.creator.AbstractWavCreator;
 import de.mossgrabers.convertwithmoss.core.creator.DestinationAudioFormat;
 import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
 import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
 import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.file.AudioFileUtils;
+import de.mossgrabers.convertwithmoss.file.riff.CommonRiffChunkId;
+import de.mossgrabers.convertwithmoss.file.wav.WaveFile;
+import de.mossgrabers.convertwithmoss.file.wav.WaveRiffChunkId;
 import de.mossgrabers.convertwithmoss.format.elektron.ElektronMultiFile.ElektronKeyZone;
 import de.mossgrabers.convertwithmoss.format.elektron.ElektronMultiFile.ElektronSampleSlot;
 import de.mossgrabers.convertwithmoss.format.elektron.ElektronMultiFile.ElektronVelocityLayer;
+import de.mossgrabers.tools.ui.Functions;
 
 
 /**
- * Creator for preset files for the Elektron Tonverk (emulti). A preset has a description file and
+ * Creator for preset files for the Elektron Tonverk (elmulti). A preset has a description file and
  * the related samples are in the same folder.
  *
  * @author Jürgen Moßgraber
  */
 public class ElektronMultiCreator extends AbstractWavCreator<ElektronMultiCreatorUI>
 {
+    /**
+     * The factory default velocity. The Tonverk rejects the whole preset file if a velocity layer
+     * has a velocity of exactly 0.0 (the WAV files are then imported as loose samples instead)!
+     */
+    private static final double                 DEFAULT_VELOCITY       = 0.49411765;
+
+    /**
+     * Loops with a length up to this number of samples (after re-sampling) are considered to be
+     * single-cycle waveforms for which the loop length is kept as exact as possible.
+     */
+    private static final int                    SINGLE_CYCLE_THRESHOLD = 512;
+
     private static final DestinationAudioFormat OPTIMIZED_AUDIO_FORMAT = new DestinationAudioFormat (new int []
     {
         24
     }, 48000, true);
-    private static final DestinationAudioFormat DEFAULT_AUDIO_FORMAT   = new DestinationAudioFormat ();
+    private static final DestinationAudioFormat DEFAULT_AUDIO_FORMAT   = new DestinationAudioFormat (new int []
+    {
+        16,
+        24
+    }, -1, false);
     private static final Set<Integer>           SUPPORTED_BIT_DEPTHS   = new HashSet<> ();
     static
     {
@@ -70,26 +93,114 @@ public class ElektronMultiCreator extends AbstractWavCreator<ElektronMultiCreato
             this.notifier.logError ("IDS_NOTIFY_FOLDER_COULD_NOT_BE_CREATED", presetFolder.getAbsolutePath ());
             return;
         }
+        final String presetName = presetFolder.getName ();
 
-        final ElektronMultiFile elektronMulti = this.createPreset (multisampleSource);
-        final String presetFile = sampleName + ".emulti";
+        multisampleSource.setGroups (this.combineSplitStereo (multisampleSource));
+
+        // Rename all zones to the Elektron sample naming convention and make sure that all zones
+        // have a valid start/stop range set which is required for trimming
+        prepareZones (presetName, multisampleSource);
+
+        // Must be done before the samples are written and before the preset data is created!
+        if (resample)
+            recalculateForResample (multisampleSource);
+
+        // Store all samples - they are physically trimmed to the zone start/stop since the
+        // Tonverk does not support 'trim-start'/'trim-end' on separate per-sample WAV files and
+        // rejects such presets. Trimming updates the zone and loop positions accordingly!
+        this.writeSamples (presetFolder, multisampleSource, resample ? OPTIMIZED_AUDIO_FORMAT : DEFAULT_AUDIO_FORMAT, true);
+
+        // Create the preset file - must be done after the samples were written since trimming
+        // does update the zone/loop positions!
+        final ElektronMultiFile elektronMulti = createPreset (multisampleSource);
+        final String presetFile = presetName + ".elmulti";
         this.notifier.log ("IDS_NOTIFY_STORING", presetFile);
         elektronMulti.write (new File (presetFolder, presetFile).toPath ());
-
-        // Store all samples
-        if (resample)
-            recalculateSamplePositions (multisampleSource, 48000);
-        this.writeSamples (presetFolder, multisampleSource, resample ? OPTIMIZED_AUDIO_FORMAT : DEFAULT_AUDIO_FORMAT, false);
 
         this.progress.notifyDone ();
     }
 
 
-    private ElektronMultiFile createPreset (final IMultisampleSource multiSampleSource) throws IOException
+    /** {@inheritDoc} */
+    @Override
+    protected void rewriteFile (final IMultisampleSource multisampleSource, final ISampleZone zone, final OutputStream outputStream, final DestinationAudioFormat destinationFormat, final boolean trim) throws IOException
     {
-        final List<IGroup> groups = this.combineSplitStereo (multiSampleSource);
-        multiSampleSource.setGroups (groups);
+        final ISampleData sampleData = zone.getSampleData ();
+        if (sampleData == null)
+            return;
 
+        // Convert resolution
+        final WaveFile wavFile = AudioFileUtils.convertToWav (sampleData, destinationFormat);
+        if (wavFile.getDataChunk () == null)
+            throw new IOException (Functions.getMessage ("IDS_WAV_CONVERSION_FAILED", zone.getName ()));
+
+        // Trim sample from zone start to end. Afterwards, clamp all loops into the trimmed
+        // boundaries (inclusive end convention) like the reference implementation
+        if (trim)
+        {
+            trimStartToEnd (wavFile, zone);
+            clampLoops (zone);
+        }
+
+        // Update information chunks
+        if (this.settingsConfiguration.isUpdateBroadcastAudioChunk ())
+            updateBroadcastAudioChunk (multisampleSource.getMetadata (), wavFile);
+        if (this.settingsConfiguration.isUpdateInstrumentChunk ())
+            updateInstrumentChunk (zone, wavFile);
+        // Contrary to the base class, only write a sample chunk when there is a loop. The factory
+        // WAV files do not contain empty sample chunks and the Tonverk WAV parser is strict!
+        if (this.settingsConfiguration.isUpdateSampleChunk () && hasLoop (zone))
+            updateSampleChunk (zone, wavFile);
+        if (this.settingsConfiguration.isRemoveJunkChunks ())
+            wavFile.removeChunks (CommonRiffChunkId.JUNK_ID, CommonRiffChunkId.JUNK2_ID, WaveRiffChunkId.FILLER_ID, WaveRiffChunkId.MD5_ID);
+
+        wavFile.write (outputStream);
+    }
+
+
+    /**
+     * Renames all zones to the Elektron sample file naming convention
+     * ('InstrumentName-VVV-NNN-note') and makes sure that the start/stop range of all zones is
+     * fully set, which is required for trimming the WAV files.
+     *
+     * @param presetName The name of the preset which is used as the prefix of all sample names
+     * @param multiSampleSource The multi-sample source
+     * @throws IOException Could not read the audio metadata of a sample
+     */
+    private static void prepareZones (final String presetName, final IMultisampleSource multiSampleSource) throws IOException
+    {
+        for (final Entry<Integer, TreeMap<Integer, List<ISampleZone>>> velocityLayerMapEntry: multiSampleSource.getOrderedSampleZones (false).entrySet ())
+        {
+            final int keyRoot = Math.clamp (velocityLayerMapEntry.getKey ().intValue (), 0, 127);
+
+            int velocityLayerIndex = 0;
+            for (final List<ISampleZone> sampleZones: velocityLayerMapEntry.getValue ().values ())
+            {
+                for (int roundRobinIndex = 0; roundRobinIndex < sampleZones.size (); roundRobinIndex++)
+                {
+                    final ISampleZone zone = sampleZones.get (roundRobinIndex);
+                    zone.setName (ElektronMultiFile.createSampleName (presetName, velocityLayerIndex, keyRoot, roundRobinIndex));
+
+                    final ISampleData sampleData = zone.getSampleData ();
+                    if (sampleData == null)
+                        continue;
+                    final int numberOfSamples = sampleData.getAudioMetadata ().getNumberOfSamples ();
+                    final int stop = zone.getStop ();
+                    if (stop <= 0 || stop > numberOfSamples)
+                        zone.setStop (numberOfSamples);
+                    final int start = zone.getStart ();
+                    if (start < 0 || start >= zone.getStop ())
+                        zone.setStart (0);
+                }
+
+                velocityLayerIndex++;
+            }
+        }
+    }
+
+
+    private static ElektronMultiFile createPreset (final IMultisampleSource multiSampleSource)
+    {
         final ElektronMultiFile elektronMulti = new ElektronMultiFile ();
         elektronMulti.name = multiSampleSource.getName ();
 
@@ -98,7 +209,7 @@ public class ElektronMultiCreator extends AbstractWavCreator<ElektronMultiCreato
             final ElektronKeyZone keyZone = new ElektronKeyZone ();
             elektronMulti.keyZones.add (keyZone);
 
-            final int keyRoot = velocityLayerMapEntry.getKey ().intValue ();
+            final int keyRoot = Math.clamp (velocityLayerMapEntry.getKey ().intValue (), 0, 127);
             keyZone.pitch = keyRoot;
 
             Double tuning = null;
@@ -109,30 +220,34 @@ public class ElektronMultiCreator extends AbstractWavCreator<ElektronMultiCreato
                 final ElektronVelocityLayer velocityLayer = new ElektronVelocityLayer ();
                 keyZone.velocityLayers.add (velocityLayer);
 
-                final List<ISampleZone> sampleZones = sampleZonesEntry.getValue ();
-                velocityLayer.velocity = sampleZonesEntry.getKey ().intValue () / 127.0;
-                // If there is only one velocity layer center the velocity
-                if (sampleZones.size () == 1 && sampleZones.get (0).getVelocityLow () == 0)
-                    velocityLayer.velocity = 0.49411765;
+                // The Tonverk rejects a velocity of exactly 0.0, use the factory default instead
+                final double velocity = Math.clamp (sampleZonesEntry.getKey ().intValue (), 0, 127) / 127.0;
+                velocityLayer.velocity = velocity <= 0 ? DEFAULT_VELOCITY : velocity;
 
-                for (final ISampleZone sampleZone: sampleZones)
+                for (final ISampleZone sampleZone: sampleZonesEntry.getValue ())
                 {
                     final ElektronSampleSlot sampleSlot = new ElektronSampleSlot ();
                     velocityLayer.sampleSlots.add (sampleSlot);
 
-                    sampleSlot.sample = sampleZone.getName () + ".wav";
-                    sampleSlot.trimStart = Integer.valueOf (sampleZone.getStart ());
-                    sampleSlot.trimEnd = Integer.valueOf (sampleZone.getStop ());
+                    // Must be identical to the file name created in writeSamples!
+                    sampleSlot.sample = createSafeFilename (sampleZone.getName ()) + ".wav";
 
-                    final List<ISampleLoop> loops = sampleZone.getLoops ();
-                    final boolean hasLoop = !loops.isEmpty ();
-                    sampleSlot.loopMode = hasLoop ? "Forward" : "Off";
-                    if (hasLoop)
+                    // Note: 'trim-start'/'trim-end' must not be set! They are only supported for
+                    // single-file multi-samples. The WAV files are physically trimmed instead.
+
+                    final boolean isLooped = hasLoop (sampleZone);
+                    sampleSlot.loopMode = isLooped ? "Forward" : "Off";
+                    if (isLooped)
                     {
-                        final ISampleLoop sampleLoop = loops.get (0);
-                        sampleSlot.loopStart = Integer.valueOf (sampleLoop.getStart ());
+                        final ISampleLoop sampleLoop = sampleZone.getLoops ().get (0);
+                        sampleSlot.loopStart = Integer.valueOf (Math.max (0, sampleLoop.getStart ()));
                         sampleSlot.loopEnd = Integer.valueOf (sampleLoop.getEnd ());
-                        sampleSlot.loopCrossfade = Integer.valueOf (sampleLoop.getCrossfadeInSamples ());
+                        final int crossfade = sampleLoop.getCrossfadeInSamples ();
+                        if (crossfade > 0)
+                            sampleSlot.loopCrossfade = Integer.valueOf (crossfade);
+                        // Continue to loop in the release phase which is the default behavior of
+                        // all source formats
+                        sampleSlot.keepLoopingOnRelease = Boolean.TRUE;
                     }
 
                     if (tuningIsSame)
@@ -143,10 +258,99 @@ public class ElektronMultiCreator extends AbstractWavCreator<ElektronMultiCreato
                 }
             }
 
-            keyZone.keyCenter = keyRoot + (tuningIsSame && tuning != null ? tuning.doubleValue () : 0);
+            // The key-center moves in the opposite direction of the tuning: the Tonverk
+            // transposes the sample by 'pitch - key-center' semi-tones
+            keyZone.keyCenter = keyRoot - (tuningIsSame && tuning != null ? tuning.doubleValue () : 0);
         }
 
         return elektronMulti;
+    }
+
+
+    private static boolean hasLoop (final ISampleZone zone)
+    {
+        final List<ISampleLoop> loops = zone.getLoops ();
+        if (loops.isEmpty ())
+            return false;
+        final ISampleLoop loop = loops.get (0);
+        return loop.getEnd () > Math.max (0, loop.getStart ());
+    }
+
+
+    /**
+     * Re-calculates the sample start, stop and loop positions for 48kHz. Contrary to
+     * recalculateSamplePositions, the loop points are handled like in the reference
+     * implementation: normal loop points are truncated; short 'single-cycle' loops keep their
+     * exact length to prevent pitch drift (rounding both end points individually can change the
+     * loop length by 1 sample which detunes a e.g. 90 samples long waveform by about 19 cents).
+     *
+     * @param multisampleSource The multi-sample source
+     * @throws IOException Could not retrieve the current sample rate
+     */
+    private static void recalculateForResample (final IMultisampleSource multisampleSource) throws IOException
+    {
+        for (final IGroup group: multisampleSource.getGroups ())
+            for (final ISampleZone zone: group.getSampleZones ())
+            {
+                final ISampleData sampleData = zone.getSampleData ();
+                if (sampleData == null)
+                    continue;
+                final double ratio = 48000.0 / sampleData.getAudioMetadata ().getSampleRate ();
+                if (ratio == 1)
+                    continue;
+
+                final int start = zone.getStart ();
+                if (start > 0)
+                    zone.setStart ((int) Math.round (start * ratio));
+                final int stop = zone.getStop ();
+                if (stop > 0)
+                    zone.setStop ((int) Math.round (stop * ratio));
+
+                for (final ISampleLoop loop: zone.getLoops ())
+                {
+                    final int loopStart = loop.getStart ();
+                    final int loopEnd = loop.getEnd ();
+                    if (loopEnd <= 0)
+                        continue;
+
+                    // Loop ends are inclusive
+                    final int scaledLength = Math.max (1, (int) Math.round ((loopEnd - Math.max (0, loopStart) + 1) * ratio));
+                    if (scaledLength <= SINGLE_CYCLE_THRESHOLD)
+                    {
+                        // Single-cycle waveform: scale the length and round only once
+                        final int newStart = Math.max (0, (int) Math.round (loopStart * ratio));
+                        loop.setStart (newStart);
+                        loop.setEnd (newStart + scaledLength - 1);
+                    }
+                    else
+                    {
+                        // Normal loop: truncate like the reference implementation
+                        if (loopStart > 0)
+                            loop.setStart ((int) (loopStart * ratio));
+                        loop.setEnd ((int) (loopEnd * ratio));
+                    }
+                }
+            }
+    }
+
+
+    /**
+     * Clamps all loops of the zone into the sample boundaries (loop ends are inclusive). Must be
+     * called after trimming since the zone stop is then equal to the number of samples of the
+     * written WAV file.
+     *
+     * @param zone The zone
+     */
+    private static void clampLoops (final ISampleZone zone)
+    {
+        final int lastIndex = zone.getStop () - 1;
+        if (lastIndex < 0)
+            return;
+        for (final ISampleLoop loop: zone.getLoops ())
+        {
+            loop.setStart (Math.clamp (loop.getStart (), 0, lastIndex));
+            loop.setEnd (Math.clamp (loop.getEnd (), loop.getStart (), lastIndex));
+        }
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/ElektronMultiCreatorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/ElektronMultiCreatorUI.java
@@ -20,7 +20,7 @@ import javafx.scene.control.CheckBox;
 
 
 /**
- * Settings for the Elektron emulti creators.
+ * Settings for the Elektron elmulti creators.
  *
  * @author Jürgen Moßgraber
  */
@@ -40,7 +40,9 @@ public class ElektronMultiCreatorUI extends WavChunkSettingsUI
      */
     public ElektronMultiCreatorUI (final String prefix)
     {
-        super (prefix, true, true, true, true);
+        // Only the sample chunk is enabled by default: the Tonverk factory WAV files contain only
+        // 'fmt ', 'data' and 'smpl' chunks and the Tonverk WAV parser is strict
+        super (prefix, false, false, true, true);
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/ElektronMultiFile.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/ElektronMultiFile.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -94,8 +95,11 @@ public class ElektronMultiFile
         public Integer loopEnd;
         /** Loop cross-fade length in samples */
         public Integer loopCrossfade;
-        /** Continue looping after key release (used for waveforms). */
-        public Boolean keepLoopingOnRelease = Boolean.TRUE;
+        /**
+         * Continue looping after key release. If omitted, the Tonverk stops looping on key release
+         * (sustain loop).
+         */
+        public Boolean keepLoopingOnRelease = Boolean.FALSE;
         /** Sample start position within WAV file (for single-file multi-sample). */
         public Integer trimStart;
         /** Sample end position within WAV file (for single-file multi-sample). */
@@ -104,14 +108,32 @@ public class ElektronMultiFile
 
 
     /**
-     * Creates a sample name.
+     * Creates a sample file name including the '.wav' file ending.
      *
      * @param instrumentName The instrument name to add to the sample name
      * @param velocityLayer The velocity layer index to add to the sample name
      * @param midiNote The MIDI note to add to the sample name
-     * @return The formatted sample name
+     * @return The formatted sample file name
      */
     public static String createSampleFileName (final String instrumentName, final int velocityLayer, final int midiNote)
+    {
+        return createSampleName (instrumentName, velocityLayer, midiNote, 0) + ".wav";
+    }
+
+
+    /**
+     * Creates a sample name (without the file ending) following the Elektron factory naming
+     * convention: 'instrumentName-VVV-NNN-note' with an additional '-rrN' suffix for round-robin
+     * samples.
+     *
+     * @param instrumentName The instrument name to add to the sample name
+     * @param velocityLayer The velocity layer index to add to the sample name
+     * @param midiNote The MIDI note to add to the sample name
+     * @param roundRobinIndex The index of the sample in a round-robin chain, no suffix is added
+     *            for values less than 1
+     * @return The formatted sample name
+     */
+    public static String createSampleName (final String instrumentName, final int velocityLayer, final int midiNote, final int roundRobinIndex)
     {
         if (midiNote < 0 || midiNote > 127)
             throw new IllegalArgumentException ("midiNote out of range");
@@ -119,7 +141,8 @@ public class ElektronMultiFile
             throw new IllegalArgumentException ("velocityLayer must be >= 0");
         final int note = midiNote % 12;
         final int octave = midiNote / 12 - 2;
-        return String.format ("%s-%03d-%03d-%s%d.wav", instrumentName, Integer.valueOf (velocityLayer), Integer.valueOf (midiNote), NOTE_NAMES[note], Integer.valueOf (octave));
+        final String name = String.format ("%s-%03d-%03d-%s%d", instrumentName, Integer.valueOf (velocityLayer), Integer.valueOf (midiNote), NOTE_NAMES[note], Integer.valueOf (octave));
+        return roundRobinIndex > 0 ? name + "-rr" + roundRobinIndex : name;
     }
 
 
@@ -201,48 +224,48 @@ public class ElektronMultiFile
         final List<String> out = new ArrayList<> ();
         out.add ("# ELEKTRON MULTI-SAMPLE MAPPING FORMAT");
         out.add ("version = " + this.version);
-        out.add ("name = '" + escape (this.name) + "'");
-        out.add ("");
+        out.add ("name = " + quote (this.name));
 
         for (final ElektronKeyZone keyZone: this.keyZones)
         {
+            out.add ("");
             out.add ("[[key-zones]]");
             out.add ("pitch = " + keyZone.pitch);
-            out.add ("key-center = " + keyZone.keyCenter);
-            out.add ("");
+            out.add ("key-center = " + formatNumber (keyZone.keyCenter));
 
             for (final ElektronVelocityLayer velocityLayer: keyZone.velocityLayers)
             {
-                out.add ("[[key-zones.velocity-layers]]");
-                out.add ("velocity = " + velocityLayer.velocity);
-                if (velocityLayer.strategy != null)
-                    out.add ("strategy = '" + escape (velocityLayer.strategy) + "'");
                 out.add ("");
+                out.add ("[[key-zones.velocity-layers]]");
+                out.add ("velocity = " + formatNumber (velocityLayer.velocity));
+                if (velocityLayer.strategy != null)
+                    out.add ("strategy = " + quote (velocityLayer.strategy));
 
                 for (final ElektronSampleSlot sampleSlot: velocityLayer.sampleSlots)
                 {
+                    out.add ("");
                     out.add ("[[key-zones.velocity-layers.sample-slots]]");
-                    out.add ("sample = '" + escape (sampleSlot.sample) + "'");
-                    if (sampleSlot.loopMode != null)
-                        out.add ("loop-mode = '" + escape (sampleSlot.loopMode) + "'");
-                    if (sampleSlot.loopStart != null && sampleSlot.loopStart.intValue () >= 0)
-                        out.add ("loop-start = " + sampleSlot.loopStart);
-                    if (sampleSlot.loopEnd != null && sampleSlot.loopEnd.intValue () >= 0)
-                        out.add ("loop-end = " + sampleSlot.loopEnd);
-                    if (sampleSlot.loopCrossfade != null && sampleSlot.loopCrossfade.intValue () >= 0)
-                        out.add ("loop-crossfade = " + sampleSlot.loopCrossfade);
-                    if (sampleSlot.keepLoopingOnRelease != null && !sampleSlot.keepLoopingOnRelease.booleanValue ())
-                        out.add ("keep-looping-on-release = " + sampleSlot.keepLoopingOnRelease);
+                    out.add ("sample = " + quote (sampleSlot.sample));
                     if (sampleSlot.trimStart != null && sampleSlot.trimStart.intValue () >= 0)
                         out.add ("trim-start = " + sampleSlot.trimStart);
                     if (sampleSlot.trimEnd != null && sampleSlot.trimEnd.intValue () >= 0)
                         out.add ("trim-end = " + sampleSlot.trimEnd);
-                    out.add ("");
+                    if (sampleSlot.loopMode != null)
+                        out.add ("loop-mode = " + quote (sampleSlot.loopMode));
+                    if ("Forward".equals (sampleSlot.loopMode))
+                    {
+                        if (sampleSlot.loopStart != null && sampleSlot.loopStart.intValue () >= 0)
+                            out.add ("loop-start = " + sampleSlot.loopStart);
+                        if (sampleSlot.loopEnd != null && sampleSlot.loopEnd.intValue () >= 0)
+                            out.add ("loop-end = " + sampleSlot.loopEnd);
+                        if (sampleSlot.loopCrossfade != null && sampleSlot.loopCrossfade.intValue () >= 0)
+                            out.add ("loop-crossfade = " + sampleSlot.loopCrossfade);
+                        if (sampleSlot.keepLoopingOnRelease != null && sampleSlot.keepLoopingOnRelease.booleanValue ())
+                            out.add ("keep-looping-on-release = true");
+                    }
                 }
             }
         }
-        if (out.get (out.size () - 1).isBlank ())
-            out.remove (out.size () - 1);
         Files.write (path, out);
     }
 
@@ -305,9 +328,44 @@ public class ElektronMultiFile
     }
 
 
-    private static String escape (final String s)
+    /**
+     * Quotes a string value. Uses single quotes except when the value contains a single quote, in
+     * that case double quotes are used and contained double quotes are escaped.
+     *
+     * @param value The value to quote
+     * @return The quoted value
+     */
+    private static String quote (final String value)
     {
-        return s == null ? "" : s.replace ("'", "\'");
+        final String text = value == null ? "" : value;
+        if (!text.contains ("'"))
+            return "'" + text + "'";
+        return '"' + text.replace ("\"", "\\\"") + '"';
+    }
+
+
+    /**
+     * Formats a floating point number like the Tonverk factory files: integral values get one
+     * decimal place (e.g. '60.0'), all others a maximum of 8 significant digits (e.g.
+     * '0.49411765').
+     *
+     * @param value The value to format
+     * @return The formatted value
+     */
+    private static String formatNumber (final double value)
+    {
+        if (value == Math.rint (value) && Math.abs (value) < 1e15)
+            return String.format (Locale.US, "%.1f", Double.valueOf (value));
+
+        String text = String.format (Locale.US, "%.8g", Double.valueOf (value));
+        if (text.indexOf ('e') < 0 && text.indexOf ('E') < 0 && text.indexOf ('.') >= 0)
+        {
+            // Remove trailing zeros but keep at least one decimal digit
+            text = text.replaceAll ("0+$", "");
+            if (text.endsWith ("."))
+                text += "0";
+        }
+        return text;
     }
 
 


### PR DESCRIPTION
The Tonverk discarded converted presets and imported the WAV files as
loose samples (showing the first WAV's name as the instrument name) or
failed loading with a multi-sample error. Fixes verified against a
reference implementation tested on Tonverk hardware:

- Write the preset file with the correct '.elmulti' extension (was
  '.emulti') which the device and the detector require.
- Physically trim samples to the zone start/end instead of writing
  'trim-start'/'trim-end' which the device only accepts for
  single-file multi-samples and rejects otherwise.
- Create the preset data after re-sampling and trimming so trim and
  loop positions are written in output coordinates. Truncate normal
  loop points, keep the exact length of short single-cycle loops to
  prevent pitch drift and clamp loops into the sample boundaries.
- Never write a velocity layer with velocity 0.0 which makes the
  device reject the whole preset; substitute the factory default
  0.49411765.
- Fix the inverted tuning direction of 'key-center' (the detector
  already reads it as 'tuning = pitch - key-center').
- Name samples following the Elektron factory convention
  'Name-VVV-NNN-note[-rrN].wav' so the references in the preset file
  always match the written WAV file names (zone names previously went
  through createSafeFilename only for the files, not the references).
- Write 'keep-looping-on-release = true' for looped samples so loops
  sustain through the release phase (omitted means stop on release).
- Quote names containing single quotes correctly; the previous escape
  was a no-op and produced unparsable preset files.
- Only write a sample chunk when a loop exists and default the
  instrument/broadcast audio chunks to off: factory WAV files contain
  only 'fmt ', 'data' and 'smpl' chunks (in that order) and the
  device's WAV parser is strict.
- Format floats with up to 8 significant digits like the factory
  presets.

