### PR TITLE
SoundFont 2: add option to keep length-mismatched stereo-linked samples as mono

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -44,6 +44,8 @@
   * Fixed: Save formatting of ampersand character when writing.
 * SoundFont 2 (thanks to Douglas Carmichael)
   * Fixed: "Marker" presets that reference no samples (commercial SoundFonts often include one or two named after the vendor or copyright, e.g. "E-mu Systems 2007") were converted into empty instruments. Presets without any samples are now skipped.
+  * Fixed: The "left and right samples do not match" notices (differing pitch, sample rate or length) are now only shown when the "log unsupported attributes" option is enabled, so a normal conversion of a quirky bank is no longer flooded with warnings.
+  * New: Added a "Keep mismatched stereo samples as mono" source option (off by default). Some SoundFonts - notably commercial E-mu banks - carry unreliable stereo links that flag two unrelated mono samples as a stereo pair; if their left and right halves also differ in length they were welded into a single stereo sample. When the option is enabled a length mismatch keeps the two samples separate as mono (a pitch or sample-rate mismatch always does). It is off by default because some banks contain genuine stereo pairs whose channels differ slightly in length.
 * TX16W
   * Fixed: First check if the referenced absolute sample file path exists before searching all local folders.
 * Waldorf Quantum/Iridium (thanks to Douglas Carmichael)

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -562,6 +562,7 @@ There are metadata fields for creator and some description specified in the form
 ### Source Options
 
 * Log unused SF2 generators: If enabled, generators which are found in the source but are not used (not supported) as input for the conversion are logged.
+* Keep mismatched stereo samples as mono: If enabled, two samples that the SoundFont links as a stereo pair but whose left and right halves differ in length are kept as separate mono samples instead of being combined into one stereo sample. Off by default. Some SoundFonts - notably commercial E-mu banks - carry unreliable stereo links that flag unrelated mono samples as a pair, so enabling this avoids welding two different sounds into a single stereo sample; leave it off if a bank contains genuine stereo pairs whose channels differ slightly in length. (A differing pitch or sample rate always keeps the samples separate.)
 * Prefix with file name: If enabled, the name of the Soundfont file is added to all resulting destination files.
 * Prefix with program number: If enabled, the preset number of the preset is added to the resulting destination file.
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
@@ -396,15 +396,25 @@ public class Sf2Detector extends AbstractDetector<Sf2DetectorUI>
         final Sf2SampleDescriptor left = ((Sf2SampleData) leftSampleZone.getSampleData ()).getSample ();
         final Sf2SampleDescriptor right = ((Sf2SampleData) rightSampleZone.getSampleData ()).getSample ();
 
+        // A genuine stereo pair must match in pitch and sample rate. If either differs the two
+        // samples are not really a pair - some SoundFonts (e.g. commercial E-mu banks) carry
+        // unreliable stereo links or flag mono samples as left/right. In that case keep them as
+        // the separate mono samples they actually are instead of welding two unrelated samples
+        // into one stereo sample. A differing length is handled the same way but only when the
+        // 'keep mismatched stereo as mono' option is enabled (off by default), because some banks
+        // contain genuine stereo pairs whose channels differ slightly in length. These source
+        // quirks are only reported when the 'log unsupported attributes' option is enabled.
         if (left.getOriginalPitch () != right.getOriginalPitch () || left.getPitchCorrection () != right.getPitchCorrection ())
         {
-            this.notifier.logError ("IDS_NOTIFY_ERR_DIFFERENT_SAMPLE_PITCH", left.getName (), right.getName ());
+            if (this.settingsConfiguration.logUnsupportedAttributes ())
+                this.notifier.logError ("IDS_NOTIFY_ERR_DIFFERENT_SAMPLE_PITCH", left.getName (), right.getName ());
             return false;
         }
 
         if (left.getSampleRate () != right.getSampleRate ())
         {
-            this.notifier.logError ("IDS_NOTIFY_ERR_DIFFERENT_SAMPLE_RATE", left.getName (), right.getName ());
+            if (this.settingsConfiguration.logUnsupportedAttributes ())
+                this.notifier.logError ("IDS_NOTIFY_ERR_DIFFERENT_SAMPLE_RATE", left.getName (), right.getName ());
             return false;
         }
 
@@ -416,11 +426,19 @@ public class Sf2Detector extends AbstractDetector<Sf2DetectorUI>
         if (!leftSampleZone.getLoops ().isEmpty () && (leftStart != rightStart || leftLoopLength != rightLoopLength))
             this.notifier.logError ("IDS_NOTIFY_ERR_DIFFERENT_LOOP_LENGTH", left.getName (), right.getName (), Long.toString (leftStart), Long.toString (leftLoopLength), Long.toString (rightStart), Long.toString (rightLoopLength));
 
-        // Only show the warning if there is no loop
         final long leftLength = left.getEnd () - left.getStart ();
         final long rightLength = right.getEnd () - right.getStart ();
         if (leftLength != rightLength)
-            this.notifier.logError ("IDS_NOTIFY_ERR_DIFFERENT_SAMPLE_LENGTH", left.getName (), Long.toString (leftLength), right.getName (), Long.toString (rightLength));
+        {
+            if (this.settingsConfiguration.logUnsupportedAttributes ())
+                this.notifier.logError ("IDS_NOTIFY_ERR_DIFFERENT_SAMPLE_LENGTH", left.getName (), Long.toString (leftLength), right.getName (), Long.toString (rightLength));
+            // Off by default the two samples are still combined into a stereo sample (some banks
+            // contain genuine stereo pairs whose channels differ slightly in length). Only when
+            // the user opts in is a length mismatch treated as "not a real pair" and the samples
+            // are kept as the separate mono samples they actually are.
+            if (this.settingsConfiguration.keepMismatchedStereoAsMono ())
+                return false;
+        }
 
         return true;
     }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2DetectorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2DetectorUI.java
@@ -29,14 +29,17 @@ public class Sf2DetectorUI extends MetadataSettingsUI
     private static final String SF2_LOG_UNSUPPORTED_ATTRIBUTES = "Sf2LogUnsupportedAttributes";
     private static final String SF2_ADD_FILE_NAME_TAG          = "Sf2AddFileName";
     private static final String SF2_ADD_PROGRAM_NUMBER_TAG     = "Sf2AddProgramNumber";
+    private static final String SF2_KEEP_MISMATCHED_STEREO     = "Sf2KeepMismatchedStereoAsMono";
 
     private CheckBox            logUnsupportedAttributesCheckBox;
     private CheckBox            addFileNameCheckBox;
     private CheckBox            addProgramNumberCheckBox;
+    private CheckBox            keepMismatchedStereoCheckBox;
 
     private boolean             logUnsupportedAttributes;
     private boolean             addFileName;
     private boolean             addProgramNumber;
+    private boolean             keepMismatchedStereo;
 
 
     /**
@@ -61,6 +64,7 @@ public class Sf2DetectorUI extends MetadataSettingsUI
 
         panel.createSeparator ("@IDS_SF2_OPTIONS");
         this.logUnsupportedAttributesCheckBox = panel.createCheckBox ("@IDS_SF2_LOG_UNSUPPORTED_ATTRIBUTES");
+        this.keepMismatchedStereoCheckBox = panel.createCheckBox ("@IDS_SF2_KEEP_MISMATCHED_STEREO_AS_MONO");
 
         // -----------------------------------------------------------
         // Naming
@@ -89,6 +93,7 @@ public class Sf2DetectorUI extends MetadataSettingsUI
         config.setBoolean (SF2_LOG_UNSUPPORTED_ATTRIBUTES, this.logUnsupportedAttributesCheckBox.isSelected ());
         config.setBoolean (SF2_ADD_FILE_NAME_TAG, this.addFileNameCheckBox.isSelected ());
         config.setBoolean (SF2_ADD_PROGRAM_NUMBER_TAG, this.addProgramNumberCheckBox.isSelected ());
+        config.setBoolean (SF2_KEEP_MISMATCHED_STEREO, this.keepMismatchedStereoCheckBox.isSelected ());
     }
 
 
@@ -101,6 +106,7 @@ public class Sf2DetectorUI extends MetadataSettingsUI
         this.logUnsupportedAttributesCheckBox.setSelected (config.getBoolean (SF2_LOG_UNSUPPORTED_ATTRIBUTES, false));
         this.addFileNameCheckBox.setSelected (config.getBoolean (SF2_ADD_FILE_NAME_TAG, false));
         this.addProgramNumberCheckBox.setSelected (config.getBoolean (SF2_ADD_PROGRAM_NUMBER_TAG, false));
+        this.keepMismatchedStereoCheckBox.setSelected (config.getBoolean (SF2_KEEP_MISMATCHED_STEREO, false));
     }
 
 
@@ -114,6 +120,7 @@ public class Sf2DetectorUI extends MetadataSettingsUI
         this.logUnsupportedAttributes = this.logUnsupportedAttributesCheckBox.isSelected ();
         this.addFileName = this.addFileNameCheckBox.isSelected ();
         this.addProgramNumber = this.addProgramNumberCheckBox.isSelected ();
+        this.keepMismatchedStereo = this.keepMismatchedStereoCheckBox.isSelected ();
 
         return true;
     }
@@ -135,6 +142,9 @@ public class Sf2DetectorUI extends MetadataSettingsUI
         value = parameters.remove (SF2_ADD_PROGRAM_NUMBER_TAG);
         this.addProgramNumber = "1".equals (value);
 
+        value = parameters.remove (SF2_KEEP_MISMATCHED_STEREO);
+        this.keepMismatchedStereo = "1".equals (value);
+
         return true;
     }
 
@@ -147,6 +157,7 @@ public class Sf2DetectorUI extends MetadataSettingsUI
         parameterNames.add (SF2_LOG_UNSUPPORTED_ATTRIBUTES);
         parameterNames.add (SF2_ADD_FILE_NAME_TAG);
         parameterNames.add (SF2_ADD_PROGRAM_NUMBER_TAG);
+        parameterNames.add (SF2_KEEP_MISMATCHED_STEREO);
         return parameterNames.toArray (new String [parameterNames.size ()]);
     }
 
@@ -170,6 +181,18 @@ public class Sf2DetectorUI extends MetadataSettingsUI
     public boolean addProgramNumber ()
     {
         return this.addProgramNumber;
+    }
+
+
+    /**
+     * Should stereo-linked samples whose left/right halves differ in length be kept as separate
+     * mono samples instead of being combined into one stereo sample?
+     *
+     * @return True to keep them as separate mono samples
+     */
+    public boolean keepMismatchedStereoAsMono ()
+    {
+        return this.keepMismatchedStereo;
     }
 
 

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -597,6 +597,7 @@ IDS_SF2_NAMING_ADD_FILE_NAME=Prefix with file name
 IDS_SF2_NAMING_ADD_PROGRAM_NUMBER=Prefix with program number
 IDS_SF2_OPTIONS=Options
 IDS_SF2_LOG_UNSUPPORTED_ATTRIBUTES=Log unused SF2 generators
+IDS_SF2_KEEP_MISMATCHED_STEREO_AS_MONO=Keep mismatched stereo samples as mono
 IDS_SF2_RESAMPLE_TO_16BIT=Re-sample 24-bit to 16-bit
 
 IDS_SFZ_OPTIONS=Options


### PR DESCRIPTION
### Problem

Some SoundFonts — in particular commercial E-mu banks such as the "Orbit" bank — carry unreliable stereo metadata: samples are flagged as left/right and linked (`wSampleLink`) to partners they are not actually the stereo halves of. When such a bank is converted, `combineToStereo` tries to weld these "pairs" back together.

`compareSampleFormat` already declines the merge when the two samples differ in pitch or sample rate, but a **length** mismatch only logged a warning and then merged them anyway — so two unrelated sounds ended up hard-panned into the left and right channels of a single stereo sample (the shorter one truncating the longer). Converting one such bank also produced a wall of warnings.

### Change (updated per review)

Per @git-moss's feedback that some banks contain genuine stereo pairs whose left/right channels differ in length, the length-mismatch behaviour is now **opt-in and off by default**:

- New **"Keep mismatched stereo samples as mono"** option (`Sf2KeepMismatchedStereoAsMono`, off by default). When enabled, a length mismatch declines the stereo merge just like a pitch/sample-rate mismatch, so the two samples are kept as the separate mono samples they actually are. **Off by default a length-mismatched pair still combines**, so genuine different-length stereo pairs are unaffected.
- The pitch / sample-rate / length "left and right samples do not match" notices are now shown only when the existing **Log unused SF2 generators** option is enabled, so a normal conversion of a quirky bank stays clean while the detail is still available on request.

Since the stereo-combining happens while *reading* the SoundFont, the checkbox lives in the SF2 source options (next to "Log unused SF2 generators"); happy to move it if you'd prefer it elsewhere.

Rebased onto current `main`. The diff is limited to `Sf2Detector.java`, `Sf2DetectorUI.java`, `Strings.properties`, and the changelog / format docs.

### Verification

Tested against a commercial E-mu "Orbit" SoundFont, converting every preset to WAV:

- **Off (default):** the 3 length-mismatched pairs are each combined into a single stereo file (unchanged from before this PR).
- **On (`Sf2KeepMismatchedStereoAsMono=1`):** those 3 pairs are instead kept as their 6 separate full-length mono samples (+3 files); the channel that was previously truncated keeps its full length.

Pitch- and sample-rate-mismatched pairs remain mono in both cases (unchanged).
