### PR TITLE
Fix stray leading comma in the source format list

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 19.0.0 (unreleased)
 
 * New: Improved user interface for long lists of formats.
+* Fixed: The source format list showed a stray comma before the file extensions, e.g. "SFZ (, *.sfz)" instead of "SFZ (*.sfz)" (thanks to Douglas Carmichael).
 * New: Added support for the Polyend Tracker (PTI) instrument format (thanks to Douglas Carmichael).
 * New: Added support for the Renoise instrument (XRNI) format (thanks to Douglas Carmichael).
 * New: Added support for the Synthstrom Deluge instrument format (thanks to Douglas Carmichael).

--- a/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
@@ -280,9 +280,12 @@ public class MainFrame extends AbstractFrame implements INotifier
             return "";
 
         final StringBuilder sb = new StringBuilder (" (");
+        boolean first = true;
         for (final String ending: fileEndings)
         {
-            if (!sb.isEmpty ())
+            if (first)
+                first = false;
+            else
                 sb.append (", ");
             sb.append ("*").append (ending);
         }


### PR DESCRIPTION
## Summary

The source format list showed a stray comma before the file extensions of every entry, e.g. `SFZ (, *.sfz)` or `Elektron Tonverk Preset (, *.tvpst)`, instead of `SFZ (*.sfz)`.

`MainFrame.formatFileEndings` initialised the `StringBuilder` with `" ("` and then used `!sb.isEmpty ()` to decide whether to prepend the `", "` separator. Since the builder was never empty, the separator was prepended before the first extension as well. A first-element flag makes the separator appear only between extensions.

### Before / After

| | |
|---|---|
| Before | `SFZ (, *.sfz)` |
| After | `SFZ (*.sfz)` |
