### PR TITLE
Fix incorrect envelope time conversions in disting EX, 1010music and Maschine 2/3

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -18,6 +18,10 @@
   * New: Added an opt-in *Snap loops to zero-crossings* processing option.
   * Fixed: Ignores hidden files/folders and the known Windows system folders when checking for empty-folder (thanks to Douglas Carmichael).
   * Fixed: Fixed some potential NullPointerExceptions.
+* 1010music (thanks to Douglas Carmichael)
+  * Fixed: The amplitude decay and release times were written with a different time scale than the one used when reading them back (25 seconds instead of 38 seconds full-scale), so a converted blackbox/Bento preset played its decay and release noticeably shorter than the source. The write scale now matches the read scale.
+* disting EX (thanks to Douglas Carmichael)
+  * Fixed: A misplaced parenthesis in the amplitude decay conversion divided only the decay time (not hold plus decay) by the time constant, so any hold time was effectively dropped from the written decay.
 * Elektron Tonverk Multisample (thanks to Douglas Carmichael)
   * New: Relabelled "Elektron Tonverk Multisample" to not confuse it with the new "Elektron Tonverk Preset".
   * Fixed: Loops were dropped when reading the multi-sample mapping (.elmulti/.eldrum) format - the loop was parsed but never attached to the sample zone, so converted instruments lost their loop.
@@ -30,6 +34,8 @@
   * Fixed: Implemented workaround for converting 32-bit FLAC files (might not always work).
 * Maschine 1
   * Fixed: File version number was always written as 0.
+* Maschine 2/3 (thanks to Douglas Carmichael)
+  * Fixed: The modulation (filter/pitch) envelope times were converted incorrectly. When reading, the attack and decay were left in milliseconds instead of seconds (a thousand times too long) and the release skipped the time-curve mapping entirely; when writing, the release skipped that mapping as well. The modulation envelope now uses the same conversion as the amplitude envelope.
 * MPC
   * Fixed: Program in XTY file was not read.
 * Omnisphere

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/disting/DistingExCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/disting/DistingExCreator.java
@@ -172,7 +172,7 @@ public class DistingExCreator extends AbstractWavCreator<DistingExCreatorUI>
                         {
                             final IEnvelope envelope = envelopeModulator.getSource ();
                             parameters[7] = Math.clamp ((int) Math.round (Math.log (envelope.getAttackTime () / 0.001) / 0.0757), 0, 127);
-                            parameters[8] = Math.clamp ((int) Math.round (Math.log (Math.max (0, envelope.getHoldTime ()) + Math.max (0, envelope.getDecayTime ()) / 0.02) / 0.0521), 0, 127);
+                            parameters[8] = Math.clamp ((int) Math.round (Math.log ((Math.max (0, envelope.getHoldTime ()) + Math.max (0, envelope.getDecayTime ())) / 0.02) / 0.0521), 0, 127);
                             parameters[10] = Math.clamp ((int) Math.round (Math.log (envelope.getReleaseTime () / 0.01) / 0.0630), 0, 127);
                         }
                     }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoCreator.java
@@ -310,8 +310,8 @@ public class BentoCreator extends AbstractMusic1010Creator
                 final int sustain = sustainVal < 0 ? 1000 : (int) Math.round (sustainVal * 1000.0);
 
                 paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_ATTACK, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getAttackTime ()), 9.0));
-                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_DECAY, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getHoldTime ()) + Math.max (0, amplitudeEnvelope.getDecayTime ()), 25.0));
-                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_RELEASE, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getReleaseTime ()), 25.0));
+                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_DECAY, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getHoldTime ()) + Math.max (0, amplitudeEnvelope.getDecayTime ()), 38.0));
+                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_RELEASE, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getReleaseTime ()), 38.0));
                 paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_SUSTAIN, Integer.toString (sustain));
             }
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Creator.java
@@ -335,8 +335,8 @@ public class Music1010Creator extends AbstractMusic1010Creator
                 final int sustain = sustainVal < 0 ? 1000 : (int) Math.round (sustainVal * 1000.0);
 
                 paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_ATTACK, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getAttackTime ()), 9.0));
-                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_DECAY, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getHoldTime ()) + Math.max (0, amplitudeEnvelope.getDecayTime ()), 25.0));
-                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_RELEASE, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getReleaseTime ()), 25.0));
+                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_DECAY, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getHoldTime ()) + Math.max (0, amplitudeEnvelope.getDecayTime ()), 38.0));
+                paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_RELEASE, MathUtils.normalizeTimeFormattedAsInt (Math.max (0, amplitudeEnvelope.getReleaseTime ()), 38.0));
                 paramsElement.setAttribute (Music1010Tag.ATTR_AMPEG_SUSTAIN, Integer.toString (sustain));
             }
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ni/maschine/maschine2/MaschinePresetAccessor.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ni/maschine/maschine2/MaschinePresetAccessor.java
@@ -455,7 +455,7 @@ public class MaschinePresetAccessor
             writeFloatValueRow (globalOffset + 148, data, attackMillisToInput ((float) (attackTime * 1000.0)));
             writeFloatValueRow (globalOffset + 156, data, decayAndReleaseMillisToInput ((float) (decayTime * 1000.0)));
             writeFloatValueRow (globalOffset + 160, data, (float) (sustainLevel < 0 ? 1 : sustainLevel));
-            writeFloatValueRow (globalOffset + 164, data, (float) (releaseTime * 1000.0));
+            writeFloatValueRow (globalOffset + 164, data, decayAndReleaseMillisToInput ((float) (releaseTime * 1000.0)));
         }
     }
 
@@ -751,13 +751,13 @@ public class MaschinePresetAccessor
 
         // Modulation envelope
         floatValues = parameterArray.readFloat (offset + (isOldFormat ? 111 : 148), 3);
-        final double modulationAttackTime = mapToAttackMillis (floatValues[0]);
+        final double modulationAttackTime = mapToAttackMillis (floatValues[0]) / 1000.0;
         floatValues = parameterArray.readFloat (offset + (isOldFormat ? 117 : 156), 3);
-        final double modulationDecayTime = mapToDecayAndRelease (floatValues[0]);
+        final double modulationDecayTime = mapToDecayAndRelease (floatValues[0]) / 1000.0;
         floatValues = parameterArray.readFloat (offset + (isOldFormat ? 120 : 160), 3);
         final double modulationSustainLevel = floatValues[0];
         floatValues = parameterArray.readFloat (offset + (isOldFormat ? 123 : 164), 3);
-        final double modulationReleaseTime = floatValues[0];
+        final double modulationReleaseTime = mapToDecayAndRelease (floatValues[0]) / 1000.0;
 
         // Modulation destinations
         floatValues = parameterArray.readFloat (offset + (isOldFormat ? 126 : 168), 3);


### PR DESCRIPTION
While auditing the creators/detectors for envelope-time conversion bugs I found three independent issues. In each case the **amplitude envelope of the same format already does it correctly**, so the fix is to make the affected path match that reference. Each fix is small and independent.

### 1. disting EX — dropped hold time in amplitude decay

`DistingExCreator` writes the amplitude decay as:

```java
Math.log (Math.max (0, envelope.getHoldTime ()) + Math.max (0, envelope.getDecayTime ()) / 0.02) / 0.0521
```

Operator precedence makes `/ 0.02` bind to the decay term only, i.e. `log(hold + decay/0.02)` instead of the intended `log((hold + decay)/0.02)`. Because `decay/0.02` dwarfs `hold`, the hold time is effectively dropped from the written decay. The reader confirms the intent — it decodes with `decay = 0.02 * Math.exp (0.0521 * value)`, whose inverse is `log((hold+decay)/0.02)/0.0521`. Fixed by parenthesising `(hold + decay)` before the division.

### 2. 1010music (blackbox and Bento) — decay/release write scale doesn't match read scale

The amplitude decay and release are **written** with a 25 s full-scale but **read back** with a 38 s full-scale:

| Parameter | Write (`normalizeTime…`) | Read (`denormalizeTime`) |
|-----------|--------------------------|--------------------------|
| Attack    | `9.0`                    | `9.0`  ✅ consistent      |
| Decay     | `25.0`                   | `38.0` ❌ mismatch        |
| Release   | `25.0`                   | `38.0` ❌ mismatch        |

`normalizeTime`/`denormalizeTime` are inverse operations, so the same full-scale constant must be used on both sides or the value doesn't round-trip — a converted blackbox/Bento preset plays its decay and release noticeably shorter than the source. Attack is already consistent at 9 s. The reader's 38 s is the device-calibrated value (it was introduced when read-back of the amp envelope was implemented), so I aligned the writer (`Music1010Creator` and `BentoCreator`) to 38 s.

### 3. Maschine 2/3 — modulation (filter/pitch) envelope time conversions

In `MaschinePresetAccessor` the modulation envelope (used for the filter and pitch envelopes) is converted differently from the amplitude envelope in the same file:

- **Reading:** attack and decay are left in milliseconds (`mapToAttackMillis` / `mapToDecayAndRelease` without the `/ 1000.0` the amp envelope applies), so they come out a thousand times too long; the release skips `mapToDecayAndRelease` entirely and uses the raw normalized value.
- **Writing:** the release skips `decayAndReleaseMillisToInput`, writing raw milliseconds into the parameter row instead of the device's encoded value.

Fixed so the modulation envelope uses the same conversion as the amplitude envelope (read: `… / 1000.0`; write: `decayAndReleaseMillisToInput (…)`). Read and write offsets (148/156/160/164) already match, so this only corrects the value mapping.

---

All four changed files compile. (The tree currently has an unrelated `XMLUtils.escapeAttribute` compile error in `OmnisphereCreator` at `main` HEAD against the vendored `uitools` jar; it is independent of these changes.) CHANGELOG updated with a per-format entry.