### PR TITLE
SoundFont 2: skip "marker" presets that reference no samples

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -35,6 +35,8 @@
 * Omnisphere
   * Fixed: Reading an Omnisphere preset with multiple sample voice elements did only return the samples of the last voice.
   * Fixed: Save formatting of ampersand character when writing.
+* SoundFont 2 (thanks to Douglas Carmichael)
+  * Fixed: "Marker" presets that reference no samples (commercial SoundFonts often include one or two named after the vendor or copyright, e.g. "E-mu Systems 2007") were converted into empty instruments. Presets without any samples are now skipped.
 * TX16W
   * Fixed: First check if the referenced absolute sample file path exists before searching all local folders.
 * Waldorf Quantum/Iridium (thanks to Douglas Carmichael)

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
@@ -140,6 +140,17 @@ public class Sf2Detector extends AbstractDetector<Sf2DetectorUI>
             if (this.settingsConfiguration.addFileName () || this.settingsConfiguration.addProgramNumber ())
                 presetName = this.addPrefixes (presetName, preset.getProgramNumber (), FileUtils.getNameWithoutType (sourceFile));
             final IMultisampleSource multisampleSource = this.createMultisampleSource (sourceFile, parts, presetName, this.combineToStereo (groups));
+
+            // Skip "empty" presets which reference no samples. Commercial SoundFonts often carry
+            // marker presets named after the vendor or the copyright (e.g. "E-mu Systems 2007")
+            // whose instrument has no zones; without this guard they would be written as empty
+            // instruments.
+            if (multisampleSource.getNonEmptyGroups (false).isEmpty ())
+            {
+                this.notifier.log ("IDS_NOTIFY_SF2_SKIP_EMPTY_PRESET", presetName);
+                continue;
+            }
+
             this.fillMetadata (sf2File, parts, multisampleSource.getMetadata ());
             multisamples.add (multisampleSource);
         }

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -57,6 +57,7 @@ IDS_NOTIFY_SFZ_PARTIALLY_UNSUPPORTED_TRIGGER=Partially unsupported trigger value
 IDS_NOTIFY_SFZ_UNSUPPORTED_TRIGGER=Unsupported trigger value: %1\n
 IDS_NOTIFY_UNSUPPORTED_OPCODES=Unused SFZ opcodes: %1\n
 IDS_NOTIFY_UNSUPPORTED_GENERATORS=Unused SF2 generators: %1\n
+IDS_NOTIFY_SF2_SKIP_EMPTY_PRESET=Skipping SoundFont preset '%1' because it contains no samples.\n
 IDS_NOTIFY_UNSUPPORTED_ATTRIBUTES=Unused <%1> attributes: %2\n
 IDS_NOTIFY_UNSUPPORTED_ELEMENTS=Unused <%1> child elements: %2\n
 IDS_NOTIFY_ERR_NO_SAMPLE_LENGTH=Could not retrieve length of sample.\n


### PR DESCRIPTION
## Problem

Commercial SoundFonts frequently include one or two presets that carry no playable content and exist only to stamp the file with the vendor or copyright. For example, an E-mu **Orbit.SF2** has presets named **"E-mu Systems 2007"** and **"DigitalSoundFactory"**, each with a preset zone that points at an instrument which has **no instrument zones** (zero samples).

`Sf2Detector` created an `IMultisampleSource` for every preset unconditionally, so these produced **empty instruments** in the destination format — an empty Waldorf QPAT, an empty Renoise XRNI, etc. The user noticed empty `.qpat` files named after those two "presets".

## Fix

After building the multi-sample for a preset, skip it if it has no non-empty groups (no samples), and log which preset was skipped. This mirrors the existing guard in `EnsoniqEpsAsrDetector` (`if (multisampleSource.getNonEmptyGroups(...).isEmpty()) continue;`), so it follows an established pattern, and it fixes the problem once at the source for **every** destination format rather than per-creator.

```java
if (multisampleSource.getNonEmptyGroups (false).isEmpty ())
{
    this.notifier.log ("IDS_NOTIFY_SF2_SKIP_EMPTY_PRESET", presetName);
    continue;
}
```

`getNonEmptyGroups(false)` is used (rather than `true`) so a preset is skipped only when it has literally no sample zones — never merely because its zones are release-triggers.

## Verification

Analyzed `Orbit.SF2` before/after:

- Before: 236 presets detected (incl. the two empty marker presets).
- After: **234** detected; the log shows
  `Skipping SoundFont preset 'E-mu Systems 2007' because it contains no samples.` and the same for `DigitalSoundFactory`.
- All 234 real presets are unaffected.

A new `IDS_NOTIFY_SF2_SKIP_EMPTY_PRESET` string is added; CHANGELOG updated.

(Note: `main` HEAD currently has an unrelated `XMLUtils.escapeAttribute` compile error in `OmnisphereCreator` against the vendored `uitools` jar; it is independent of this change — the modified `Sf2Detector` compiles clean.)