### PR TITLE
Waldorf QPAT: set Particle oscillator to Normal sample mode so samples key-track

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixed: Ignores hidden files/folders and the known Windows system folders when checking for empty-folder (thanks to Douglas Carmichael).
 * Fixed: The source format list showed a stray comma before the file extensions (thanks to Douglas Carmichael).
 * Fixed: Fixed some potential NullPointerExceptions.
+* Fixed: Waldorf Quantum/Iridium: a preset created from a single sample played at a fixed pitch instead of following the keyboard, because the Particle oscillator was not switched to its "Normal" sample mode (thanks to Douglas Carmichael).
 * Elektron Tonverk Multisample (thanks to Douglas Carmichael)
   * New: Relabelled "Elektron Tonverk Multisample" to not confuse it with the new "Elektron Tonverk Preset".
   * Fixed: Loops were dropped when reading the multi-sample mapping (.elmulti/.eldrum) format - the loop was parsed but never attached to the sample zone, so converted instruments lost their loop.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
@@ -343,6 +343,11 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
             // Particle
             parameters.add (new WaldorfQpatParameter ("Osc" + groupIndex + "Type", "Particle", 2.0f));
 
+            // Osc1ParticleSampleMode: [2] "Normal" selects normal, key-tracked sample playback.
+            // Without it the oscillator defaults to a mode that plays a single sample at a fixed
+            // pitch, so a sample mapped across the keyboard does not follow the played note.
+            parameters.add (new WaldorfQpatParameter ("Osc" + groupIndex + "ParticleSampleMode", "Normal", 2.0f));
+
             // Osc1CoarsePitch / Osc1FinePitch: already set in the sample maps!
             parameters.add (new WaldorfQpatParameter ("Osc" + groupIndex + "CoarsePitch", "+0 semi", 24.0f));
             parameters.add (new WaldorfQpatParameter ("Osc" + groupIndex + "FinePitch", "+0.0 cents", 0.5f));


### PR DESCRIPTION
### Problem

A QPAT preset created from a **single sample** (one zone mapped across the keyboard) plays at a **fixed pitch** on Quantum/Iridium — the note does not follow the played key, and the oscillator page shows no key-track control.

### Cause

`WaldorfQpatCreator` writes `Osc<n>Type = Particle` and `Osc<n>Keytrack = +100 %`, but never writes **`Osc<n>ParticleSampleMode`**. The Particle oscillator then defaults to a mode that does not key-track a sample. (A multi-sample map still appears to track only because moving across the keyboard switches to a different zone/recording.)

### Fix

Write `Osc<n>ParticleSampleMode = "Normal"` (value `2.0`) for every oscillator group, selecting normal, key-tracked sample playback — the same value a native Quantum/Iridium sample import writes.

### Verification

- Confirmed on Iridium hardware: adding this one parameter to an affected preset makes a single sample follow the keyboard across its full range.
- Diffed a converted preset against a native-import patch that tracks correctly; this parameter was the only difference in the pitch path.
- `mvn compile` passes.
