### PR TITLE
Waldorf QPAT: write the full sample when a zone has no explicit start/end

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Waldorf Quantum/Iridium (thanks to Douglas Carmichael)
   * Fixed: A very short envelope time (at or below 0.06 seconds - in particular a zero attack, decay or release) was written as an out-of-range parameter value; exactly zero produced negative infinity. The corrupt value could cause a click at the start of every note on the device. Such times are now clamped to the shortest representable value.
   * Fixed: An amplitude envelope with no attack and no decay that sustains below full level popped at the start of every note - the device snapped to the 100% attack peak and instantly dropped to the sustain level. Such an envelope is now written flat (full sustain) with the sustain level folded into the sample gain, so the loudness is unchanged but the discontinuity is gone.
+  * Fixed: A sample zone without an explicit start/end (e.g. converted from a format that stores only loop points) was written with a sample start and end of -1; the whole sample is now used.
 
 ## 18.1.1
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
@@ -245,14 +245,18 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
                 // Pan - CURRENTLY IGNORED
                 sb.append (formatMapDouble ((zone.getPanning () + 1.0) / 2.0)).append ('\t');
 
-                // Start / End
-                sb.append (formatMapDouble (zone.getStart () / numSampleFrames)).append ('\t');
-                sb.append (formatMapDouble (zone.getStop () / numSampleFrames)).append ('\t');
+                // Start / End - a zone whose start/stop was never set keeps the model default of -1,
+                // which would otherwise be written as a negative position (the device then shows a
+                // sample start/end of -1). Treat an unset start/stop as the full sample.
+                final double startFrame = zone.getStart () < 0 ? 0 : zone.getStart ();
+                final double stopFrame = zone.getStop () <= 0 ? numSampleFrames : zone.getStop ();
+                sb.append (formatMapDouble (startFrame / numSampleFrames)).append ('\t');
+                sb.append (formatMapDouble (stopFrame / numSampleFrames)).append ('\t');
 
                 // Loop mode, start, stop
                 final List<ISampleLoop> loops = zone.getLoops ();
                 if (loops.isEmpty ())
-                    sb.append ("0\t0\t").append (formatMapDouble (zone.getStop () / numSampleFrames)).append ('\t');
+                    sb.append ("0\t0\t").append (formatMapDouble (stopFrame / numSampleFrames)).append ('\t');
                 else
                 {
                     final ISampleLoop loop = loops.get (0);


### PR DESCRIPTION
## Summary

When the Waldorf QPAT creator builds a sample map it stores each zone's start and end as `start / numberOfFrames` and `stop / numberOfFrames`. A sample zone whose start/stop was never set keeps the model default of `-1`, so the map received a negative position. On the device this shows up as a **sample start and end of `-1`** instead of the sample playing across its full length (and the loop points then reference a sample whose end is `-1`).

This was surfaced while converting Elektron Tonverk presets — whose Multi/Drum mapping slots store only loop points, no sample-trim start/end — to QPAT, but it applies to any source that leaves a zone's start/stop unset.

## Fix

Treat an unset (negative) start/stop as the full sample range: clamp the start to `0` and the stop to the number of frames. The no-loop branch reuses the same resolved stop. Zones that set an explicit start/stop are unaffected.

## Testing

Converted multi-samples whose zones carried no explicit trim to QPAT and confirmed the sample map now writes a start of `0.0` and an end of `1.0` (the whole sample) instead of `-1`. Zones with an explicit sub-range still write the correct fractional start/end (e.g. a 7200..64800 trim of a 72000-frame sample writes `0.1`/`0.9`).
