### PR TITLE
Synthstrom Deluge: create a sustain loop for time-stretch (STRETCH) samples

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed: Converting into the root of a USB stick or external drive could fail with "The output folder is not empty" even when it looked empty, because the operating system keeps hidden bookkeeping files there (e.g. .Spotlight-V100, .Trashes and .fseventsd on macOS). Hidden files/folders and the known Windows system folders are now ignored by the empty-folder check (thanks to Douglas Carmichael).
 * Synthstrom Deluge (thanks to Douglas Carmichael)
   * Fixed: Sample-based SOUND and KIT files were rejected with "This is not a Deluge KIT or SOUND file" when the root tag carried attributes (e.g. `firmwareVersion` written inline by firmware 3.x). The broken-XML workaround only matched the bare `<sound>`/`<kit>` tag; the root tag is now matched with or without attributes.
+  * Fixed: Samples set to the time-stretch playback mode (`loopMode="3"`, e.g. evolving "hold" pads) were converted with no loop at all, so a sustained note played the sample once and then dropped to silence or noise on the destination. The time-stretch effect itself cannot be reproduced, but such samples now get a normal forward loop from their stored loop start so they sustain.
 * FLAC/OGG
   * Fixed: FLAC or OGG samples stored inside a ZIP archive (e.g. discoDSP Bliss or DecentSampler libraries) could fail to decompress.
   * Fixed: Stereo (multi-channel) samples stored in a compressed format were truncated to half their length when decompressed while writing to an uncompressed destination.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
@@ -422,7 +422,12 @@ public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
         zone.setKeyRoot (keyRoot);
         zone.setTuning (rootNote - keyRoot);
 
-        final boolean isLoop = loopMode == DelugeTag.LOOP_MODE_LOOP;
+        // A Deluge oscillator in STRETCH (time-stretch) mode sustains by looping its sample through
+        // the granular time-stretch engine. ConvertWithMoss cannot reproduce the time-stretch, but
+        // such a sample still carries a loop start and is meant to sustain, so it is treated as a
+        // normal forward loop here. Without this a held STRETCH patch (e.g. a sustained pad) would
+        // play its sample once and then drop out, because no loop was created at all.
+        final boolean isLoop = loopMode == DelugeTag.LOOP_MODE_LOOP || loopMode == DelugeTag.LOOP_MODE_STRETCH;
         final ISampleLoop loop = applyZonePositions (getDirectChild (zoneParent, DelugeTag.ZONE), zone, sampleData, isLoop);
 
         try


### PR DESCRIPTION
## Summary

A Deluge oscillator set to **STRETCH** (time-stretch) playback — `loopMode="3"` — sustains by looping its sample through the Deluge's granular time-stretch engine. `DelugeDetector` only created a loop when `loopMode == LOOP_MODE_LOOP` (2), so **STRETCH samples were converted with no loop at all**. A held note then played the one-shot sample once and dropped to silence or noise — broken for the evolving "hold/release" pads that rely on this mode.

ConvertWithMoss can't reproduce the time-stretch DSP, but a STRETCH sample still has a stored loop start and is *meant to sustain*, so this treats it as a normal forward loop. The granular character is lost; the sustain is restored.

## Change

One condition in `DelugeDetector.createZone`:

```java
final boolean isLoop = loopMode == DelugeTag.LOOP_MODE_LOOP || loopMode == DelugeTag.LOOP_MODE_STRETCH;
```

CUT (0) and ONCE (1) still correctly get no loop — only LOOP (2) and now STRETCH (3) create a sustain loop.

## Before / after

Converting a real STRETCH pad (Rephazer "DT FM Hold and Release Pad", 12 zones), Deluge → SFZ:

| | result |
|--|--|
| **before** | `loop_mode=no_loop` on all 12 zones — the sample plays once, then the held note drops out |
| **after**  | `loop_mode=loop_continuous`, `loop_start` read from the patch (46979, 49993, …) — it sustains |

The `loop_end` defaults to the sample end; that path is tidied up by the loop-end default in #160, with which this composes — together they produce a fully clean sustaining loop.
