### PR TITLE
Synthstrom Deluge: read sample-based files whose root tag has attributes

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -10,6 +10,8 @@
 * New: Added support for the Downloadable Sound format (DLS) - read only.
 * New: Added several new tags for category detection.
 * Fixed: Converting into the root of a USB stick or external drive could fail with "The output folder is not empty" even when it looked empty, because the operating system keeps hidden bookkeeping files there (e.g. .Spotlight-V100, .Trashes and .fseventsd on macOS). Hidden files/folders and the known Windows system folders are now ignored by the empty-folder check (thanks to Douglas Carmichael).
+* Synthstrom Deluge (thanks to Douglas Carmichael)
+  * Fixed: Sample-based SOUND and KIT files were rejected with "This is not a Deluge KIT or SOUND file" when the root tag carried attributes (e.g. `firmwareVersion` written inline by firmware 3.x). The broken-XML workaround only matched the bare `<sound>`/`<kit>` tag; the root tag is now matched with or without attributes.
 * FLAC/OGG
   * Fixed: FLAC or OGG samples stored inside a ZIP archive (e.g. discoDSP Bliss or DecentSampler libraries) could fail to decompress.
   * Fixed: Stereo (multi-channel) samples stored in a compressed format were truncated to half their length when decompressed while writing to an uncompressed destination.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
@@ -116,19 +116,53 @@ public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
     /**
      * Removes tags outside of the root tag which prevent parsing the XML file. 'firmwareVersion'
      * and 'earliestCompatibleFirmware'.
-     * 
+     * <p>
+     * The root tag (<i>kit</i> or <i>sound</i>) might carry attributes (e.g.
+     * <code>&lt;sound firmwareVersion="3.0.5" ...&gt;</code>) which is why the tag start is matched
+     * rather than the exact <code>&lt;kit&gt;</code>/<code>&lt;sound&gt;</code> literal.
+     *
      * @param xmlCode The XML document code
      * @return The cleaned document code
      * @throws IOException If the root tag could not be found
      */
     private static String fixBrokenXml (final String xmlCode) throws IOException
     {
-        int pos = xmlCode.indexOf ("<kit>");
+        int pos = findRootTag (xmlCode, DelugeTag.KIT);
         if (pos < 0)
-            pos = xmlCode.indexOf ("<sound>");
+            pos = findRootTag (xmlCode, DelugeTag.SOUND);
         if (pos < 0)
             throw new IOException (Functions.getMessage ("IDS_DELUGE_NOT_A_DELUGE_FILE"));
         return XML_HEADER + xmlCode.substring (pos);
+    }
+
+
+    /**
+     * Find the start position of the opening root tag with the given name. The tag is matched
+     * whether it has attributes (e.g. <code>&lt;sound firmwareVersion="..."&gt;</code>) or not
+     * (e.g. <code>&lt;sound&gt;</code>). Tags which merely start with the given name (e.g.
+     * <code>soundSources</code>) are not matched.
+     *
+     * @param xmlCode The XML document code
+     * @param tagName The name of the tag to find
+     * @return The index of the opening '&lt;' or -1 if not found
+     */
+    private static int findRootTag (final String xmlCode, final String tagName)
+    {
+        final String tagStart = "<" + tagName;
+        int pos = xmlCode.indexOf (tagStart);
+        while (pos >= 0)
+        {
+            final int after = pos + tagStart.length ();
+            if (after < xmlCode.length ())
+            {
+                // The tag name must be followed by whitespace, the tag end or a self-closing slash
+                final char c = xmlCode.charAt (after);
+                if (c == '>' || c == '/' || Character.isWhitespace (c))
+                    return pos;
+            }
+            pos = xmlCode.indexOf (tagStart, after);
+        }
+        return -1;
     }
 
 


### PR DESCRIPTION
Sample-based Deluge SOUND and KIT files are rejected with *"This is not a Deluge KIT or SOUND file"* when the root `<sound>`/`<kit>` tag carries attributes. Files written by firmware 3.x do exactly that — they store `firmwareVersion`/`earliestCompatibleFirmware` inline as attributes on the root element:

```xml
<sound
    firmwareVersion="3.0.5"
    earliestCompatibleFirmware="3.0.0"
    polyphonic="poly"
    ...>
```

### Cause

The broken-XML workaround added as a follow-up to the Deluge format support (#152) locates the root element by searching for a literal string:

```java
int pos = xmlCode.indexOf ("<kit>");
if (pos < 0)
    pos = xmlCode.indexOf ("<sound>");
```

The literal `<sound>`/`<kit>` never matches when the tag has attributes, because the tag name is then followed by whitespace (or a newline) instead of `>`. The workaround runs on every file, so these otherwise-valid files always fail to load.

### Fix

Match the tag *start* instead, accepting the root tag with or without attributes. The bare `<sound>`/`<kit>` form (and the malformed files the workaround targets, which store the firmware version as elements *before* the root) still work. Tags that merely start with the same characters (e.g. `soundSources`) are not matched, since the tag name must be followed by whitespace, `>` or `/`.

### Verification

Analysed a firmware-3.x sample pack (Rephazer "Analog Befour"): **100/100 SOUND presets and the KIT now load** with their samples, key ranges and loop points resolved correctly. Before this change every one of them was rejected.
