### PR TITLE
Add Synthstrom Deluge instrument format support (read + write)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * New: Added support for the Polyend Tracker (PTI) instrument format (thanks to Douglas Carmichael).
 * New: Added support for the Renoise instrument (XRNI) format (thanks to Douglas Carmichael).
+* New: Added support for the Synthstrom Deluge instrument format.
 * New: Added support for the Downloadable Sound format (DLS) - read only.
 * New: Added several new tags for category detection.
 * FLAC/OGG

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -65,6 +65,7 @@ The following multi-sample formats are supported:
 * [SFZ](#sfz)
 * [SoundFont 2](#soundfont-2)
 * [Spectrasonics Omnisphere 3](#spectrasonics-omnisphere-3)
+* [Synthstrom Deluge](#synthstrom-deluge)
 * [TAL Sampler](#tal-sampler)
 * [Waldorf Quantum MkI, MkII / Iridium / Iridium Core](#waldorf-quantum-mki-mkii--iridium--iridium-core)
 * [Yamaha YSFC](#yamaha-ysfc)
@@ -578,6 +579,23 @@ then move the prt_omn file to
 
 **Note 1**: You can create a sub-folder with the name of a category, e.g. "Vox Humana" and put it there.
 **Note 2**: When opening Omnisphere both the presets and soundsources need to be rescanned! If only the presets are scanned an error shows up that the soundsource cannot be located!
+
+## Synthstrom Deluge
+
+The Synthstrom Audible Deluge is a standalone hardware synthesizer, sampler and sequencer. Its sounds are stored as XML files (file ending *xml*) on the SD-card; a *sound* holds a (multi-)sample based synth voice and a *kit* holds a set of drums. The samples themselves are referenced by a path which is relative to the SD-card root (e.g. *SAMPLES/My Patch/C3.wav*). Both reading and writing are supported.
+
+The Deluge has gone through several firmware generations which changed how the XML is written: the official firmware (up to v4) stores the parameters as child elements while the community firmware additionally writes them as attributes. When reading, **both** variants - and both *sound* and *kit* files - are understood, so patches authored on either firmware are translated without losing information. The sample mapping (key ranges), the original root note (from the *transpose* / *cents* offset, or the fixed root note of a drum), the sample playback start/end and loop points, the loop mode (one-shot or loop), the reversed flag, the low- and high-pass filter (with the various filter modes) as well as the amplitude envelope and the velocity-to-volume modulation are converted.
+
+When writing, a multi-sample is stored as a *sound* patch with a single sample oscillator whose zones are written as a *sampleRanges* list. The file is written in the **element-based form of the official v4 firmware** (`firmwareVersion="4.1.0-alpha"`), so it loads on both the official v4 firmware and on the community firmware - no community-only features are used. The output mirrors the Deluge SD-card layout: the patch is written to a *SYNTHS* sub-folder and its samples to *SAMPLES/&lt;name&gt;/* next to it, and the *fileName* references are written relative to that card root.
+
+### Destination Options
+
+* Options to write/update [WAV Chunk Information](#wav-chunk-information).
+
+### Limitations
+
+* A Deluge *sound* has a single sample oscillator with one sample per key, therefore only one velocity layer is written. If a source contains several velocity layers, the loudest zone of each key is kept and the others are ignored.
+* The filter cut-off / resonance and the envelope times are stored as the Deluge's internal 32-bit parameter values. Since the device uses internal (table driven) curves for these, the conversion is a musically faithful approximation rather than an exact match.
 
 ## TAL Sampler
 

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -588,6 +588,8 @@ The Deluge has gone through several firmware generations which changed how the X
 
 When writing, a multi-sample is stored as a *sound* patch with a single sample oscillator whose zones are written as a *sampleRanges* list. The file is written in the **element-based form of the official v4 firmware** (`firmwareVersion="4.1.0-alpha"`), so it loads on both the official v4 firmware and on the community firmware - no community-only features are used. The output mirrors the Deluge SD-card layout: the patch is written to a *SYNTHS* sub-folder and its samples to *SAMPLES/&lt;name&gt;/* next to it, and the *fileName* references are written relative to that card root.
 
+The Deluge has no loop cross-fade parameter of its own, so - exactly like the Renoise format - a loop cross-fade is baked into the looped sample audio. This happens automatically (there is no extra option) whenever a forward loop has a cross-fade: set one with the *Set fixed loop-crossfade* processing option, or it is taken from the source. This removes clicks at the loop point of samples whose loop was not designed to be click-free without a cross-fade (many auto-sampled instruments rely on the host applying a cross-fade at play time). With no cross-fade set, the loop is written exactly as it is.
+
 ### Destination Options
 
 * Options to write/update [WAV Chunk Information](#wav-chunk-information).
@@ -595,7 +597,7 @@ When writing, a multi-sample is stored as a *sound* patch with a single sample o
 ### Limitations
 
 * A Deluge *sound* has a single sample oscillator with one sample per key, therefore only one velocity layer is written. If a source contains several velocity layers, the loudest zone of each key is kept and the others are ignored.
-* The filter cut-off / resonance and the envelope times are stored as the Deluge's internal 32-bit parameter values. Since the device uses internal (table driven) curves for these, the conversion is a musically faithful approximation rather than an exact match.
+* The amplitude envelope attack, decay and release times are converted using the Deluge's internal rate tables (attack about 0.7 ms .. 3 s, decay/release about 6 ms .. 6 s); times outside that range are clamped. The filter cut-off / resonance are stored as the Deluge's internal 32-bit parameter values and are a musically faithful approximation rather than an exact match.
 
 ## TAL Sampler
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
@@ -79,6 +79,8 @@ import de.mossgrabers.convertwithmoss.format.sfz.SfzCreator;
 import de.mossgrabers.convertwithmoss.format.sfz.SfzDetector;
 import de.mossgrabers.convertwithmoss.format.sxt.SxtCreator;
 import de.mossgrabers.convertwithmoss.format.sxt.SxtDetector;
+import de.mossgrabers.convertwithmoss.format.synthstrom.DelugeCreator;
+import de.mossgrabers.convertwithmoss.format.synthstrom.DelugeDetector;
 import de.mossgrabers.convertwithmoss.format.tal.TALSamplerCreator;
 import de.mossgrabers.convertwithmoss.format.tal.TALSamplerDetector;
 import de.mossgrabers.convertwithmoss.format.tx16wx.TX16WxCreator;
@@ -154,6 +156,7 @@ public class ConverterBackend
             new OmnisphereDetector (notifier),
             new PolyendTrackerDetector (notifier),
             new RenoiseDetector (notifier),
+            new DelugeDetector (notifier),
             new S5xxDetector (notifier),
             new S770Detector (notifier),
             new SxtDetector (notifier),
@@ -185,6 +188,7 @@ public class ConverterBackend
             new OmnisphereCreator (notifier),
             new PolyendTrackerCreator (notifier),
             new RenoiseCreator (notifier),
+            new DelugeCreator (notifier),
             new SxtCreator (notifier),
             new WavCreator (notifier),
             new SfzCreator (notifier),

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
@@ -1,0 +1,408 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synthstrom;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.INotifier;
+import de.mossgrabers.convertwithmoss.core.creator.AbstractWavCreator;
+import de.mossgrabers.convertwithmoss.core.detector.DefaultMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.model.IAudioMetadata;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
+import de.mossgrabers.convertwithmoss.core.model.IFilter;
+import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.IMetadata;
+import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.core.model.enumeration.FilterType;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultGroup;
+import de.mossgrabers.convertwithmoss.core.settings.WavChunkSettingsUI;
+import de.mossgrabers.tools.FileUtils;
+import de.mossgrabers.tools.XMLUtils;
+
+
+/**
+ * Creator for Synthstrom Deluge synth (sound) preset files. A preset is an XML file (placed in a
+ * <i>SYNTHS</i> folder) which references its samples (placed in a <i>SAMPLES</i> folder) by a path
+ * relative to the SD card root. The multi-sample is written as a single sample oscillator with one
+ * sample range per zone.
+ * <p>
+ * Only features available on the official v4 firmware are written so that the created instruments
+ * load on both the official and the community firmware. The element based file structure is used
+ * which is understood by all firmware versions.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class DelugeCreator extends AbstractWavCreator<WavChunkSettingsUI>
+{
+    private static final String SYNTHS_FOLDER  = "SYNTHS";
+    private static final String SAMPLES_FOLDER = "SAMPLES";
+
+
+    /**
+     * Constructor.
+     *
+     * @param notifier The notifier
+     */
+    public DelugeCreator (final INotifier notifier)
+    {
+        super ("Synthstrom Deluge", "Deluge", notifier, new WavChunkSettingsUI ("Deluge"));
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void createPreset (final File destinationFolder, final IMultisampleSource multisampleSource) throws IOException
+    {
+        final List<ISampleZone> zones = getMappedZones (multisampleSource);
+        if (zones.isEmpty ())
+        {
+            this.notifier.logError ("IDS_DELUGE_NO_SAMPLES");
+            return;
+        }
+        makeUniqueSampleNames (zones);
+
+        // Create the SYNTHS folder and a unique preset file inside it
+        final File synthsFolder = new File (destinationFolder, SYNTHS_FOLDER);
+        safeCreateDirectory (synthsFolder);
+        final File presetFile = this.createUniqueFilename (synthsFolder, createSafeFilename (multisampleSource.getName ()), "xml");
+        final String baseName = FileUtils.getNameWithoutType (presetFile);
+        this.notifier.log ("IDS_NOTIFY_STORING", presetFile.getAbsolutePath ());
+
+        final String relativeSampleFolder = SAMPLES_FOLDER + "/" + baseName;
+
+        // Write the samples into SAMPLES/<name>/
+        final File sampleFolder = new File (destinationFolder, relativeSampleFolder);
+        safeCreateDirectory (sampleFolder);
+        this.writeSamples (sampleFolder, createTemporarySource (multisampleSource, zones));
+
+        // Create and store the XML document referencing the samples by their card-relative path
+        final Optional<String> metadata = this.createSoundDocument (zones, relativeSampleFolder);
+        if (metadata.isEmpty ())
+            return;
+        try (final FileWriter writer = new FileWriter (presetFile, StandardCharsets.UTF_8))
+        {
+            writer.write (metadata.get ());
+        }
+
+        this.progress.notifyDone ();
+    }
+
+
+    /**
+     * Collect the zones to write. The Deluge synth only supports a single layer mapped across the
+     * keyboard, therefore zones from all groups are flattened and - if several zones share the same
+     * upper key - only the one with the highest velocity is kept.
+     *
+     * @param multisampleSource The multi-sample source
+     * @return The zones sorted by their upper key
+     */
+    private static List<ISampleZone> getMappedZones (final IMultisampleSource multisampleSource)
+    {
+        final List<ISampleZone> allZones = new ArrayList<> ();
+        for (final IGroup group: multisampleSource.getNonEmptyGroups (true))
+            allZones.addAll (group.getSampleZones ());
+
+        allZones.sort (Comparator.comparingInt ((final ISampleZone zone) -> limitToDefault (zone.getKeyHigh (), 127)).thenComparing (Comparator.comparingInt ((final ISampleZone zone) -> limitToDefault (zone.getVelocityHigh (), 127)).reversed ()));
+
+        final List<ISampleZone> result = new ArrayList<> ();
+        int lastKeyHigh = Integer.MIN_VALUE;
+        for (final ISampleZone zone: allZones)
+        {
+            final int keyHigh = limitToDefault (zone.getKeyHigh (), 127);
+            if (keyHigh == lastKeyHigh)
+                continue;
+            result.add (zone);
+            lastKeyHigh = keyHigh;
+        }
+        return result;
+    }
+
+
+    /**
+     * Make the names of the zones unique (and file system safe) so that each one is written to its
+     * own sample file.
+     *
+     * @param zones The zones to update
+     */
+    private static void makeUniqueSampleNames (final List<ISampleZone> zones)
+    {
+        final Set<String> usedNames = new HashSet<> ();
+        for (final ISampleZone zone: zones)
+        {
+            final String base = createSafeFilename (zone.getName ());
+            String name = base;
+            int counter = 2;
+            while (!usedNames.add (name.toLowerCase (Locale.ENGLISH)))
+                name = base + "_" + counter++;
+            zone.setName (name);
+        }
+    }
+
+
+    /**
+     * Create a temporary multi-sample source containing only the given zones in a single group so
+     * that exactly these zones are written by {@link #writeSamples}.
+     *
+     * @param multisampleSource The original multi-sample source (used for the metadata)
+     * @param zones The zones to write
+     * @return The temporary source
+     */
+    private static IMultisampleSource createTemporarySource (final IMultisampleSource multisampleSource, final List<ISampleZone> zones)
+    {
+        final IGroup group = new DefaultGroup ();
+        for (final ISampleZone zone: zones)
+            group.addSampleZone (zone);
+
+        final DefaultMultisampleSource source = new DefaultMultisampleSource ();
+        source.setGroups (Collections.singletonList (group));
+
+        final IMetadata sourceMetadata = multisampleSource.getMetadata ();
+        final IMetadata metadata = source.getMetadata ();
+        metadata.setDescription (sourceMetadata.getDescription ());
+        metadata.setCreator (sourceMetadata.getCreator ());
+        metadata.setCategory (sourceMetadata.getCategory ());
+        metadata.setCreationDateTime (sourceMetadata.getCreationDateTime ());
+        return source;
+    }
+
+
+    /**
+     * Create the XML structure of the synth preset.
+     *
+     * @param zones The zones to write
+     * @param relativeSampleFolder The card-relative path of the sample folder
+     * @return The XML document as a string
+     */
+    private Optional<String> createSoundDocument (final List<ISampleZone> zones, final String relativeSampleFolder)
+    {
+        final Optional<Document> optionalDocument = this.createXMLDocument ();
+        if (optionalDocument.isEmpty ())
+            return Optional.empty ();
+        final Document document = optionalDocument.get ();
+        document.setXmlStandalone (true);
+
+        final Element soundElement = document.createElement (DelugeTag.SOUND);
+        document.appendChild (soundElement);
+        soundElement.setAttribute (DelugeTag.FIRMWARE_VERSION, DelugeTag.FIRMWARE_VERSION_VALUE);
+        soundElement.setAttribute (DelugeTag.EARLIEST_COMPATIBLE_FIRMWARE, DelugeTag.EARLIEST_COMPATIBLE_VALUE);
+
+        final boolean anyLoop = zones.stream ().anyMatch (zone -> !zone.getLoops ().isEmpty ());
+        final boolean reversed = zones.stream ().anyMatch (ISampleZone::isReversed);
+
+        // Oscillator 1 with the sample(s)
+        final Element osc1 = XMLUtils.addElement (document, soundElement, DelugeTag.OSC1);
+        XMLUtils.addTextElement (document, osc1, DelugeTag.TYPE, DelugeTag.TYPE_SAMPLE);
+        XMLUtils.addTextElement (document, osc1, DelugeTag.LOOP_MODE, Integer.toString (anyLoop ? DelugeTag.LOOP_MODE_LOOP : DelugeTag.LOOP_MODE_ONCE));
+        XMLUtils.addTextElement (document, osc1, DelugeTag.REVERSED, reversed ? "1" : "0");
+        XMLUtils.addTextElement (document, osc1, DelugeTag.TIME_STRETCH_ENABLE, "0");
+        XMLUtils.addTextElement (document, osc1, DelugeTag.TIME_STRETCH_AMOUNT, "0");
+
+        if (zones.size () == 1)
+            this.writeZone (document, osc1, zones.get (0), relativeSampleFolder, -1);
+        else
+        {
+            final Element sampleRanges = XMLUtils.addElement (document, osc1, DelugeTag.SAMPLE_RANGES);
+            for (int i = 0; i < zones.size (); i++)
+            {
+                final Element sampleRange = XMLUtils.addElement (document, sampleRanges, DelugeTag.SAMPLE_RANGE);
+                // The last (highest) range does not store the top note - it covers everything above
+                final int topNote = i == zones.size () - 1 ? -1 : limitToDefault (zones.get (i).getKeyHigh (), 127);
+                this.writeZone (document, sampleRange, zones.get (i), relativeSampleFolder, topNote);
+            }
+        }
+
+        // Silent second oscillator
+        final Element osc2 = XMLUtils.addElement (document, soundElement, DelugeTag.OSC2);
+        XMLUtils.addTextElement (document, osc2, DelugeTag.TYPE, DelugeTag.TYPE_SQUARE);
+
+        XMLUtils.addTextElement (document, soundElement, DelugeTag.POLYPHONIC, DelugeTag.POLYPHONIC_POLY);
+        XMLUtils.addTextElement (document, soundElement, DelugeTag.VOICE_PRIORITY, "1");
+        XMLUtils.addTextElement (document, soundElement, DelugeTag.MODE, DelugeTag.MODE_SUBTRACTIVE);
+        XMLUtils.addTextElement (document, soundElement, DelugeTag.LPF_MODE, DelugeTag.LPF_MODE_24DB);
+
+        final Element unison = XMLUtils.addElement (document, soundElement, DelugeTag.UNISON);
+        XMLUtils.addTextElement (document, unison, DelugeTag.UNISON_NUM, "1");
+        XMLUtils.addTextElement (document, unison, DelugeTag.UNISON_DETUNE, "8");
+
+        this.writeDefaultParams (document, soundElement, zones.get (0));
+
+        return this.createXMLString (document);
+    }
+
+
+    /**
+     * Write the file name, pitch and zone (sample positions) for one zone.
+     *
+     * @param document The XML document
+     * @param parent The parent element (the oscillator for a single sample or a sample range)
+     * @param zone The zone
+     * @param relativeSampleFolder The card-relative path of the sample folder
+     * @param topNote The top note of the range or -1 if it should not be written
+     */
+    private void writeZone (final Document document, final Element parent, final ISampleZone zone, final String relativeSampleFolder, final int topNote)
+    {
+        if (topNote >= 0)
+            XMLUtils.addTextElement (document, parent, DelugeTag.RANGE_TOP_NOTE, Integer.toString (topNote));
+
+        XMLUtils.addTextElement (document, parent, DelugeTag.FILE_NAME, relativeSampleFolder + "/" + createSafeFilename (zone.getName ()) + ".wav");
+
+        final double rootNote = (zone.getKeyRoot () < 0 ? limitToDefault (zone.getKeyHigh (), DelugeValues.REFERENCE_NOTE) : zone.getKeyRoot ()) + zone.getTuning ();
+        final int [] transposeCents = DelugeValues.transposeCentsFromRootNote (rootNote);
+        XMLUtils.addTextElement (document, parent, DelugeTag.TRANSPOSE_OSC, Integer.toString (transposeCents[0]));
+        XMLUtils.addTextElement (document, parent, DelugeTag.CENTS, Integer.toString (transposeCents[1]));
+
+        final Element zoneElement = XMLUtils.addElement (document, parent, DelugeTag.ZONE);
+        XMLUtils.addTextElement (document, zoneElement, DelugeTag.START_SAMPLE_POS, Integer.toString (Math.max (0, zone.getStart ())));
+        XMLUtils.addTextElement (document, zoneElement, DelugeTag.END_SAMPLE_POS, Integer.toString (getEndPosition (zone)));
+
+        final List<ISampleLoop> loops = zone.getLoops ();
+        if (!loops.isEmpty ())
+        {
+            final ISampleLoop loop = loops.get (0);
+            XMLUtils.addTextElement (document, zoneElement, DelugeTag.START_LOOP_POS, Integer.toString (Math.max (0, loop.getStart ())));
+            XMLUtils.addTextElement (document, zoneElement, DelugeTag.END_LOOP_POS, Integer.toString (Math.max (0, loop.getEnd ())));
+        }
+    }
+
+
+    /**
+     * Write the default parameters (oscillator volumes, filter, amplitude envelope and the velocity
+     * to volume patch cable).
+     *
+     * @param document The XML document
+     * @param soundElement The sound element
+     * @param firstZone The first zone (used for the amplitude envelope and filter)
+     */
+    private void writeDefaultParams (final Document document, final Element soundElement, final ISampleZone firstZone)
+    {
+        final Element defaultParams = XMLUtils.addElement (document, soundElement, DelugeTag.DEFAULT_PARAMS);
+
+        XMLUtils.addTextElement (document, defaultParams, DelugeTag.OSC_A_VOLUME, DelugeValues.formatHex (DelugeValues.PARAM_MAX));
+        XMLUtils.addTextElement (document, defaultParams, DelugeTag.OSC_B_VOLUME, DelugeValues.formatHex (DelugeValues.PARAM_MIN));
+
+        writeFilter (document, defaultParams, firstZone.getFilter ().orElse (null));
+
+        final Element envelope1 = XMLUtils.addElement (document, defaultParams, DelugeTag.ENVELOPE1);
+        final IEnvelope ampEnvelope = firstZone.getAmplitudeEnvelopeModulator ().getSource ();
+        XMLUtils.addTextElement (document, envelope1, DelugeTag.ATTACK, DelugeValues.formatHex (DelugeValues.timeToParam (ampEnvelope.getAttackTime ())));
+        XMLUtils.addTextElement (document, envelope1, DelugeTag.DECAY, DelugeValues.formatHex (envelopeDecay (ampEnvelope)));
+        XMLUtils.addTextElement (document, envelope1, DelugeTag.SUSTAIN, DelugeValues.formatHex (envelopeSustain (ampEnvelope)));
+        XMLUtils.addTextElement (document, envelope1, DelugeTag.RELEASE, DelugeValues.formatHex (DelugeValues.timeToParam (ampEnvelope.getReleaseTime ())));
+
+        // Make the sound velocity sensitive (matches the firmware's default for sample based sounds)
+        final Element patchCables = XMLUtils.addElement (document, defaultParams, DelugeTag.PATCH_CABLES);
+        final Element patchCable = XMLUtils.addElement (document, patchCables, DelugeTag.PATCH_CABLE);
+        XMLUtils.addTextElement (document, patchCable, DelugeTag.SOURCE, DelugeTag.SOURCE_VELOCITY);
+        XMLUtils.addTextElement (document, patchCable, DelugeTag.DESTINATION, DelugeTag.DESTINATION_VOLUME);
+        XMLUtils.addTextElement (document, patchCable, DelugeTag.AMOUNT, DelugeValues.formatHex (DelugeValues.PATCH_CABLE_FULL));
+    }
+
+
+    /**
+     * Write the low-pass and high-pass filter frequency/resonance. If a filter is set it is mapped,
+     * otherwise the filter is left fully open.
+     *
+     * @param document The XML document
+     * @param defaultParams The default parameters element
+     * @param filter The filter or null
+     */
+    private static void writeFilter (final Document document, final Element defaultParams, final IFilter filter)
+    {
+        int lpfFrequency = DelugeValues.PARAM_MAX;
+        int lpfResonance = DelugeValues.PARAM_MIN;
+        int hpfFrequency = DelugeValues.PARAM_MIN;
+        int hpfResonance = DelugeValues.PARAM_MIN;
+
+        if (filter != null)
+        {
+            final int frequency = DelugeValues.cutoffToParam (filter.getCutoff ());
+            final int resonance = DelugeValues.levelToParam (filter.getResonance ());
+            if (filter.getType () == FilterType.HIGH_PASS)
+            {
+                hpfFrequency = frequency;
+                hpfResonance = resonance;
+            }
+            else
+            {
+                lpfFrequency = frequency;
+                lpfResonance = resonance;
+            }
+        }
+
+        XMLUtils.addTextElement (document, defaultParams, DelugeTag.LPF_FREQUENCY, DelugeValues.formatHex (lpfFrequency));
+        XMLUtils.addTextElement (document, defaultParams, DelugeTag.LPF_RESONANCE, DelugeValues.formatHex (lpfResonance));
+        XMLUtils.addTextElement (document, defaultParams, DelugeTag.HPF_FREQUENCY, DelugeValues.formatHex (hpfFrequency));
+        XMLUtils.addTextElement (document, defaultParams, DelugeTag.HPF_RESONANCE, DelugeValues.formatHex (hpfResonance));
+    }
+
+
+    /**
+     * Get the end sample position of a zone. If the zone does not specify an end the total number of
+     * samples is used.
+     *
+     * @param zone The zone
+     * @return The end position in samples
+     */
+    private static int getEndPosition (final ISampleZone zone)
+    {
+        final int stop = zone.getStop ();
+        if (stop > 0)
+            return stop;
+        try
+        {
+            final IAudioMetadata audioMetadata = zone.getSampleData ().getAudioMetadata ();
+            final int numberOfSamples = audioMetadata.getNumberOfSamples ();
+            if (numberOfSamples > 0)
+                return numberOfSamples;
+        }
+        catch (final IOException ex)
+        {
+            // Ignore and fall through
+        }
+        return Math.max (0, stop);
+    }
+
+
+    /**
+     * Calculate the Deluge decay parameter value combining the hold and decay phases.
+     *
+     * @param envelope The envelope
+     * @return The Deluge parameter value
+     */
+    private static int envelopeDecay (final IEnvelope envelope)
+    {
+        final double decayTime = Math.max (0, envelope.getHoldTime ()) + Math.max (0, envelope.getDecayTime ());
+        return envelope.getDecayTime () < 0 && envelope.getHoldTime () < 0 ? DelugeValues.userValueToParam (20) : DelugeValues.timeToParam (decayTime);
+    }
+
+
+    /**
+     * Calculate the Deluge sustain parameter value.
+     *
+     * @param envelope The envelope
+     * @return The Deluge parameter value
+     */
+    private static int envelopeSustain (final IEnvelope envelope)
+    {
+        final double sustainLevel = envelope.getSustainLevel ();
+        return sustainLevel < 0 ? DelugeValues.PARAM_MAX : DelugeValues.levelToParam (sustainLevel);
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
@@ -23,6 +23,7 @@ import org.w3c.dom.Element;
 import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
 import de.mossgrabers.convertwithmoss.core.INotifier;
 import de.mossgrabers.convertwithmoss.core.creator.AbstractWavCreator;
+import de.mossgrabers.convertwithmoss.core.creator.DestinationAudioFormat;
 import de.mossgrabers.convertwithmoss.core.detector.DefaultMultisampleSource;
 import de.mossgrabers.convertwithmoss.core.model.IAudioMetadata;
 import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
@@ -32,8 +33,12 @@ import de.mossgrabers.convertwithmoss.core.model.IMetadata;
 import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
 import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
 import de.mossgrabers.convertwithmoss.core.model.enumeration.FilterType;
+import de.mossgrabers.convertwithmoss.core.model.enumeration.LoopType;
 import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultGroup;
 import de.mossgrabers.convertwithmoss.core.settings.WavChunkSettingsUI;
+import de.mossgrabers.convertwithmoss.file.wav.DataChunk;
+import de.mossgrabers.convertwithmoss.file.wav.FormatChunk;
+import de.mossgrabers.convertwithmoss.file.wav.WaveFile;
 import de.mossgrabers.tools.FileUtils;
 import de.mossgrabers.tools.XMLUtils;
 
@@ -47,6 +52,11 @@ import de.mossgrabers.tools.XMLUtils;
  * Only features available on the official v4 firmware are written so that the created instruments
  * load on both the official and the community firmware. The element based file structure is used
  * which is understood by all firmware versions.
+ * <p>
+ * The Deluge has no loop cross-fade parameter of its own. Like the Renoise creator, a loop
+ * cross-fade - set with the 'Set fixed loop-crossfade' processing option or read from the source -
+ * is therefore baked into the looped sample audio. No extra option is needed for this; the
+ * cross-fade is applied automatically whenever a forward loop carries one.
  *
  * @author Jürgen Moßgraber
  */
@@ -302,10 +312,10 @@ public class DelugeCreator extends AbstractWavCreator<WavChunkSettingsUI>
 
         final Element envelope1 = XMLUtils.addElement (document, defaultParams, DelugeTag.ENVELOPE1);
         final IEnvelope ampEnvelope = firstZone.getAmplitudeEnvelopeModulator ().getSource ();
-        XMLUtils.addTextElement (document, envelope1, DelugeTag.ATTACK, DelugeValues.formatHex (DelugeValues.timeToParam (ampEnvelope.getAttackTime ())));
+        XMLUtils.addTextElement (document, envelope1, DelugeTag.ATTACK, DelugeValues.formatHex (DelugeValues.attackTimeToParam (ampEnvelope.getAttackTime ())));
         XMLUtils.addTextElement (document, envelope1, DelugeTag.DECAY, DelugeValues.formatHex (envelopeDecay (ampEnvelope)));
         XMLUtils.addTextElement (document, envelope1, DelugeTag.SUSTAIN, DelugeValues.formatHex (envelopeSustain (ampEnvelope)));
-        XMLUtils.addTextElement (document, envelope1, DelugeTag.RELEASE, DelugeValues.formatHex (DelugeValues.timeToParam (ampEnvelope.getReleaseTime ())));
+        XMLUtils.addTextElement (document, envelope1, DelugeTag.RELEASE, DelugeValues.formatHex (DelugeValues.releaseTimeToParam (ampEnvelope.getReleaseTime ())));
 
         // Make the sound velocity sensitive (matches the firmware's default for sample based sounds)
         final Element patchCables = XMLUtils.addElement (document, defaultParams, DelugeTag.PATCH_CABLES);
@@ -390,7 +400,7 @@ public class DelugeCreator extends AbstractWavCreator<WavChunkSettingsUI>
     private static int envelopeDecay (final IEnvelope envelope)
     {
         final double decayTime = Math.max (0, envelope.getHoldTime ()) + Math.max (0, envelope.getDecayTime ());
-        return envelope.getDecayTime () < 0 && envelope.getHoldTime () < 0 ? DelugeValues.userValueToParam (20) : DelugeValues.timeToParam (decayTime);
+        return envelope.getDecayTime () < 0 && envelope.getHoldTime () < 0 ? DelugeValues.userValueToParam (20) : DelugeValues.releaseTimeToParam (decayTime);
     }
 
 
@@ -404,5 +414,133 @@ public class DelugeCreator extends AbstractWavCreator<WavChunkSettingsUI>
     {
         final double sustainLevel = envelope.getSustainLevel ();
         return sustainLevel < 0 ? DelugeValues.PARAM_MAX : DelugeValues.levelToParam (sustainLevel);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected boolean requiresRewrite (final DestinationAudioFormat destinationFormat)
+    {
+        // The Deluge reads all sample bounds and loop points from the XML, never from chunks in the
+        // WAV file. Reconstructing the sample is therefore loss-less for it and lets a loop
+        // cross-fade be baked into the audio - the same way the Renoise creator always re-encodes
+        // its samples.
+        return true;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected void additionalProcessing (final IMultisampleSource multisampleSource, final ISampleZone zone, final WaveFile wavFile)
+    {
+        super.additionalProcessing (multisampleSource, zone, wavFile);
+
+        // The Deluge has no loop cross-fade parameter. A loop cross-fade (set via the 'Set fixed
+        // loop-crossfade' processing option or read from the source) is baked into the sample audio
+        // so that forward loops do not click at the loop point.
+        final ISampleLoop loop = getCrossfadeLoop (zone);
+        if (loop != null)
+            applyLoopCrossfade (wavFile, loop.getStart (), loop.getEnd (), loop.getCrossfadeInSamples ());
+    }
+
+
+    /**
+     * Get the (first) loop of a zone if a cross-fade should be baked into its audio. Only forward
+     * loops with a cross-fade greater than zero are considered.
+     *
+     * @param zone The zone
+     * @return The loop or null if no cross-fade should be applied
+     */
+    private static ISampleLoop getCrossfadeLoop (final ISampleZone zone)
+    {
+        final List<ISampleLoop> loops = zone.getLoops ();
+        if (loops.isEmpty ())
+            return null;
+        final ISampleLoop loop = loops.get (0);
+        if (loop.getCrossfade () > 0 && loop.getType () == LoopType.FORWARDS && loop.getStart () >= 0 && loop.getEnd () > loop.getStart ())
+            return loop;
+        return null;
+    }
+
+
+    /**
+     * Bake a loop cross-fade into the audio of a forward loop. The cross-fade region at the end of
+     * the loop is blended with the audio preceding the loop start so that the loop wraps seamlessly.
+     *
+     * @param wavFile The WAV file whose audio data is modified in place
+     * @param loopStart The loop start frame
+     * @param loopEnd The loop end frame (exclusive)
+     * @param crossfadeSamples The requested cross-fade length in frames
+     */
+    private static void applyLoopCrossfade (final WaveFile wavFile, final int loopStart, final int loopEnd, final int crossfadeSamples)
+    {
+        final FormatChunk formatChunk = wavFile.getFormatChunk ();
+        final DataChunk dataChunk = wavFile.getDataChunk ();
+        if (formatChunk == null || dataChunk == null || crossfadeSamples <= 0)
+            return;
+
+        final int channels = formatChunk.getNumberOfChannels ();
+        final int bytesPerFrame = formatChunk.calculateBytesPerSample ();
+        final int bytesPerChannel = channels == 0 ? 0 : bytesPerFrame / channels;
+        if (bytesPerChannel != 2 && bytesPerChannel != 3)
+            return;
+
+        final byte [] data = dataChunk.getData ();
+        final int totalFrames = data.length / bytesPerFrame;
+        final int end = Math.min (loopEnd, totalFrames);
+
+        // The cross-fade can neither be longer than the loop nor reach before the start of the sample
+        final int crossfade = Math.min (crossfadeSamples, Math.min (end - loopStart, loopStart));
+        if (crossfade <= 0)
+            return;
+
+        for (int j = 0; j < crossfade; j++)
+        {
+            final int endFrame = end - crossfade + j;
+            final int preFrame = loopStart - crossfade + j;
+            final double mix = (j + 1.0) / crossfade;
+            for (int c = 0; c < channels; c++)
+            {
+                final int endPos = endFrame * bytesPerFrame + c * bytesPerChannel;
+                final int prePos = preFrame * bytesPerFrame + c * bytesPerChannel;
+                final int blended = (int) Math.round (readSample (data, endPos, bytesPerChannel) * (1.0 - mix) + readSample (data, prePos, bytesPerChannel) * mix);
+                writeSample (data, endPos, bytesPerChannel, blended);
+            }
+        }
+
+        dataChunk.setData (data);
+    }
+
+
+    /**
+     * Read a little-endian signed PCM sample.
+     *
+     * @param data The audio data
+     * @param pos The byte position
+     * @param bytesPerChannel The number of bytes per channel sample (2 or 3)
+     * @return The signed sample value
+     */
+    private static int readSample (final byte [] data, final int pos, final int bytesPerChannel)
+    {
+        if (bytesPerChannel == 2)
+            return (short) (data[pos] & 0xFF | (data[pos + 1] & 0xFF) << 8);
+        return data[pos] & 0xFF | (data[pos + 1] & 0xFF) << 8 | data[pos + 2] << 16;
+    }
+
+
+    /**
+     * Write a little-endian signed PCM sample.
+     *
+     * @param data The audio data
+     * @param pos The byte position
+     * @param bytesPerChannel The number of bytes per channel sample (2 or 3)
+     * @param value The sample value
+     */
+    private static void writeSample (final byte [] data, final int pos, final int bytesPerChannel, final int value)
+    {
+        data[pos] = (byte) (value & 0xFF);
+        data[pos + 1] = (byte) (value >> 8 & 0xFF);
+        if (bytesPerChannel == 3)
+            data[pos + 2] = (byte) (value >> 16 & 0xFF);
     }
 }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
@@ -1,0 +1,668 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synthstrom;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.INotifier;
+import de.mossgrabers.convertwithmoss.core.detector.AbstractDetector;
+import de.mossgrabers.convertwithmoss.core.detector.DefaultMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.model.IAudioMetadata;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
+import de.mossgrabers.convertwithmoss.core.model.IFilter;
+import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.IMetadata;
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.core.model.enumeration.FilterType;
+import de.mossgrabers.convertwithmoss.core.model.enumeration.LoopType;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultFilter;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultGroup;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleZone;
+import de.mossgrabers.convertwithmoss.core.settings.MetadataSettingsUI;
+import de.mossgrabers.convertwithmoss.file.AudioFileUtils;
+import de.mossgrabers.tools.FileUtils;
+import de.mossgrabers.tools.XMLUtils;
+
+
+/**
+ * Detects recursively Synthstrom Deluge instrument files in folders. Files must end with
+ * <i>.xml</i> and contain a synth (<i>sound</i>) or drum kit (<i>kit</i>) at the top level. Synths
+ * which use sample oscillators are read as a multi-sample (one zone per sample range). Kits are read
+ * as a multi-sample with one zone per drum, mapped to ascending notes.
+ * <p>
+ * The Deluge format exists in two flavors which are both supported: the older format stores values
+ * as XML child elements while newer firmware stores them as XML attributes.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
+{
+    private static final String ERR_LOAD_FILE         = "IDS_NOTIFY_ERR_LOAD_FILE";
+    private static final String ERR_BAD_METADATA_FILE = "IDS_NOTIFY_ERR_BAD_METADATA_FILE";
+    private static final String ERR_SAMPLE_MISSING    = "IDS_NOTIFY_ERR_SAMPLE_DOES_NOT_EXIST";
+
+    private static final String ENDING_DELUGE         = ".xml";
+    private static final int    KIT_BASE_NOTE         = 36;
+    private static final int    SEARCH_LEVELS         = 4;
+
+    private File                previousSampleFolder;
+
+
+    /**
+     * Constructor.
+     *
+     * @param notifier The notifier
+     */
+    public DelugeDetector (final INotifier notifier)
+    {
+        super ("Synthstrom Deluge", "Deluge", notifier, new MetadataSettingsUI ("Deluge"), ENDING_DELUGE);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected List<IMultisampleSource> readPresetFile (final File file)
+    {
+        if (this.waitForDelivery ())
+            return Collections.emptyList ();
+
+        this.previousSampleFolder = null;
+
+        try
+        {
+            final String content = this.loadTextFile (file);
+            final Document document = XMLUtils.parseDocument (new InputSource (new StringReader (content)));
+            return this.parseMetadataFile (file, document);
+        }
+        catch (final SAXException ex)
+        {
+            // The file is not (valid) XML - might be a JSON Deluge file or an unrelated XML file.
+            // Simply ignore it since the '.xml' ending is shared with other formats.
+            return Collections.emptyList ();
+        }
+        catch (final IOException ex)
+        {
+            this.notifier.logError (ERR_LOAD_FILE, ex);
+            return Collections.emptyList ();
+        }
+    }
+
+
+    /**
+     * Parses the XML document of a Deluge instrument file.
+     *
+     * @param file The source file
+     * @param document The parsed XML document
+     * @return The parsed multi-sample source as a singleton list or an empty list
+     */
+    private List<IMultisampleSource> parseMetadataFile (final File file, final Document document)
+    {
+        final Element top = document.getDocumentElement ();
+        if (top == null)
+            return Collections.emptyList ();
+
+        final String rootName = top.getNodeName ();
+        final boolean isKit = DelugeTag.KIT.equals (rootName);
+        if (!isKit && !DelugeTag.SOUND.equals (rootName))
+            return Collections.emptyList ();
+
+        final List<IGroup> groups = isKit ? this.parseKit (file, top) : this.parseSound (file, top);
+        if (groups.isEmpty ())
+            return Collections.emptyList ();
+
+        final String presetName = FileUtils.getNameWithoutType (file);
+        final String n = this.settingsConfiguration.isPreferFolderName () ? this.sourceFolder.getName () : presetName;
+        final String [] parts = AudioFileUtils.createPathParts (file.getParentFile (), this.sourceFolder, n);
+        final IMultisampleSource multisampleSource = new DefaultMultisampleSource (file, parts, presetName);
+
+        final IMetadata metadata = multisampleSource.getMetadata ();
+        this.createMetadata (metadata, this.getFirstSample (groups), parts);
+        this.updateCreationDateTime (metadata, file);
+
+        multisampleSource.setGroups (groups);
+        return Collections.singletonList (multisampleSource);
+    }
+
+
+    /**
+     * Parse a synth (sound) preset.
+     *
+     * @param file The source file
+     * @param soundElement The sound element
+     * @return A list with one group (containing all zones) or an empty list if not sample based
+     */
+    private List<IGroup> parseSound (final File file, final Element soundElement)
+    {
+        final Element oscElement = findSampleOscillator (soundElement);
+        if (oscElement == null)
+            return Collections.emptyList ();
+
+        final List<ISampleZone> zones = this.parseSampleOscillator (file, oscElement);
+        if (zones.isEmpty ())
+            return Collections.emptyList ();
+
+        this.applySoundParameters (soundElement, zones);
+
+        final IGroup group = new DefaultGroup ();
+        for (final ISampleZone zone: zones)
+            group.addSampleZone (zone);
+
+        final List<IGroup> groups = new ArrayList<> ();
+        groups.add (group);
+        return groups;
+    }
+
+
+    /**
+     * Parse a drum kit preset. Each drum which uses a sample is mapped to one zone with an ascending
+     * note starting at {@link #KIT_BASE_NOTE}.
+     *
+     * @param file The source file
+     * @param kitElement The kit element
+     * @return A list with one group (containing all drum zones) or an empty list
+     */
+    private List<IGroup> parseKit (final File file, final Element kitElement)
+    {
+        final Element soundSources = getDirectChild (kitElement, DelugeTag.SOUND_SOURCES);
+        if (soundSources == null)
+            return Collections.emptyList ();
+
+        final IGroup group = new DefaultGroup ();
+        int note = KIT_BASE_NOTE;
+        for (final Element drumSound: getDirectChildren (soundSources, DelugeTag.SOUND))
+        {
+            if (note > 127)
+                break;
+            final Element oscElement = findSampleOscillator (drumSound);
+            if (oscElement == null)
+                continue;
+
+            final ISampleZone zone = this.createDrumZone (file, oscElement, note);
+            if (zone == null)
+                continue;
+
+            this.applySoundParameters (drumSound, Collections.singletonList (zone));
+            group.addSampleZone (zone);
+            note++;
+        }
+
+        final List<IGroup> groups = new ArrayList<> ();
+        if (!group.getSampleZones ().isEmpty ())
+            groups.add (group);
+        return groups;
+    }
+
+
+    /**
+     * Find the first oscillator which uses a sample.
+     *
+     * @param soundElement The sound element to search
+     * @return The oscillator element or null if there is no sample based oscillator
+     */
+    private static Element findSampleOscillator (final Element soundElement)
+    {
+        for (final String oscTag: new String []
+        {
+            DelugeTag.OSC1,
+            DelugeTag.OSC2
+        })
+        {
+            final Element osc = getDirectChild (soundElement, oscTag);
+            if (osc != null && DelugeTag.TYPE_SAMPLE.equals (getValue (osc, DelugeTag.TYPE)) && (getDirectChild (osc, DelugeTag.SAMPLE_RANGES) != null || !getValue (osc, DelugeTag.FILE_NAME).isBlank ()))
+                return osc;
+        }
+        return null;
+    }
+
+
+    /**
+     * Parse all sample zones of a sample oscillator.
+     *
+     * @param file The source file
+     * @param oscElement The oscillator element
+     * @return The parsed zones
+     */
+    private List<ISampleZone> parseSampleOscillator (final File file, final Element oscElement)
+    {
+        final int loopMode = getIntValue (oscElement, DelugeTag.LOOP_MODE, DelugeTag.LOOP_MODE_CUT);
+        final boolean reversed = getIntValue (oscElement, DelugeTag.REVERSED, 0) != 0;
+
+        final List<ISampleZone> zones = new ArrayList<> ();
+        final Element sampleRanges = getDirectChild (oscElement, DelugeTag.SAMPLE_RANGES);
+        if (sampleRanges != null)
+        {
+            final List<Element> rangeElements = getDirectChildren (sampleRanges, DelugeTag.SAMPLE_RANGE);
+            int previousTopNote = -1;
+            for (final Element rangeElement: rangeElements)
+            {
+                final int topNote = getIntValue (rangeElement, DelugeTag.RANGE_TOP_NOTE, -1);
+                final int keyLow = previousTopNote + 1;
+                final int keyHigh = topNote >= 0 ? topNote : 127;
+                final ISampleZone zone = this.createZone (file, rangeElement, rangeElement, keyLow, keyHigh, -1, loopMode, reversed);
+                if (zone != null)
+                    zones.add (zone);
+                previousTopNote = keyHigh;
+            }
+        }
+        else
+        {
+            // Single sample - file name and zone are stored directly on the oscillator element
+            final ISampleZone zone = this.createZone (file, oscElement, oscElement, 0, 127, -1, loopMode, reversed);
+            if (zone != null)
+                zones.add (zone);
+        }
+        return zones;
+    }
+
+
+    /**
+     * Create a single zone for one drum of a kit.
+     *
+     * @param file The source file
+     * @param oscElement The oscillator element of the drum
+     * @param note The note to which the drum is mapped
+     * @return The zone or null if the drum has no usable sample
+     */
+    private ISampleZone createDrumZone (final File file, final Element oscElement, final int note)
+    {
+        final int loopMode = getIntValue (oscElement, DelugeTag.LOOP_MODE, DelugeTag.LOOP_MODE_CUT);
+        final boolean reversed = getIntValue (oscElement, DelugeTag.REVERSED, 0) != 0;
+
+        Element attributeElement = oscElement;
+        Element zoneParent = oscElement;
+        final Element sampleRanges = getDirectChild (oscElement, DelugeTag.SAMPLE_RANGES);
+        if (sampleRanges != null)
+        {
+            final List<Element> rangeElements = getDirectChildren (sampleRanges, DelugeTag.SAMPLE_RANGE);
+            if (rangeElements.isEmpty ())
+                return null;
+            attributeElement = rangeElements.get (0);
+            zoneParent = rangeElements.get (0);
+        }
+        return this.createZone (file, attributeElement, zoneParent, note, note, note, loopMode, reversed);
+    }
+
+
+    /**
+     * Create one sample zone.
+     *
+     * @param file The source file
+     * @param attributeElement The element which contains the file name, transpose and cents
+     * @param zoneParent The element which contains the zone child element with the sample positions
+     * @param keyLow The lowest note of the zone
+     * @param keyHigh The highest note of the zone
+     * @param fixedRootNote If &gt;= 0, this root note is used instead of the one calculated from
+     *            transpose/cents
+     * @param loopMode The Deluge loop mode of the oscillator
+     * @param reversed True if the sample is reversed
+     * @return The created zone or null if the sample could not be loaded
+     */
+    private ISampleZone createZone (final File file, final Element attributeElement, final Element zoneParent, final int keyLow, final int keyHigh, final double fixedRootNote, final int loopMode, final boolean reversed)
+    {
+        final String fileName = getValue (attributeElement, DelugeTag.FILE_NAME);
+        if (fileName.isBlank ())
+            return null;
+
+        final File sampleFile = findSampleFile (this.notifier, file.getParentFile (), this.previousSampleFolder, fileName, SEARCH_LEVELS);
+        if (!sampleFile.exists ())
+        {
+            this.notifier.logError (ERR_SAMPLE_MISSING, sampleFile.getAbsolutePath ());
+            return null;
+        }
+        this.previousSampleFolder = sampleFile.getParentFile ();
+
+        final ISampleData sampleData;
+        try
+        {
+            sampleData = createSampleData (sampleFile, this.notifier);
+        }
+        catch (final IOException ex)
+        {
+            this.notifier.logError (ERR_BAD_METADATA_FILE, ex);
+            return null;
+        }
+
+        final ISampleZone zone = new DefaultSampleZone (FileUtils.getNameWithoutType (sampleFile), sampleData);
+        zone.setKeyLow (keyLow);
+        zone.setKeyHigh (keyHigh);
+        zone.setReversed (reversed);
+
+        final int transpose = getIntValue (attributeElement, DelugeTag.TRANSPOSE_OSC, 0);
+        final int cents = getIntValue (attributeElement, DelugeTag.CENTS, 0);
+        final double rootNote = fixedRootNote >= 0 ? fixedRootNote : DelugeValues.rootNoteFromTranspose (transpose, cents);
+        final int keyRoot = (int) Math.round (rootNote);
+        zone.setKeyRoot (keyRoot);
+        zone.setTuning (rootNote - keyRoot);
+
+        final boolean isLoop = loopMode == DelugeTag.LOOP_MODE_LOOP;
+        final DefaultSampleLoop loop = this.applyZonePositions (getDirectChild (zoneParent, DelugeTag.ZONE), zone, sampleData, isLoop);
+
+        try
+        {
+            sampleData.addZoneData (zone, false, loop == null && isLoop);
+        }
+        catch (final IOException ex)
+        {
+            this.notifier.logError (ERR_BAD_METADATA_FILE, ex);
+        }
+
+        return zone;
+    }
+
+
+    /**
+     * Read the sample start/end and loop positions from a zone element and apply them to the zone.
+     * Handles both the sample-frame based positions and the older milliseconds/seconds based
+     * positions.
+     *
+     * @param zoneElement The zone element (may be null)
+     * @param zone The zone to fill
+     * @param sampleData The sample data (used for the sample rate when converting milliseconds)
+     * @param isLoop True if the oscillator loop mode is set to loop
+     * @return The created loop or null if there is none
+     */
+    private DefaultSampleLoop applyZonePositions (final Element zoneElement, final ISampleZone zone, final ISampleData sampleData, final boolean isLoop)
+    {
+        if (zoneElement == null)
+            return null;
+
+        int sampleRate = 0;
+        int numberOfSamples = Integer.MAX_VALUE;
+        try
+        {
+            final IAudioMetadata audioMetadata = sampleData.getAudioMetadata ();
+            sampleRate = audioMetadata.getSampleRate ();
+            numberOfSamples = audioMetadata.getNumberOfSamples ();
+        }
+        catch (final IOException ex)
+        {
+            // Ignore - fall back to no millisecond conversion
+        }
+
+        int start = (int) Math.round (getDoubleValue (zoneElement, DelugeTag.START_SAMPLE_POS, -1));
+        int end = (int) Math.round (getDoubleValue (zoneElement, DelugeTag.END_SAMPLE_POS, -1));
+        if (start < 0)
+            start = millisecondsToSamples (getDoubleValue (zoneElement, DelugeTag.START_SECONDS, 0) * 1000.0 + getDoubleValue (zoneElement, DelugeTag.START_MILLISECONDS, 0), sampleRate);
+        if (end < 0)
+        {
+            final int endFromMilliseconds = millisecondsToSamples (getDoubleValue (zoneElement, DelugeTag.END_SECONDS, 0) * 1000.0 + getDoubleValue (zoneElement, DelugeTag.END_MILLISECONDS, 0), sampleRate);
+            // A very large end value is used as a 'play to the end' marker in old files
+            end = endFromMilliseconds < numberOfSamples ? endFromMilliseconds : -1;
+        }
+
+        if (start > 0)
+            zone.setStart (start);
+        if (end > 0)
+            zone.setStop (end);
+
+        if (!isLoop)
+            return null;
+
+        final int loopStart = (int) Math.round (getDoubleValue (zoneElement, DelugeTag.START_LOOP_POS, -1));
+        final int loopEnd = (int) Math.round (getDoubleValue (zoneElement, DelugeTag.END_LOOP_POS, -1));
+        if (loopStart <= 0 && loopEnd <= 0)
+            return null;
+
+        final DefaultSampleLoop loop = new DefaultSampleLoop ();
+        loop.setType (LoopType.FORWARDS);
+        if (loopStart >= 0)
+            loop.setStart (loopStart);
+        if (loopEnd > 0)
+            loop.setEnd (loopEnd);
+        zone.addLoop (loop);
+        return loop;
+    }
+
+
+    /**
+     * Read the amplitude envelope and filter from the default parameters of a sound and apply them
+     * to all given zones.
+     *
+     * @param soundElement The sound element
+     * @param zones The zones to fill
+     */
+    private void applySoundParameters (final Element soundElement, final List<ISampleZone> zones)
+    {
+        final Element defaultParams = getDirectChild (soundElement, DelugeTag.DEFAULT_PARAMS);
+        if (defaultParams == null)
+            return;
+
+        final Element envelope1 = getDirectChild (defaultParams, DelugeTag.ENVELOPE1);
+        if (envelope1 != null)
+            for (final ISampleZone zone: zones)
+                readEnvelope (envelope1, zone.getAmplitudeEnvelopeModulator ().getSource ());
+
+        final IFilter filter = readFilter (soundElement, defaultParams);
+        if (filter != null)
+            for (final ISampleZone zone: zones)
+                zone.setFilter (new DefaultFilter (filter.getType (), filter.getPoles (), filter.getCutoff (), filter.getResonance ()));
+    }
+
+
+    /**
+     * Read an envelope from a Deluge envelope element.
+     *
+     * @param envelopeElement The envelope element
+     * @param envelope The envelope to fill
+     */
+    private static void readEnvelope (final Element envelopeElement, final IEnvelope envelope)
+    {
+        final String attack = getValue (envelopeElement, DelugeTag.ATTACK);
+        final String decay = getValue (envelopeElement, DelugeTag.DECAY);
+        final String sustain = getValue (envelopeElement, DelugeTag.SUSTAIN);
+        final String release = getValue (envelopeElement, DelugeTag.RELEASE);
+
+        if (!attack.isBlank ())
+            envelope.setAttackTime (DelugeValues.paramToTime (DelugeValues.parseValue (attack, DelugeValues.PARAM_MIN)));
+        if (!decay.isBlank ())
+            envelope.setDecayTime (DelugeValues.paramToTime (DelugeValues.parseValue (decay, DelugeValues.PARAM_MIN)));
+        if (!sustain.isBlank ())
+            envelope.setSustainLevel (DelugeValues.paramToLevel (DelugeValues.parseValue (sustain, DelugeValues.PARAM_MAX)));
+        if (!release.isBlank ())
+            envelope.setReleaseTime (DelugeValues.paramToTime (DelugeValues.parseValue (release, DelugeValues.PARAM_MIN)));
+    }
+
+
+    /**
+     * Read the filter from the default parameters. The low-pass filter is preferred. A filter is
+     * only returned if it is actually engaged (i.e. not fully open). Both the newer flat attributes
+     * (lpfFrequency) and the older nested elements (lpf/frequency) are supported. The filter slot
+     * mode (which might be an official or a community firmware feature) is mapped to the matching
+     * filter type.
+     *
+     * @param soundElement The sound element which contains the filter mode
+     * @param defaultParams The default parameters element which contains the frequency/resonance
+     * @return The filter or null
+     */
+    private static IFilter readFilter (final Element soundElement, final Element defaultParams)
+    {
+        final Element nestedLpf = getDirectChild (defaultParams, DelugeTag.LPF);
+        final String lpfFrequency = nestedLpf != null ? getValue (nestedLpf, DelugeTag.FREQUENCY) : getValue (defaultParams, DelugeTag.LPF_FREQUENCY);
+        if (!lpfFrequency.isBlank ())
+        {
+            final int frequencyParam = DelugeValues.parseValue (lpfFrequency, DelugeValues.PARAM_MAX);
+            if (frequencyParam < DelugeValues.PARAM_MAX)
+            {
+                final String lpfResonance = nestedLpf != null ? getValue (nestedLpf, DelugeTag.RESONANCE) : getValue (defaultParams, DelugeTag.LPF_RESONANCE);
+                final double resonance = DelugeValues.paramToLevel (DelugeValues.parseValue (lpfResonance, DelugeValues.PARAM_MIN));
+                return createFilter (getValue (soundElement, DelugeTag.LPF_MODE), FilterType.LOW_PASS, 4, DelugeValues.paramToCutoff (frequencyParam), resonance);
+            }
+        }
+
+        final Element nestedHpf = getDirectChild (defaultParams, DelugeTag.HPF);
+        final String hpfFrequency = nestedHpf != null ? getValue (nestedHpf, DelugeTag.FREQUENCY) : getValue (defaultParams, DelugeTag.HPF_FREQUENCY);
+        if (!hpfFrequency.isBlank ())
+        {
+            final int frequencyParam = DelugeValues.parseValue (hpfFrequency, DelugeValues.PARAM_MIN);
+            if (frequencyParam > DelugeValues.PARAM_MIN)
+            {
+                final String hpfResonance = nestedHpf != null ? getValue (nestedHpf, DelugeTag.RESONANCE) : getValue (defaultParams, DelugeTag.HPF_RESONANCE);
+                final double resonance = DelugeValues.paramToLevel (DelugeValues.parseValue (hpfResonance, DelugeValues.PARAM_MIN));
+                return createFilter (getValue (soundElement, DelugeTag.HPF_MODE), FilterType.HIGH_PASS, 2, DelugeValues.paramToCutoff (frequencyParam), resonance);
+            }
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Create a filter, mapping the Deluge filter mode to the type and number of poles.
+     *
+     * @param mode The Deluge filter mode string (might be empty)
+     * @param defaultType The type to use if the mode is not set
+     * @param defaultPoles The number of poles to use if the mode is not set
+     * @param cutoff The cut-off frequency in Hertz
+     * @param resonance The resonance in the range of [0..1]
+     * @return The filter
+     */
+    private static IFilter createFilter (final String mode, final FilterType defaultType, final int defaultPoles, final double cutoff, final double resonance)
+    {
+        FilterType type = defaultType;
+        int poles = defaultPoles;
+        if (mode != null && !mode.isBlank ())
+            switch (mode)
+            {
+                case "12dB":
+                    type = FilterType.LOW_PASS;
+                    poles = 2;
+                    break;
+                case "24dB", "24dBDrive":
+                    type = FilterType.LOW_PASS;
+                    poles = 4;
+                    break;
+                case "HPLadder":
+                    type = FilterType.HIGH_PASS;
+                    poles = 4;
+                    break;
+                case "SVF_Band":
+                    type = FilterType.BAND_PASS;
+                    poles = 2;
+                    break;
+                case "SVF_Notch":
+                    type = FilterType.BAND_REJECTION;
+                    poles = 2;
+                    break;
+                default:
+                    break;
+            }
+        return new DefaultFilter (type, poles, cutoff, resonance);
+    }
+
+
+    /**
+     * Convert a number of milliseconds to samples.
+     *
+     * @param milliseconds The milliseconds
+     * @param sampleRate The sample rate, 0 if unknown
+     * @return The number of samples or -1 if it could not be calculated or the milliseconds are 0
+     */
+    private static int millisecondsToSamples (final double milliseconds, final int sampleRate)
+    {
+        if (milliseconds <= 0 || sampleRate <= 0)
+            return -1;
+        return (int) Math.round (milliseconds * sampleRate / 1000.0);
+    }
+
+
+    ////////////////////////////////////////////////////////////
+    // Helpers which read a value from either an XML attribute (newer format) or a child element
+    // (older format).
+
+    /**
+     * Get a value which is stored either as an XML attribute or as the text content of a direct
+     * child element.
+     *
+     * @param parent The parent element
+     * @param name The name of the attribute or child element
+     * @return The value or an empty string if not present
+     */
+    private static String getValue (final Element parent, final String name)
+    {
+        final String attribute = parent.getAttribute (name);
+        if (!attribute.isEmpty ())
+            return attribute;
+        final Element child = getDirectChild (parent, name);
+        return child == null ? "" : child.getTextContent ().trim ();
+    }
+
+
+    private static int getIntValue (final Element parent, final String name, final int defaultValue)
+    {
+        final String value = getValue (parent, name);
+        if (value.isBlank ())
+            return defaultValue;
+        try
+        {
+            return Integer.parseInt (value.trim ());
+        }
+        catch (final NumberFormatException ex)
+        {
+            return defaultValue;
+        }
+    }
+
+
+    private static double getDoubleValue (final Element parent, final String name, final double defaultValue)
+    {
+        final String value = getValue (parent, name);
+        if (value.isBlank ())
+            return defaultValue;
+        try
+        {
+            return Double.parseDouble (value.trim ());
+        }
+        catch (final NumberFormatException ex)
+        {
+            return defaultValue;
+        }
+    }
+
+
+    /**
+     * Get the first direct child element with the given name.
+     *
+     * @param parent The parent element
+     * @param name The name of the child element
+     * @return The child element or null
+     */
+    private static Element getDirectChild (final Element parent, final String name)
+    {
+        for (final Element child: XMLUtils.getChildElements (parent))
+            if (name.equals (child.getNodeName ()))
+                return child;
+        return null;
+    }
+
+
+    /**
+     * Get all direct child elements with the given name.
+     *
+     * @param parent The parent element
+     * @param name The name of the child elements
+     * @return The child elements (might be empty)
+     */
+    private static List<Element> getDirectChildren (final Element parent, final String name)
+    {
+        final List<Element> result = new ArrayList<> ();
+        for (final Element child: XMLUtils.getChildElements (parent))
+            if (name.equals (child.getNodeName ()))
+                result.add (child);
+        return result;
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
@@ -468,13 +468,13 @@ public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
         final String release = getValue (envelopeElement, DelugeTag.RELEASE);
 
         if (!attack.isBlank ())
-            envelope.setAttackTime (DelugeValues.paramToTime (DelugeValues.parseValue (attack, DelugeValues.PARAM_MIN)));
+            envelope.setAttackTime (DelugeValues.paramToAttackTime (DelugeValues.parseValue (attack, DelugeValues.PARAM_MIN)));
         if (!decay.isBlank ())
-            envelope.setDecayTime (DelugeValues.paramToTime (DelugeValues.parseValue (decay, DelugeValues.PARAM_MIN)));
+            envelope.setDecayTime (DelugeValues.paramToReleaseTime (DelugeValues.parseValue (decay, DelugeValues.PARAM_MIN)));
         if (!sustain.isBlank ())
             envelope.setSustainLevel (DelugeValues.paramToLevel (DelugeValues.parseValue (sustain, DelugeValues.PARAM_MAX)));
         if (!release.isBlank ())
-            envelope.setReleaseTime (DelugeValues.paramToTime (DelugeValues.parseValue (release, DelugeValues.PARAM_MIN)));
+            envelope.setReleaseTime (DelugeValues.paramToReleaseTime (DelugeValues.parseValue (release, DelugeValues.PARAM_MIN)));
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeTag.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeTag.java
@@ -1,0 +1,200 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synthstrom;
+
+/**
+ * The XML tags and attributes used in a Synthstrom Deluge instrument file (case sensitive).
+ *
+ * @author Jürgen Moßgraber
+ */
+public class DelugeTag
+{
+    /** The root tag of a synth (sound) preset. */
+    public static final String SOUND                         = "sound";
+    /** The root tag of a kit preset. */
+    public static final String KIT                           = "kit";
+
+    /** The firmware version which created the file. */
+    public static final String FIRMWARE_VERSION              = "firmwareVersion";
+    /** The earliest firmware version which can load the file. */
+    public static final String EARLIEST_COMPATIBLE_FIRMWARE  = "earliestCompatibleFirmware";
+
+    /** The firmware version to write (modern XML structure, avoids legacy read paths). */
+    public static final String FIRMWARE_VERSION_VALUE        = "4.1.0-alpha";
+    /** The earliest compatible firmware version to write. */
+    public static final String EARLIEST_COMPATIBLE_VALUE     = "4.1.0-alpha";
+
+    // Sound attributes
+    /** The polyphony mode. */
+    public static final String POLYPHONIC                    = "polyphonic";
+    /** The voice priority. */
+    public static final String VOICE_PRIORITY                = "voicePriority";
+    /** The synthesis mode. */
+    public static final String MODE                          = "mode";
+    /** The sound transpose. */
+    public static final String TRANSPOSE                     = "transpose";
+    /** The maximum number of voices. */
+    public static final String MAX_VOICES                    = "maxVoices";
+    /** The path attribute (community firmware, used for kit drums). */
+    public static final String PATH                          = "path";
+    /** The name attribute. */
+    public static final String NAME                          = "name";
+
+    // Oscillator tags / attributes
+    /** The first oscillator. */
+    public static final String OSC1                          = "osc1";
+    /** The second oscillator. */
+    public static final String OSC2                          = "osc2";
+    /** The oscillator type. */
+    public static final String TYPE                          = "type";
+    /** The oscillator type value for a sample. */
+    public static final String TYPE_SAMPLE                   = "sample";
+    /** The loop/repeat mode of a sample oscillator. */
+    public static final String LOOP_MODE                     = "loopMode";
+    /** Whether the sample is reversed. */
+    public static final String REVERSED                      = "reversed";
+    /** Whether time-stretch is enabled. */
+    public static final String TIME_STRETCH_ENABLE           = "timeStretchEnable";
+    /** The time-stretch amount. */
+    public static final String TIME_STRETCH_AMOUNT           = "timeStretchAmount";
+    /** The file name of a sample. */
+    public static final String FILE_NAME                     = "fileName";
+    /** The per-zone cents fine tune. */
+    public static final String CENTS                         = "cents";
+
+    // Multi-sample tags / attributes
+    /** The container of all sample ranges. */
+    public static final String SAMPLE_RANGES                 = "sampleRanges";
+    /** One sample range (zone). */
+    public static final String SAMPLE_RANGE                  = "sampleRange";
+    /** The highest note of a sample range. */
+    public static final String RANGE_TOP_NOTE                = "rangeTopNote";
+
+    /** The oscillator transpose (single sample). */
+    public static final String TRANSPOSE_OSC                 = "transpose";
+    /** The retrigger phase of an oscillator. */
+    public static final String RETRIG_PHASE                  = "retrigPhase";
+
+    // Zone tag / attributes
+    /** The zone tag, which contains the sample positions. */
+    public static final String ZONE                          = "zone";
+    /** The start of the playback in samples. */
+    public static final String START_SAMPLE_POS              = "startSamplePos";
+    /** The end of the playback in samples. */
+    public static final String END_SAMPLE_POS                = "endSamplePos";
+    /** The start of the loop in samples. */
+    public static final String START_LOOP_POS                = "startLoopPos";
+    /** The end of the loop in samples. */
+    public static final String END_LOOP_POS                  = "endLoopPos";
+    /** The start of the playback in milli-seconds (old format). */
+    public static final String START_MILLISECONDS            = "startMilliseconds";
+    /** The end of the playback in milli-seconds (old format). */
+    public static final String END_MILLISECONDS              = "endMilliseconds";
+    /** The start of the playback in seconds (old format). */
+    public static final String START_SECONDS                 = "startSeconds";
+    /** The end of the playback in seconds (old format). */
+    public static final String END_SECONDS                   = "endSeconds";
+
+    // Default parameters tag / attributes
+    /** The container of the default parameter values. */
+    public static final String DEFAULT_PARAMS                = "defaultParams";
+    /** The volume of oscillator A. */
+    public static final String OSC_A_VOLUME                  = "oscAVolume";
+    /** The volume of oscillator B. */
+    public static final String OSC_B_VOLUME                  = "oscBVolume";
+    /** The post-effects volume. */
+    public static final String VOLUME                        = "volume";
+    /** The low-pass filter frequency. */
+    public static final String LPF_FREQUENCY                 = "lpfFrequency";
+    /** The low-pass filter resonance. */
+    public static final String LPF_RESONANCE                 = "lpfResonance";
+    /** The high-pass filter frequency. */
+    public static final String HPF_FREQUENCY                 = "hpfFrequency";
+    /** The high-pass filter resonance. */
+    public static final String HPF_RESONANCE                 = "hpfResonance";
+    /** The low-pass filter mode (slope/type). */
+    public static final String LPF_MODE                      = "lpfMode";
+    /** The high-pass filter mode (slope/type). */
+    public static final String HPF_MODE                      = "hpfMode";
+    /** The nested low-pass filter element (old format). */
+    public static final String LPF                           = "lpf";
+    /** The nested high-pass filter element (old format). */
+    public static final String HPF                           = "hpf";
+    /** The frequency child element of a nested filter (old format). */
+    public static final String FREQUENCY                     = "frequency";
+    /** The resonance child element of a nested filter (old format). */
+    public static final String RESONANCE                     = "resonance";
+
+    // Unison child elements
+    /** The number of unison voices. */
+    public static final String UNISON_NUM                    = "num";
+    /** The unison detune. */
+    public static final String UNISON_DETUNE                 = "detune";
+
+    // Envelope tags / attributes
+    /** The amplitude envelope. */
+    public static final String ENVELOPE1                     = "envelope1";
+    /** The modulation envelope. */
+    public static final String ENVELOPE2                     = "envelope2";
+    /** The attack time. */
+    public static final String ATTACK                        = "attack";
+    /** The decay time. */
+    public static final String DECAY                         = "decay";
+    /** The sustain level. */
+    public static final String SUSTAIN                       = "sustain";
+    /** The release time. */
+    public static final String RELEASE                       = "release";
+
+    // Patch cable tags / attributes
+    /** The container of all patch cables. */
+    public static final String PATCH_CABLES                  = "patchCables";
+    /** One patch cable. */
+    public static final String PATCH_CABLE                   = "patchCable";
+    /** The modulation source of a patch cable. */
+    public static final String SOURCE                        = "source";
+    /** The modulation destination of a patch cable. */
+    public static final String DESTINATION                   = "destination";
+    /** The amount of a patch cable. */
+    public static final String AMOUNT                        = "amount";
+    /** The patch source velocity. */
+    public static final String SOURCE_VELOCITY               = "velocity";
+
+    // Kit tags / attributes
+    /** The container of all drum sounds of a kit. */
+    public static final String SOUND_SOURCES                 = "soundSources";
+
+    // Oscillator unison
+    /** The unison tag. */
+    public static final String UNISON                        = "unison";
+
+    /** The Deluge loop mode: play once and stop (no release tail). */
+    public static final int    LOOP_MODE_CUT                 = 0;
+    /** The Deluge loop mode: play once with release tail. */
+    public static final int    LOOP_MODE_ONCE                = 1;
+    /** The Deluge loop mode: loop. */
+    public static final int    LOOP_MODE_LOOP                = 2;
+    /** The Deluge loop mode: time-stretch. */
+    public static final int    LOOP_MODE_STRETCH             = 3;
+
+    /** The synthesis mode value for a subtractive (sample) synth. */
+    public static final String MODE_SUBTRACTIVE              = "subtractive";
+    /** The polyphony mode value to write. */
+    public static final String POLYPHONIC_POLY               = "poly";
+    /** The oscillator type value for a silent second oscillator. */
+    public static final String TYPE_SQUARE                   = "square";
+    /** The default low-pass filter mode value to write. */
+    public static final String LPF_MODE_24DB                 = "24dB";
+    /** The patch cable destination for the volume. */
+    public static final String DESTINATION_VOLUME            = "volume";
+
+
+    /**
+     * Constructor.
+     */
+    protected DelugeTag ()
+    {
+        // Intentionally empty
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeValues.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeValues.java
@@ -36,10 +36,32 @@ public final class DelugeValues
     /** The scaling factor of one user value step (see firmware getParamFromUserValue). */
     private static final long   USER_VALUE_STEP  = 85899345L;
 
-    private static final double MIN_ENV_TIME     = 0.001;
-    private static final double MAX_ENV_TIME     = 20.0;
     private static final double MIN_FREQUENCY    = 20.0;
     private static final double MAX_FREQUENCY    = 20000.0;
+
+    /** The envelope stage length threshold (2^23) used by the firmware envelope engine. */
+    private static final int    ENV_STAGE_LENGTH = 8388608;
+    /** The device sample rate in Hz at which the envelope rate tables are defined. */
+    private static final double DEVICE_RATE      = 44100.0;
+
+    /**
+     * The attack rate table of the firmware indexed by the knob position (0..50). The actual attack
+     * time is <code>ENV_STAGE_LENGTH / (rate * DEVICE_RATE)</code> seconds (about 0.7 ms .. 3.0 s).
+     */
+    private static final int [] ATTACK_RATE_TABLE  =
+    {
+        262144, 221969, 187951, 159147, 134757, 114105, 96618, 81811, 69273, 58656, 49667, 42055, 35610, 30153, 25532, 21619, 18306, 15500, 13125, 11113, 9410, 7968, 6747, 5713, 4837, 4096, 3468, 2937, 2487, 2106, 1783, 1510, 1278, 1082, 917, 776, 657, 556, 471, 399, 338, 286, 242, 205, 174, 147, 124, 105, 89, 76, 64
+    };
+
+    /**
+     * The decay/release rate table of the firmware indexed by the knob position (0..50). Decay and
+     * release share this table. The actual time is <code>ENV_STAGE_LENGTH / (rate * DEVICE_RATE)</code>
+     * seconds (about 5.8 ms .. 5.9 s).
+     */
+    private static final int [] RELEASE_RATE_TABLE =
+    {
+        32691, 4604, 2444, 1648, 1234, 980, 809, 685, 592, 519, 460, 412, 372, 338, 309, 283, 261, 241, 224, 208, 194, 181, 169, 159, 149, 140, 132, 124, 117, 110, 104, 98, 93, 88, 83, 78, 74, 70, 66, 62, 59, 56, 53, 50, 47, 44, 41, 39, 36, 34, 32
+    };
 
 
     /**
@@ -145,30 +167,98 @@ public final class DelugeValues
 
 
     /**
-     * Convert an envelope time in seconds to a 32-bit parameter value (approximated).
+     * Convert an attack time in seconds to a 32-bit parameter value using the firmware attack rate
+     * table.
      *
-     * @param seconds The time in seconds, a negative value is interpreted as the fastest time
+     * @param seconds The time in seconds
      * @return The parameter value
      */
-    public static int timeToParam (final double seconds)
+    public static int attackTimeToParam (final double seconds)
     {
-        if (seconds <= MIN_ENV_TIME)
-            return PARAM_MIN;
-        final double userValue = MAX_USER_VALUE * Math.log (seconds / MIN_ENV_TIME) / Math.log (MAX_ENV_TIME / MIN_ENV_TIME);
-        return userValueToParam ((int) Math.round (userValue));
+        return timeToParam (seconds, ATTACK_RATE_TABLE);
     }
 
 
     /**
-     * Convert a 32-bit envelope time parameter value to seconds (approximated).
+     * Convert a 32-bit attack parameter value to a time in seconds.
      *
      * @param param The parameter value
      * @return The time in seconds
      */
-    public static double paramToTime (final int param)
+    public static double paramToAttackTime (final int param)
     {
-        final int userValue = paramToUserValue (param);
-        return MIN_ENV_TIME * Math.pow (MAX_ENV_TIME / MIN_ENV_TIME, userValue / (double) MAX_USER_VALUE);
+        return paramToTime (param, ATTACK_RATE_TABLE);
+    }
+
+
+    /**
+     * Convert a decay or release time in seconds to a 32-bit parameter value. Decay and release
+     * share the same firmware rate table.
+     *
+     * @param seconds The time in seconds
+     * @return The parameter value
+     */
+    public static int releaseTimeToParam (final double seconds)
+    {
+        return timeToParam (seconds, RELEASE_RATE_TABLE);
+    }
+
+
+    /**
+     * Convert a 32-bit decay or release parameter value to a time in seconds.
+     *
+     * @param param The parameter value
+     * @return The time in seconds
+     */
+    public static double paramToReleaseTime (final int param)
+    {
+        return paramToTime (param, RELEASE_RATE_TABLE);
+    }
+
+
+    private static double rateToSeconds (final int rate)
+    {
+        return rate <= 0 ? Double.MAX_VALUE : ENV_STAGE_LENGTH / (rate * DEVICE_RATE);
+    }
+
+
+    private static int timeToParam (final double seconds, final int [] rateTable)
+    {
+        final int last = rateTable.length - 1;
+        if (seconds <= rateToSeconds (rateTable[0]))
+            return PARAM_MIN;
+        if (seconds >= rateToSeconds (rateTable[last]))
+            return PARAM_MAX;
+        for (int i = 0; i < last; i++)
+        {
+            final double t0 = rateToSeconds (rateTable[i]);
+            final double t1 = rateToSeconds (rateTable[i + 1]);
+            if (seconds >= t0 && seconds <= t1)
+            {
+                final double userValue = i + (t1 <= t0 ? 0.0 : (seconds - t0) / (t1 - t0));
+                return userValueToParam (userValue);
+            }
+        }
+        return PARAM_MAX;
+    }
+
+
+    private static double paramToTime (final int param, final int [] rateTable)
+    {
+        final int last = rateTable.length - 1;
+        final double userValue = Math.clamp ((param + 2147483648.0) / USER_VALUE_STEP, 0, MAX_USER_VALUE);
+        final int index = (int) Math.floor (userValue);
+        if (index >= last)
+            return rateToSeconds (rateTable[last]);
+        final double t0 = rateToSeconds (rateTable[index]);
+        final double t1 = rateToSeconds (rateTable[index + 1]);
+        return t0 + (t1 - t0) * (userValue - index);
+    }
+
+
+    private static int userValueToParam (final double userValue)
+    {
+        return (int) Math.round (Math.clamp (userValue, 0, MAX_USER_VALUE) * USER_VALUE_STEP - 2147483648.0);
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeValues.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeValues.java
@@ -1,0 +1,248 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synthstrom;
+
+/**
+ * Helper methods to convert between the values of the Synthstrom Deluge format and the model used in
+ * ConvertWithMoss.
+ * <p>
+ * The Deluge stores all modulation/parameter values (envelopes, filters, volumes, ...) as signed
+ * 32-bit integers written as upper-case hexadecimal strings (e.g. <code>0x7FFFFFFF</code>). The full
+ * range <code>0x80000000 .. 0x7FFFFFFF</code> maps to a knob/menu position of <code>0 .. 50</code>.
+ * Times and filter cut-off frequencies are non-linear (table driven) on the device; they are
+ * approximated here with an exponential curve which is good enough for a faithful musical result.
+ * <p>
+ * Sample pitch is stored as a <i>transpose</i> (semitones) plus <i>cents</i> offset relative to the
+ * reference note 60. The original root note of a sample therefore is
+ * <code>60 - transpose - cents / 100</code>.
+ *
+ * @author Jürgen Moßgraber
+ */
+public final class DelugeValues
+{
+    /** The reference MIDI note to which transpose/cents are relative. */
+    public static final int     REFERENCE_NOTE   = 60;
+    /** The minimum parameter value (0x80000000). */
+    public static final int     PARAM_MIN        = Integer.MIN_VALUE;
+    /** The maximum parameter value (0x7FFFFFFF). */
+    public static final int     PARAM_MAX        = Integer.MAX_VALUE;
+    /** A patch cable amount which corresponds to a fully open modulation (user value 50). */
+    public static final int     PATCH_CABLE_FULL = 0x3FFFFFE8;
+
+    /** The maximum user/knob value. */
+    private static final int    MAX_USER_VALUE   = 50;
+    /** The scaling factor of one user value step (see firmware getParamFromUserValue). */
+    private static final long   USER_VALUE_STEP  = 85899345L;
+
+    private static final double MIN_ENV_TIME     = 0.001;
+    private static final double MAX_ENV_TIME     = 20.0;
+    private static final double MIN_FREQUENCY    = 20.0;
+    private static final double MAX_FREQUENCY    = 20000.0;
+
+
+    /**
+     * Constructor. Hidden, since this is a utility class.
+     */
+    private DelugeValues ()
+    {
+        // Intentionally empty
+    }
+
+
+    /**
+     * Format an integer parameter value as the upper-case hexadecimal string expected by the Deluge.
+     *
+     * @param value The value
+     * @return The formatted string e.g. <code>0x7FFFFFFF</code>
+     */
+    public static String formatHex (final int value)
+    {
+        return String.format ("0x%08X", Integer.valueOf (value));
+    }
+
+
+    /**
+     * Parse a Deluge parameter value. Values are normally upper-case hexadecimal (prefixed with
+     * <code>0x</code>) but plain decimal values (as written by some older firmware/tools) are
+     * supported as well. Additional hexadecimal digits (automation nodes) are ignored.
+     *
+     * @param text The text to parse
+     * @param defaultValue The value to return if the text is empty or cannot be parsed
+     * @return The parsed value
+     */
+    public static int parseValue (final String text, final int defaultValue)
+    {
+        if (text == null)
+            return defaultValue;
+        final String trimmed = text.trim ();
+        if (trimmed.isEmpty ())
+            return defaultValue;
+
+        try
+        {
+            if (trimmed.length () > 2 && (trimmed.charAt (0) == '0') && (trimmed.charAt (1) == 'x' || trimmed.charAt (1) == 'X'))
+            {
+                final int end = Math.min (10, trimmed.length ());
+                return (int) Long.parseLong (trimmed.substring (2, end), 16);
+            }
+            return (int) Long.parseLong (trimmed);
+        }
+        catch (final NumberFormatException ex)
+        {
+            return defaultValue;
+        }
+    }
+
+
+    /**
+     * Convert a user/knob value (0..50) to a 32-bit parameter value (linear).
+     *
+     * @param userValue The user value in the range of [0..50]
+     * @return The parameter value
+     */
+    public static int userValueToParam (final int userValue)
+    {
+        return (int) ((long) clampUserValue (userValue) * USER_VALUE_STEP - 2147483648L);
+    }
+
+
+    /**
+     * Convert a 32-bit parameter value to a user/knob value (0..50, linear).
+     *
+     * @param param The parameter value
+     * @return The user value in the range of [0..50]
+     */
+    public static int paramToUserValue (final int param)
+    {
+        return clampUserValue ((int) Math.round ((param + 2147483648.0) / USER_VALUE_STEP));
+    }
+
+
+    /**
+     * Convert a level in the range of [0..1] to a 32-bit parameter value.
+     *
+     * @param level The level in the range of [0..1]
+     * @return The parameter value
+     */
+    public static int levelToParam (final double level)
+    {
+        return userValueToParam ((int) Math.round (Math.clamp (level, 0, 1) * MAX_USER_VALUE));
+    }
+
+
+    /**
+     * Convert a 32-bit parameter value to a level in the range of [0..1].
+     *
+     * @param param The parameter value
+     * @return The level in the range of [0..1]
+     */
+    public static double paramToLevel (final int param)
+    {
+        return paramToUserValue (param) / (double) MAX_USER_VALUE;
+    }
+
+
+    /**
+     * Convert an envelope time in seconds to a 32-bit parameter value (approximated).
+     *
+     * @param seconds The time in seconds, a negative value is interpreted as the fastest time
+     * @return The parameter value
+     */
+    public static int timeToParam (final double seconds)
+    {
+        if (seconds <= MIN_ENV_TIME)
+            return PARAM_MIN;
+        final double userValue = MAX_USER_VALUE * Math.log (seconds / MIN_ENV_TIME) / Math.log (MAX_ENV_TIME / MIN_ENV_TIME);
+        return userValueToParam ((int) Math.round (userValue));
+    }
+
+
+    /**
+     * Convert a 32-bit envelope time parameter value to seconds (approximated).
+     *
+     * @param param The parameter value
+     * @return The time in seconds
+     */
+    public static double paramToTime (final int param)
+    {
+        final int userValue = paramToUserValue (param);
+        return MIN_ENV_TIME * Math.pow (MAX_ENV_TIME / MIN_ENV_TIME, userValue / (double) MAX_USER_VALUE);
+    }
+
+
+    /**
+     * Convert a filter cut-off frequency in Hertz to a 32-bit parameter value (approximated).
+     *
+     * @param hertz The frequency in Hertz
+     * @return The parameter value
+     */
+    public static int cutoffToParam (final double hertz)
+    {
+        final double clamped = Math.clamp (hertz, MIN_FREQUENCY, MAX_FREQUENCY);
+        final double userValue = MAX_USER_VALUE * Math.log (clamped / MIN_FREQUENCY) / Math.log (MAX_FREQUENCY / MIN_FREQUENCY);
+        return userValueToParam ((int) Math.round (userValue));
+    }
+
+
+    /**
+     * Convert a 32-bit filter cut-off parameter value to a frequency in Hertz (approximated).
+     *
+     * @param param The parameter value
+     * @return The frequency in Hertz
+     */
+    public static double paramToCutoff (final int param)
+    {
+        final int userValue = paramToUserValue (param);
+        return MIN_FREQUENCY * Math.pow (MAX_FREQUENCY / MIN_FREQUENCY, userValue / (double) MAX_USER_VALUE);
+    }
+
+
+    /**
+     * Calculate the root note of a sample from the Deluge transpose and cents values.
+     *
+     * @param transpose The transpose value in semitones
+     * @param cents The cents value
+     * @return The root note (might be fractional)
+     */
+    public static double rootNoteFromTranspose (final int transpose, final int cents)
+    {
+        return REFERENCE_NOTE - transpose - cents / 100.0;
+    }
+
+
+    /**
+     * Calculate the Deluge transpose and cents values from a root note.
+     *
+     * @param rootNote The root note (might be fractional)
+     * @return An array with the transpose value at index 0 and the cents value at index 1
+     */
+    public static int [] transposeCentsFromRootNote (final double rootNote)
+    {
+        final double semitones = REFERENCE_NOTE - rootNote;
+        int transpose = (int) semitones;
+        int cents = (int) Math.round ((semitones - transpose) * 100.0);
+        if (cents <= -100)
+        {
+            transpose -= 1;
+            cents += 100;
+        }
+        else if (cents >= 100)
+        {
+            transpose += 1;
+            cents -= 100;
+        }
+        return new int []
+        {
+            transpose,
+            cents
+        };
+    }
+
+
+    private static int clampUserValue (final int userValue)
+    {
+        return Math.clamp (userValue, 0, MAX_USER_VALUE);
+    }
+}

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -169,6 +169,8 @@ IDS_DS_TEMPLATE_DIR_IS_FILE=Selected path is not a directory.
 IDS_DS_COULD_NOT_CREATE_TEMPLATES=Could not create the template: %1.
 IDS_DS_TEMPLATES_CREATED=Template successfully created.
 
+IDS_DELUGE_NO_SAMPLES=The multi-sample does not contain any samples to write.\n
+
 IDS_EPS_UNKNOWN_DISK_FORMAT=Unknown disk image format: %1\n
 IDS_EPS_INVALID_GKH=Invalid GKH fileIndicator\n
 IDS_EPS_UNKNOWN_GKH_NUMBER=Unknown GKH number type: %1\n


### PR DESCRIPTION
Adds support for the Synthstrom Audible Deluge instrument format (the XML `sound`/`kit` files stored on the SD card), both reading and writing.

## Reading
- Reads **both** firmware variants — the official (element-based) form and the community (attribute-based) form — and both `sound` (synth) and `kit` (drum) files.
- Translates the sample mapping (key ranges), the original root note (from the *transpose*/*cents* offset, or the fixed root note of a drum), the sample playback start/end and loop points, the loop mode (one-shot or loop), the reversed flag, the low- and high-pass filter (with the various filter modes), the amplitude envelope and the velocity-to-volume modulation.

## Writing
- Writes a multi-sample as a `sound` patch with a single sample oscillator whose zones become a `sampleRanges` list.
- Uses the **element-based form of the official v4 firmware** (`firmwareVersion="4.1.0-alpha"`), so the output loads on both the official v4 firmware and the community firmware — no community-only features are used.
- Mirrors the Deluge SD-card layout: the patch is written to a `SYNTHS` sub-folder and its samples to `SAMPLES/<name>/`, with the `fileName` references written relative to the card root.

## Envelope &amp; loop handling
- The amplitude envelope attack/decay/release times are converted using the Deluge's internal rate tables rather than an exponential approximation, so the times round-trip faithfully. Attack uses the attack-rate table; decay and release share the release-rate table.
- The Deluge has no native loop cross-fade parameter, so — exactly like the Renoise creator — a loop cross-fade is baked into the looped sample audio. This happens automatically whenever a forward loop carries a cross-fade; the amount comes from the existing *Set fixed loop-crossfade* processing option or from the source. With none set, the loop is written exactly as-is.

Registered in `ConverterBackend`; documented in `README-FORMATS.md`; CHANGELOG updated. Verified by building and running EXS24 → Deluge conversions and loading the results on Deluge hardware running community firmware 1.2.1 — confirming that the v4 element-based output loads and plays on the community firmware as intended (it is designed to load on both the official v4 and community firmware).
