### PR TITLE
Ignore hidden and system files in the output-folder empty check

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -8,6 +8,7 @@
 * New: Added support for the Synthstrom Deluge instrument format (thanks to Douglas Carmichael).
 * New: Added support for the Downloadable Sound format (DLS) - read only.
 * New: Added several new tags for category detection.
+* Fixed: Converting into the root of a USB stick or external drive could fail with "The output folder is not empty" even when it looked empty, because the operating system keeps hidden bookkeeping files there (e.g. .Spotlight-V100, .Trashes and .fseventsd on macOS). Hidden files/folders and the known Windows system folders are now ignored by the empty-folder check (thanks to Douglas Carmichael).
 * FLAC/OGG
   * Fixed: FLAC or OGG samples stored inside a ZIP archive (e.g. discoDSP Bliss or DecentSampler libraries) could fail to decompress.
   * Fixed: Stereo (multi-channel) samples stored in a compressed format were truncated to half their length when decompressed while writing to an uncompressed destination.

--- a/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import de.mossgrabers.convertwithmoss.core.ConverterBackend;
@@ -912,8 +911,10 @@ public class MainFrame extends AbstractFrame implements INotifier
 
 
     /**
-     * Checks if folder is empty. Ignores OS thumb-nail files like .DS_Store on MAC and Thumbs.db on
-     * Windows.
+     * Checks if folder is empty. Ignores hidden files/folders (e.g. .DS_Store on macOS and the
+     * .Spotlight-V100, .Trashes and .fseventsd folders created on the root of a removable volume)
+     * as well as the known Windows system folders, so that the root of a USB stick or external
+     * drive is not wrongly reported as non-empty.
      *
      * @param directoryPath Path of folder to check
      * @return True if directory is empty
@@ -923,7 +924,13 @@ public class MainFrame extends AbstractFrame implements INotifier
         boolean result = true;
         try (final Stream<Path> paths = Files.list (Path.of (directoryPath)))
         {
-            result = paths.filter (path -> !Pattern.matches ("^(\\.(DS_Store|desktop)|Thumbs.db|ConvertWithMoss.log)$", path.getFileName ().toString ())).count () == 0;
+            result = paths.filter (path -> {
+                // Ignore hidden entries (e.g. macOS .DS_Store and the volume-root
+                // .Spotlight-V100, .Trashes, .fseventsd folders) and the known Windows system
+                // folders, none of which the user wants to preserve.
+                final String name = path.getFileName ().toString ();
+                return !name.startsWith (".") && !"Thumbs.db".equals (name) && !"ConvertWithMoss.log".equals (name) && !"System Volume Information".equals (name) && !"$RECYCLE.BIN".equals (name);
+            }).count () == 0;
         }
         catch (final IOException _)
         {


### PR DESCRIPTION
## Summary

Converting into the root of a USB stick or external drive could fail with *"The output folder is not empty. Please select an empty folder."* even when the drive looked completely empty in the file manager.

The operating system keeps hidden bookkeeping entries on the root of every removable volume that the user never sees — `.Spotlight-V100`, `.Trashes` and `.fseventsd` on macOS, `System Volume Information` / `$RECYCLE.BIN` on Windows. `MainFrame.isEmptyFolder` only whitelisted `.DS_Store`, `.desktop`, `Thumbs.db` and `ConvertWithMoss.log`, so those volume-root entries made the check report the folder as non-empty.

The check now ignores all hidden dot-entries plus the known Windows system folders, so a freshly formatted stick root counts as empty. Since the only purpose of the check is to avoid clobbering the user's existing presets, ignoring OS bookkeeping files is safe — and it no longer needs updating each time the OS adds a new hidden folder.

### Before / After

| | |
|---|---|
| Before | Root of a USB stick → `The output folder is not empty` |
| After | Root of a USB stick → conversion proceeds |

Verified with `mvn compile` (JDK 25 release target). The `java.util.regex.Pattern` import is removed as it is no longer used.
