### PR TITLE
Fix stereo compressed (FLAC/OGG) samples truncated to half length

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 18.1.2
+
+* Fixed: Stereo (multi-channel) samples stored in a compressed format (e.g. FLAC or OGG) were truncated to half their length when decompressed while writing to an uncompressed destination. This dropped the second half of every such sample and could move loop points to the wrong position (audible as a click at the loop point).
+
 ## 18.1.1
 
 * New: If the source does not contain pitch bend values, the default is now 2 semi-tones (instead of 0).

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/AudioFileUtils.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/AudioFileUtils.java
@@ -377,8 +377,11 @@ public final class AudioFileUtils
                 audioDataBytes = convertedAudioInputStream.readAllBytes ();
             }
 
-            // Step 2 - Convert from raw data to WAV format
-            final int numFrames = audioDataBytes.length / (convertFormat.getFrameSize () * channels);
+            // Step 2 - Convert from raw data to WAV format. Note: getFrameSize() already accounts
+            // for all channels (bytes-per-sample * channels), so it must not be multiplied by the
+            // channel count again - doing so halved the frame count for stereo samples and
+            // truncated them to half their length.
+            final int numFrames = audioDataBytes.length / convertFormat.getFrameSize ();
             final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream (audioDataBytes);
             try (final AudioInputStream wavAudioInputStream = new AudioInputStream (byteArrayInputStream, convertFormat, numFrames))
             {


### PR DESCRIPTION
## Problem

`AudioFileUtils.decompressToWav` computes the number of frames as:

```java
final int numFrames = audioDataBytes.length / (convertFormat.getFrameSize () * channels);
```

`AudioFormat.getFrameSize()` already accounts for all channels (bytes-per-sample × channels), so multiplying by `channels` again divides by the channel count twice. For stereo samples this yields **half** the real frame count, so the `AudioInputStream` is told it is half as long and `AudioSystem.write` emits only the first half of the audio. Mono samples (channels = 1) are unaffected, which is why this went unnoticed.

## Impact

Any conversion from a format that stores **stereo compressed** audio (FLAC/OGG) to a destination written as uncompressed WAV loses the second half of every sample. Because some creators store loop positions as a fraction of the sample length (e.g. Waldorf Quantum/Iridium), the loop end then lands at the wrong position in the now-shorter sample, which is audible as a click at the loop point.

Concrete example: converting a Renoise instrument (XRNI, which stores stereo FLAC) to Waldorf Quantum/Iridium produced 8.03 s patches from 16.05 s sources, and a sustained-note loop clicked on the hardware.

## Fix

Drop the redundant `* channels`:

```java
final int numFrames = audioDataBytes.length / convertFormat.getFrameSize ();
```

## Verification

For a stereo 48 kHz source resampled to 44.1 kHz / 16-bit:

* Output frame count: 353,991 (before) → 707,981 (after), matching an independent reference resample (707,963).
* Loop-seam discontinuity at the device loop point: 1.45–1.65 % full-scale (before) → 0.000 % (after).
