### PR TITLE
Synthstrom Deluge: carry the per-patch volume as a sample-zone gain

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed: Converting into the root of a USB stick or external drive could fail with "The output folder is not empty" even when it looked empty, because the operating system keeps hidden bookkeeping files there (e.g. .Spotlight-V100, .Trashes and .fseventsd on macOS). Hidden files/folders and the known Windows system folders are now ignored by the empty-folder check (thanks to Douglas Carmichael).
 * Synthstrom Deluge (thanks to Douglas Carmichael)
   * Fixed: Sample-based SOUND and KIT files were rejected with "This is not a Deluge KIT or SOUND file" when the root tag carried attributes (e.g. `firmwareVersion` written inline by firmware 3.x). The broken-XML workaround only matched the bare `<sound>`/`<kit>` tag; the root tag is now matched with or without attributes.
+  * The per-patch post-effects volume is now carried as a sample-zone gain, so a converted patch keeps the relative level the sound designer set (previously every patch was converted at full level regardless of its volume). The full volume maps to 0 dB and lower volumes attenuate - it never boosts.
 * FLAC/OGG
   * Fixed: FLAC or OGG samples stored inside a ZIP archive (e.g. discoDSP Bliss or DecentSampler libraries) could fail to decompress.
   * Fixed: Stereo (multi-channel) samples stored in a compressed format were truncated to half their length when decompressed while writing to an uncompressed destination.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
@@ -520,6 +520,18 @@ public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
             for (final ISampleZone zone: zones)
                 readEnvelope (envelope1, zone.getAmplitudeEnvelopeModulator ().getSource ());
 
+        // The post-effects "volume" parameter is the per-patch output level set by the sound
+        // designer. Carry it as a zone gain so the relative balance between patches is preserved;
+        // the full volume maps to 0 dB and lower volumes attenuate (it never boosts).
+        final String volume = getValue (defaultParams, DelugeTag.VOLUME);
+        if (!volume.isBlank ())
+        {
+            final double gain = DelugeValues.paramToGainDecibels (DelugeValues.parseValue (volume, DelugeValues.PARAM_MAX));
+            if (gain < 0)
+                for (final ISampleZone zone: zones)
+                    zone.setGain (gain);
+        }
+
         final IFilter filter = readFilter (soundElement, defaultParams);
         if (filter != null)
             for (final ISampleZone zone: zones)

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeValues.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeValues.java
@@ -269,6 +269,22 @@ public final class DelugeValues
 
 
     /**
+     * Convert a 32-bit volume parameter value to a gain in decibels. The value is interpreted as a
+     * linear amplitude level (see {@link #paramToLevel}), so the gain is <code>20 * log10(level)</code>
+     * relative to the full volume, which maps to 0 dB. Lower volumes attenuate; the maximum never
+     * boosts. A muted volume is clamped to a very low but finite gain to avoid negative infinity.
+     *
+     * @param param The 32-bit parameter value
+     * @return The gain in decibels (0 or negative)
+     */
+    public static double paramToGainDecibels (final int param)
+    {
+        final double level = paramToLevel (param);
+        return level <= 0 ? -120.0 : 20.0 * Math.log10 (level);
+    }
+
+
+    /**
      * Convert an attack time in seconds to a 32-bit parameter value using the firmware attack rate
      * table.
      *


### PR DESCRIPTION
## Summary

The Deluge's post-effects **`volume`** parameter is the per-patch output level the sound designer set. `DelugeDetector` ignored it, so **every patch was converted at full level** — the relative balance between patches (a quiet pad vs. a punchy lead) was lost.

This reads `volume` and applies it as a sample-zone gain (`ISampleZone.setGain`), which the creators already write. It's interpreted as a linear amplitude level via the existing firmware-grounded `paramToLevel` (the same mapping used for the envelope sustain level), so the gain is `20·log10(level)`. **Full volume maps to 0 dB and lower volumes attenuate — it never boosts**, so there's no clipping risk and patches already at full convert unchanged.

## Change

- `DelugeValues.paramToGainDecibels(param)` — new helper, `20·log10(paramToLevel(param))`, guarded against negative infinity.
- `DelugeDetector.applySoundParameters` — reads `volume` from the sound's default params and applies the gain to every zone (only when it attenuates).

## Reference choice

The maximum volume (knob 50) maps to 0 dB. Verified against a 250-patch library — this leaves the patches that sit at full volume untouched and faithfully attenuates the rest:

| volume (knob) | level | gain | # patches |
|--|--|--|--|
| 50 (max) | 1.00 | **0 dB** (untouched) | 22 |
| 47 | 0.94 | −0.54 dB | 43 |
| 40 | 0.80 | −1.94 dB | 76 |
| 25 | 0.50 | −6.02 dB | 54 |
| … | … | … | (28 distinct values, −11.1 … 0 dB) |

So the loudest patches stay at unity and the rest pick up the attenuation the designer intended. If you'd prefer a different 0 dB reference (anchored to the Deluge's nominal default rather than the maximum), that's a one-line change — happy to adjust.

## Notes

Composes cleanly with the velocity→amplitude sensitivity work — that's a modulation *depth*, this is the static *base* level. Since Deluge support hasn't shipped in a release yet, there's no existing-conversion behavior to regress, so this is the moment to get per-patch level right.
