### PR TITLE
Synthstrom Deluge: keep the loop when the source omits the loop end

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -10,6 +10,8 @@
 * New: Added support for the Downloadable Sound format (DLS) - read only.
 * New: Added several new tags for category detection.
 * Fixed: Converting into the root of a USB stick or external drive could fail with "The output folder is not empty" even when it looked empty, because the operating system keeps hidden bookkeeping files there (e.g. .Spotlight-V100, .Trashes and .fseventsd on macOS). Hidden files/folders and the known Windows system folders are now ignored by the empty-folder check (thanks to Douglas Carmichael).
+* Synthstrom Deluge (thanks to Douglas Carmichael)
+  * Fixed: A sample with a loop start but no loop end (the Deluge stores no `endLoopPos` when the loop runs to the end of the sample) lost its loop on conversion - the loop end stayed unset (-1) and was written as a negative, degenerate loop, so the sound no longer sustained (e.g. a pad ended abruptly instead of looping until the release). The loop end now defaults to the end of the sample.
 * FLAC/OGG
   * Fixed: FLAC or OGG samples stored inside a ZIP archive (e.g. discoDSP Bliss or DecentSampler libraries) could fail to decompress.
   * Fixed: Stereo (multi-channel) samples stored in a compressed format were truncated to half their length when decompressed while writing to an uncompressed destination.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
@@ -461,8 +461,18 @@ public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
         loop.setType (LoopType.FORWARDS);
         if (loopStart >= 0)
             loop.setStart (loopStart);
+        // The Deluge omits the loop end when the loop runs to the end of the (played) sample. Default
+        // it to the sample/zone end so a valid loop is created; otherwise the unset end (-1) would be
+        // written as a negative, degenerate loop and the sound would lose its sustain on export (e.g.
+        // a pad ending abruptly instead of looping until the release).
         if (loopEnd > 0)
             loop.setEnd (loopEnd);
+        else
+        {
+            final int loopEndDefault = end > 0 ? end : numberOfSamples;
+            if (loopEndDefault > 0 && loopEndDefault != Integer.MAX_VALUE)
+                loop.setEnd (loopEndDefault);
+        }
         zone.addLoop (loop);
         return loop;
     }


### PR DESCRIPTION
A Deluge sample oscillator stores **no `endLoopPos`** when the loop runs to the end of the sample — only `startLoopPos` is written. The detector set the loop end only when `endLoopPos` was present:

```java
if (loopEnd > 0)
    loop.setEnd (loopEnd);
```

so in the (common) loop-to-end case the loop end stayed at the model default of **−1**. Creators then wrote a negative, degenerate loop, and the sound lost its sustain — a looping pad ended abruptly instead of sustaining until the release.

### Example

The "R663 A4 Organ Dream Pad" preset (firmware 3.x) has `startLoopPos="111218"`, `endSamplePos="164574"` and **no** `endLoopPos`. Converted to a Waldorf Iridium (QPAT), the sample-map row was:

```
… loopMode=1  loopStart=0.67578915  loopEnd=-0.00000608 …
```

`loopEnd = −1 / 164574`. With the loop start (0.676) past the loop end (~0) the device can't loop, so the sample plays once and stops; the sustaining pad lost its sustain and ended abruptly instead of fading out over its (correctly converted) ~6 s release.

### Fix

Default the loop end to the zone/sample end (`endSamplePos`, falling back to the sample frame count) when `endLoopPos` is absent. The same preset now writes:

```
… loopMode=1  loopStart=0.67578915  loopEnd=0.99999392 …
```

a valid forward loop, and the pad sustains again. Verified end-to-end (Deluge → QPAT).

Follow-up to the Deluge format support (#152); independent of the root-tag read fix (#159).
