### PR TITLE
Add opt-in metadata option to detect the category from a name prefix

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -15,6 +15,7 @@
   * New: Added support for sustain / 'loop until release' loop mode (the loop runs while the key is held and then plays the remainder of the sample on release, as opposed to a continuous loop) - Ableton, Ensoniq EPS/ASR, EXS24, NI Kontakt, Renoise, SoundFont 2, SFZ, SXT, Tonverk (thanks to Douglas Carmichael).
   * New: Added support for filter cutoff keyboard-tracking: Ableton Sampler, Akai AKP/AKM, Akai S1000, Bliss, Ensoniq, Omnisphere, SXT, Roland, SFZ, Synthstrom Deluge, TAL Sampler, TX16W, Waldorf, Yamaha YSFC.
   * New: Added several new tags for category detection.
+  * New: Added an opt-in metadata option "Category tag at name start declares the category" (off by default): many commercial libraries prefix each preset name with its category (e.g. 'PAD Solina', 'BASS Growler'). When enabled, such a prefix takes precedence over keyword matches elsewhere in the name, which could otherwise win accidentally (e.g. 'BELL Vibrato Strings' was detected as Strings instead of Bell), and common abbreviations (BRAS, DRM, FLUT, GRAN, ORG, PERC, PHYS, PLUK, POLY, REES, STRG, SWEP, VOC) are recognized as well. Also added 'Reese' as a Bass category tag (thanks to Douglas Carmichael).
   * New: Added an opt-in *Snap loops to zero-crossings* processing option.
   * Fixed: Ignores hidden files/folders and the known Windows system folders when checking for empty-folder (thanks to Douglas Carmichael).
   * Fixed: Fixed some potential NullPointerExceptions.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -13,6 +13,7 @@ The following settings are available in several source and destination formats a
 If there are no metadata fields (category, creator, etc.) specified in the format, information is retrieved from Broadcast Audio Extension chunks in the WAV files. If no such chunks are present, ConvertWithMoss can detect from the name and path of the file. The following settings can be used to tweak the detection process:
 
 * Prefer folder name: If enabled the name of the multi-sample will be extracted from the folder instead of the sample names.
+* Category tag at name start declares the category: Many commercial libraries prefix each preset name with its category (e.g. 'PAD Solina', 'BASS Growler'). If enabled, such a tag at the very start of the name declares the category and takes precedence over keyword matches elsewhere in the name (e.g. 'BELL Vibrato Strings' is then detected as Bell instead of Strings). Common abbreviations are recognized as well: BRAS, DRM, FLUT, GRAN, ORG, PERC, PHYS, PLUK, POLY, REES, STRG, SWEP, VOC. Leave it off for libraries which do not follow this naming convention (a name like 'Syn Brass' would otherwise be detected as Synth instead of Brass).
 * Default creator: The name which is set as the creator of the multi-samples, if no creator tag could be found.
 * Creator tag(s): Here you can set a number of creator names, which need to be separated by comma. You can also use this to look up other things. For example, I set the names of the synthesizers which I sampled. My string looks like: "01W,FM8,Pro-53,Virus B,XV" (without the quotes).
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/model/implementation/DefaultMetadata.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/model/implementation/DefaultMetadata.java
@@ -122,7 +122,7 @@ public class DefaultMetadata implements IMetadata
         if (this.creator.isBlank ())
             this.setCreator (TagDetector.detect (parts, config.getCreatorTags (), config.getCreatorName ()));
         if (this.category.isBlank () || TagDetector.CATEGORY_UNKNOWN.equals (this.category))
-            this.setCategory (category == null || category.isBlank () ? TagDetector.detectCategory (parts) : category);
+            this.setCategory (category == null || category.isBlank () ? TagDetector.detectCategory (parts, config.isCategoryFromNamePrefix ()) : category);
         if (this.keywords.length == 0)
             this.setKeywords (TagDetector.detectKeywords (parts));
     }

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/settings/IMetadataConfig.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/settings/IMetadataConfig.java
@@ -20,6 +20,15 @@ public interface IMetadataConfig
 
 
     /**
+     * Should a category tag at the very start of a name (e.g. 'PAD Solina') declare the category
+     * of the multi-sample?
+     *
+     * @return True if the category should be detected from the name prefix
+     */
+    boolean isCategoryFromNamePrefix ();
+
+
+    /**
      * Get the default creator name to use.
      *
      * @return The default creator

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/settings/MetadataSettingsUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/settings/MetadataSettingsUI.java
@@ -24,18 +24,21 @@ import javafx.scene.layout.Pane;
  */
 public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
 {
-    private static final String PREFER_FOLDER_NAME = "PreferFolderName";
-    private static final String DEFAULT_CREATOR    = "DefaultCreator";
-    private static final String TAG_CREATORS       = "Creators";
+    private static final String PREFER_FOLDER_NAME       = "PreferFolderName";
+    private static final String CATEGORY_FROM_NAME_PREFIX = "CategoryFromNamePrefix";
+    private static final String DEFAULT_CREATOR           = "DefaultCreator";
+    private static final String TAG_CREATORS              = "Creators";
 
     private TitledSeparator     separator;
     protected final String      prefix;
 
     private CheckBox            preferFolderNameCheckBox;
+    private CheckBox            categoryFromNamePrefixCheckBox;
     private TextField           defaultCreatorField;
     private TextField           creatorsField;
 
     private boolean             preferFolderName;
+    private boolean             categoryFromNamePrefix;
     private String              defaultCreator;
     private String []           creators;
 
@@ -70,6 +73,7 @@ public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
     {
         this.separator = panel.createSeparator ("@IDS_METADATA_HEADER");
         this.preferFolderNameCheckBox = panel.createCheckBox ("@IDS_METADATA_PREFER_FOLDER");
+        this.categoryFromNamePrefixCheckBox = panel.createCheckBox ("@IDS_METADATA_CATEGORY_FROM_NAME_PREFIX");
         this.defaultCreatorField = panel.createField ("@IDS_METADATA_DEFAULT_CREATOR");
         this.creatorsField = panel.createField ("@IDS_METADATA_CREATORS", "@IDS_NOTIFY_COMMA", -1);
     }
@@ -80,6 +84,7 @@ public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
     public void loadSettings (final BasicConfig configuration)
     {
         this.preferFolderNameCheckBox.setSelected (configuration.getBoolean (this.prefix + PREFER_FOLDER_NAME, false));
+        this.categoryFromNamePrefixCheckBox.setSelected (configuration.getBoolean (this.prefix + CATEGORY_FROM_NAME_PREFIX, false));
         this.defaultCreatorField.setText (configuration.getProperty (this.prefix + DEFAULT_CREATOR, "moss"));
         this.creatorsField.setText (configuration.getProperty (this.prefix + TAG_CREATORS, ""));
     }
@@ -90,6 +95,7 @@ public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
     public void saveSettings (final BasicConfig configuration)
     {
         configuration.setProperty (this.prefix + PREFER_FOLDER_NAME, Boolean.toString (this.preferFolderNameCheckBox.isSelected ()));
+        configuration.setProperty (this.prefix + CATEGORY_FROM_NAME_PREFIX, Boolean.toString (this.categoryFromNamePrefixCheckBox.isSelected ()));
         configuration.setProperty (this.prefix + DEFAULT_CREATOR, this.defaultCreatorField.getText ());
         configuration.setProperty (this.prefix + TAG_CREATORS, this.creatorsField.getText ());
     }
@@ -100,6 +106,7 @@ public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
     public boolean checkSettingsUI (final INotifier notifier)
     {
         this.preferFolderName = this.preferFolderNameCheckBox.isSelected ();
+        this.categoryFromNamePrefix = this.categoryFromNamePrefixCheckBox.isSelected ();
         this.defaultCreator = this.defaultCreatorField.getText ();
         this.creators = StringUtils.splitByComma (this.creatorsField.getText ());
         return true;
@@ -112,6 +119,9 @@ public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
     {
         String value = parameters.remove (this.prefix + PREFER_FOLDER_NAME);
         this.preferFolderName = "1".equals (value);
+
+        value = parameters.remove (this.prefix + CATEGORY_FROM_NAME_PREFIX);
+        this.categoryFromNamePrefix = "1".equals (value);
 
         this.defaultCreator = parameters.remove (this.prefix + DEFAULT_CREATOR);
 
@@ -128,6 +138,7 @@ public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
         return new String []
         {
             this.prefix + PREFER_FOLDER_NAME,
+            this.prefix + CATEGORY_FROM_NAME_PREFIX,
             this.prefix + DEFAULT_CREATOR,
             this.prefix + TAG_CREATORS
         };
@@ -139,6 +150,14 @@ public class MetadataSettingsUI implements IMetadataConfig, ICoreTaskSettings
     public boolean isPreferFolderName ()
     {
         return this.preferFolderName;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isCategoryFromNamePrefix ()
+    {
+        return this.categoryFromNamePrefix;
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/TagDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/TagDetector.java
@@ -28,6 +28,7 @@ public class TagDetector
 {
     private static final Map<String, String []> CATEGORIES                    = new HashMap<> ();
     private static final Map<String, String>    CATEGORY_LOOKUP               = new TreeMap<> (new StringLengthComparator ());
+    private static final Map<String, String>    CATEGORY_PREFIX_LOOKUP        = new HashMap<> ();
     private static final Map<String, String>    KEYWORD_LOOKUP                = new TreeMap<> (new StringLengthComparator ());
     private static final List<String>           WORD_DICT                     = new ArrayList<> ();
 
@@ -157,6 +158,7 @@ public class TagDetector
             "Picked Bs",
             CATEGORY_BASS,
             "Fretless",
+            "Reese",
             "Slap",
             "Fingered"
         });
@@ -513,6 +515,27 @@ public class TagDetector
                 CATEGORY_LOOKUP.put (v.toUpperCase (Locale.US), category);
         }
 
+        // A category tag at the very start of a name declares the intended category explicitly
+        // (a wide-spread naming convention in commercial libraries, e.g. 'PAD Solina' or
+        // 'BASS Growler'). All category keywords can be used as such a prefix. Additionally,
+        // the following common abbreviations are recognized - only as a name prefix, since they
+        // are too ambiguous for the contains-matching of the general detection (e.g. 'GRAN' is
+        // contained in 'Grand' and 'ORG' in 'Forge').
+        CATEGORY_PREFIX_LOOKUP.putAll (CATEGORY_LOOKUP);
+        CATEGORY_PREFIX_LOOKUP.put ("BRAS", CATEGORY_BRASS);
+        CATEGORY_PREFIX_LOOKUP.put ("DRM", CATEGORY_DRUM);
+        CATEGORY_PREFIX_LOOKUP.put ("FLUT", CATEGORY_PIPE);
+        CATEGORY_PREFIX_LOOKUP.put ("GRAN", CATEGORY_SYNTH);
+        CATEGORY_PREFIX_LOOKUP.put ("ORG", CATEGORY_ORGAN);
+        CATEGORY_PREFIX_LOOKUP.put ("PERC", CATEGORY_PERCUSSION);
+        CATEGORY_PREFIX_LOOKUP.put ("PHYS", CATEGORY_SYNTH);
+        CATEGORY_PREFIX_LOOKUP.put ("PLUK", CATEGORY_PLUCK);
+        CATEGORY_PREFIX_LOOKUP.put ("POLY", CATEGORY_SYNTH);
+        CATEGORY_PREFIX_LOOKUP.put ("REES", CATEGORY_BASS);
+        CATEGORY_PREFIX_LOOKUP.put ("STRG", CATEGORY_STRINGS);
+        CATEGORY_PREFIX_LOOKUP.put ("SWEP", CATEGORY_SYNTH);
+        CATEGORY_PREFIX_LOOKUP.put ("VOC", CATEGORY_VOCAL);
+
         Arrays.asList (KEYWORDS).forEach (value -> KEYWORD_LOOKUP.put (value.toUpperCase (Locale.US), value));
 
         // Normalize and sort words by descending length for camel case method
@@ -557,7 +580,22 @@ public class TagDetector
      */
     public static String detectCategory (final String [] texts)
     {
-        return detect (texts, CATEGORY_LOOKUP, CATEGORY_UNKNOWN);
+        return detectCategory (Arrays.asList (texts), false);
+    }
+
+
+    /**
+     * Detect a category in the given strings.
+     *
+     * @param texts The texts
+     * @param categoryFromNamePrefix If true, a category tag at the very start of one of the texts
+     *            declares the category and takes precedence over keyword matches anywhere in the
+     *            texts
+     * @return The detected tag
+     */
+    public static String detectCategory (final String [] texts, final boolean categoryFromNamePrefix)
+    {
+        return detectCategory (Arrays.asList (texts), categoryFromNamePrefix);
     }
 
 
@@ -569,7 +607,53 @@ public class TagDetector
      */
     public static String detectCategory (final Collection<String> texts)
     {
+        return detectCategory (texts, false);
+    }
+
+
+    /**
+     * Detect a category in the given strings.
+     *
+     * @param texts The texts
+     * @param categoryFromNamePrefix If true, a category tag at the very start of one of the texts
+     *            declares the category and takes precedence over keyword matches anywhere in the
+     *            texts
+     * @return The detected tag
+     */
+    public static String detectCategory (final Collection<String> texts, final boolean categoryFromNamePrefix)
+    {
+        if (categoryFromNamePrefix)
+        {
+            final String category = detectCategoryByNamePrefix (texts);
+            if (category != null)
+                return category;
+        }
         return detect (texts, CATEGORY_LOOKUP, CATEGORY_UNKNOWN);
+    }
+
+
+    /**
+     * Detect a category from a category tag at the very start of a text (e.g. 'PAD Solina' or
+     * 'BASS Growler'). Such a prefix declares the intended category explicitly and therefore takes
+     * precedence over keyword matches anywhere in the texts, which can otherwise win accidentally
+     * (e.g. 'BELL Vibrato Strings' would be detected as Strings instead of Bell).
+     *
+     * @param texts The texts, the most specific (e.g. the preset name) first
+     * @return The category or null if the first word of none of the texts is a category tag
+     */
+    private static String detectCategoryByNamePrefix (final Collection<String> texts)
+    {
+        for (final String text: texts)
+        {
+            final String [] tokens = text.trim ().toUpperCase (Locale.US).split ("[ _-]+");
+            if (tokens.length > 1)
+            {
+                final String category = CATEGORY_PREFIX_LOOKUP.get (tokens[0]);
+                if (category != null)
+                    return category;
+            }
+        }
+        return null;
     }
 
 

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -509,6 +509,7 @@ IDS_EXEC_CANCEL_TOOLTIP=Cancel the processing
 
 IDS_METADATA_HEADER=Metadata
 IDS_METADATA_PREFER_FOLDER=Prefer folder name
+IDS_METADATA_CATEGORY_FROM_NAME_PREFIX=Category tag at name start declares the category (e.g. 'PAD Solina')
 IDS_METADATA_DEFAULT_CREATOR=Default creator:
 IDS_METADATA_CREATORS=Creator tags (if found in name or path):
 


### PR DESCRIPTION
### Problem

Many commercial libraries prefix every preset name with its category — e.g. `PAD Solina`, `BASS Growler`, or the Vulture Culture "Legendary Synths" SFZ libraries where all 187 presets are named like `BELL Poly800 Vibrato Strings`, `REES OS Repentless`, `STRG K3 Analog Strings`.

The category detection matches keywords anywhere in the name and picks the longest match, so such names can land in the wrong category (`BELL Poly800 Vibrato Strings` → **Strings** instead of Bell, because 'Strings' is the longer keyword) or in no category at all when the prefix is an abbreviation that is no keyword (`STRG`, `REES`, `PLUK`, ... → **Unknown**). Since the category also selects the default amplitude envelope for sources without one, this affects more than browsing metadata.

### Change

A new checkbox **"Category tag at name start declares the category"** in the common metadata options (CLI: `<Format>CategoryFromNamePrefix=1`), **off by default**:

- When enabled, a category tag at the very start of a name declares the category and takes precedence over keyword matches elsewhere in the name. All existing category keywords work as such a prefix.
- Common abbreviations are recognized as a prefix as well: `BRAS`, `DRM`, `FLUT`, `GRAN`, `ORG`, `PERC`, `PHYS`, `PLUK`, `POLY`, `REES`, `STRG`, `SWEP`, `VOC`. They are deliberately **not** added to the general keyword lists because they are too ambiguous for contains-matching (`GRAN` is contained in 'Grand Piano', `ORG` in 'Forge').
- It is off by default because the naming convention is not universal: e.g. the E-mu Orbit bank has a preset `Syn Brass` (a brass sound) which the prefix rule would classify as Synth.
- Also adds `Reese` as a regular Bass category tag.

### Verification

- **Option off (default):** converting a 234-preset SF2 bank (E-mu Orbit) to QPAT produces **byte-identical** output to current `main` — zero behavior change.
- **Option on:** all 187 presets of the two "Legendary Synths" SFZ libraries map deterministically to their vendor taxonomy (18 distinct name prefixes → Bass, Bell, Brass, Drum, Pipe, Keyboard, Lead, Organ, Pad, Pluck, FX, Strings, Vocal, Synth); previously 14 of them were Unknown and a further ~40 landed in accidental categories.
- `normalizeCategory` and the format-specific `detectCategory` callers (Kontakt icon names, SF2/DLS descriptions, QPAT categories, Maschine) keep the existing behavior — the prefix logic only applies to the name/path based detection when the option is enabled.