### PR TITLE
Add support for the Synclavier Regen timbre/library format (SFLC)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -8,6 +8,7 @@
 * New: Added support for the Elektron Tonverk preset (TVPST) (thanks to Douglas Carmichael).
 * New: Added support for the Roland MV-8000/MV-8800 patch format (MV0) (thanks to Douglas Carmichael).
 * New: Added support for the Roland ZEN-Core sound format (SVZ) (thanks to Douglas Carmichael).
+* New: Added support for the Synclavier Regen timbre/library format (SFLC) (thanks to Douglas Carmichael).
 * New: Added support for the Fairlight CMI 3 - read only (thanks to PythonBlue).
 * New: Added support for the Downloadable Sound format (DLS) - read only.
 * User Interface

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -69,6 +69,7 @@ The following multi-sample formats are supported:
 * [SFZ](#sfz)
 * [SoundFont 2](#soundfont-2)
 * [Spectrasonics Omnisphere 3](#spectrasonics-omnisphere-3)
+* [Synclavier Regen](#synclavier-regen)
 * [Synthstrom Deluge](#synthstrom-deluge)
 * [TAL Sampler](#tal-sampler)
 * [Waldorf Quantum MkI, MkII / Iridium / Iridium Core](#waldorf-quantum-mki-mkii--iridium--iridium-core)
@@ -634,6 +635,27 @@ then move the prt_omn file to
 
 **Note 1**: You can create a sub-folder with the name of a category, e.g. "Vox Humana" and put it there.
 **Note 2**: When opening Omnisphere both the presets and soundsources need to be rescanned! If only the presets are scanned an error shows up that the soundsource cannot be located!
+
+## Synclavier Regen
+
+The Synclavier Regen (2023) is a desktop re-creation of the classic Synclavier synthesizer. Its sounds are organized in *libraries* - a folder placed under *Libraries/* on the device SD card that holds one or more *timbres* together with their samples and two index files. A timbre is a plain UTF-8 text file named *NN-Entry.txt* which starts with a title and a comment line followed by *SynclavierVirtualInstrumentTimbreVersion...* and the parameter lines. A timbre has up to twelve *partials* (layers); each partial maps its samples across the keyboard through *SynclavierPTPatchListEntry* lines (key range, root key, volume, tuning, start, loop). ConvertWithMoss reads a whole library folder (each timbre becomes one multi-sample) and writes a library folder that can be copied to the device SD card.
+
+The format is not documented by Synclavier Digital, it was reverse-engineered from the device firmware and the freely available libraries (see *documentation/design/SYNCLAVIER_REGEN_FORMAT.md*). Names, the comment and its *#tags* (on writing, the category is written as the Regen's primary category tag - mapped to its canonical tag list, see the Regen manual - and the keywords as property tags; on reading, the first tag becomes the category and the rest the keywords), the partial/zone layout, key ranges, root keys, per-zone volume (`gain[dB] = 36 * f - 12`) and tuning (`tune[cents] = 250 * f - 125`), the per-partial volume (dB) and pitch (a fine tune in cents, a semitone transpose and an octave transpose), the sample start, the loop (start, end, cross-fade), velocity layers (each layer becomes a partial selected by velocity via its crossfade window - a timbre has 12 partials, so up to 12 velocity layers), the per-partial amplitude envelope, the per-partial panning and the timbre-global multi-mode filter (low-pass, high-pass or band-pass with a 2- or 4-pole slope; cutoff, resonance, filter envelope and keyboard tracking) are read and written. The additive/FM synthesis parameters (the index envelope, harmonic coefficients, frame partials, modulation matrix) are not converted. Mono and stereo samples in 16- or 24-bit at any sample rate are supported.
+
+Commercial libraries store their samples as *.sflc* files: a normal FLAC file whose bytes are obfuscated with a key-stream that is keyed by the file's own base name. ConvertWithMoss reads these transparently and, on writing, produces the same obfuscated *.sflc* files (so renaming an *.sflc* file breaks it). User libraries may instead reference plain *.wav* or *.flac* samples, which are also read. Samples that are used by several partials or timbres are stored only once, as in the original libraries. When a source folder is converted as a whole (the library option), all timbres are written into a single library folder together with the shared sample pool and the *_&lt;name&gt;.tsv* and *_TimbreIndex.tsv* index files; otherwise each timbre is written as its own small library folder.
+
+### Getting a converted library onto the Regen
+
+The Regen loads sounds from *libraries* on a FAT32-formatted SD card. To convert your sounds and use them on the device:
+
+1. Convert with *Synclavier Regen* as the destination. When converting a whole folder of sounds, enable the library option (the *Create Library* / library name field in the GUI, or `-l "<Name>"` on the command line) so they become one library you can browse on the device. Without it, every sound is written as its own separate one-timbre library, which quickly clutters the browser.
+2. Copy the produced library folder(s) into the `Libraries/` folder at the top level of the SD card - create `Libraries/` first if the card is blank. Everything a library needs is inside its own folder: the `NN-Entry.txt` timbres, the samples and the `_<name>.tsv` / `_TimbreIndex.tsv` index files. Copy the whole folder, not its contents.
+3. Insert the card into the Regen and choose *Load* on the *"Load SD Card?"* prompt.
+4. On the device, open the library browser, switch to the *User* libraries, select your library and load its timbres (they are addressed as *bank-entry*, e.g. *2-4*, matching the `NN-Entry.txt` numbering).
+
+A Regen library holds at most **64 timbres** (8 banks of 8). When a conversion produces more, it is automatically written as several numbered libraries (`<Name> 1`, `<Name> 2`, …), each within the limit.
+
+To give a library a cover and description in the browser, add a `CDImage.png` (1:1 aspect ratio) and a `Description.txt` (up to 220 characters) to its folder - both names are case-sensitive. The `Description.txt` is written automatically from the descriptions of the converted sounds (the same metadata description carried by other formats; the unique descriptions of a library's timbres are combined, as the SoundFont creator does for its comment). When none of the sounds has a description, no `Description.txt` is written and the device shows its default. Either way you can add or replace it.
 
 ## Synthstrom Deluge
 

--- a/documentation/design/SYNCLAVIER_REGEN_FORMAT.md
+++ b/documentation/design/SYNCLAVIER_REGEN_FORMAT.md
@@ -1,0 +1,240 @@
+# Synclavier Regen library / timbre / SFLC format
+
+This document describes the file format used by the **Synclavier Regen** (2023), reverse-engineered
+from the device firmware (`SynclavierRegen.update`, a squashfs image containing the ARM64 application
+`SynclavierIIDesktopRelease`) and the freely available libraries on <https://www.synclavier.com/regen-downloads/>.
+It is the basis of the `de.mossgrabers.convertwithmoss.format.synclavier` detector and creator.
+
+The format is not officially documented. All of the following was recovered by analysis; where a value
+could not be pinned down with certainty it is called out.
+
+## 1. Library folder
+
+Sounds are organized in **libraries**. A library is a folder placed under `Libraries/` on the device SD
+card and contains:
+
+* one or more **timbres**, each a UTF-8 text file named `NN-Entry.txt` (see §3),
+* the referenced **samples** (`.sflc`, or plain `.wav`/`.flac` in user libraries),
+* `_<LibraryName>.tsv` — the sample index (§5),
+* `_TimbreIndex.tsv` — the timbre index (§5),
+* optional `Description.txt`, `Tier.txt`, cover image, and a `Session/` / `Studios/` / `Reverbs/` tree.
+
+The `NN` in the timbre file name is derived from the zero-based bank entry index `be`:
+
+```
+NN = 10 * (be / 8 + 1) + be % 8 + 1        (integer arithmetic)
+```
+
+so entry 0 → `11-Entry.txt`, entry 7 → `18-Entry.txt`, entry 8 → `21-Entry.txt`, … This matches every
+library with zero exceptions.
+
+## 2. SFLC sample obfuscation
+
+A `.sflc` file is a **standard FLAC file whose bytes are XORed with a key-stream**. The key-stream is
+produced by a full-period (2^64) linear congruential generator (LCG) seeded from the file's *base name*
+(the file name without its extension). Because the transformation is a plain XOR, the same routine both
+obfuscates and de-obfuscates. The whole file is high-entropy with no header — there is no `fLaC` magic
+until it is de-obfuscated.
+
+```
+A    = 0x3357C6A7C5DCC7F5     # LCG multiplier (A % 4 == 1)
+C    = 0x8D14B6503262BD01     # LCG increment (odd)  -> full period 2^64
+SEED = 0xAEAEE9B5E0E46745     # seed base
+name = base file name without extension, as UTF-8 bytes   # e.g. "Prodigy Long Sync"
+
+# seed derivation
+state = SEED
+for b in name:
+    state = ((b ^ state) * A + C) mod 2^64
+
+# key-stream and XOR (encrypt == decrypt)
+for i, byte in enumerate(file_bytes):
+    state = (state * A + C) mod 2^64
+    plain[i] = byte ^ (state & 0xFF)
+```
+
+In the firmware the three 64-bit constants are obfuscated as arrays of eight 32-bit floats, each a
+perfect square; `floor(sqrt(f))` of the eight floats gives the eight little-endian bytes of the constant
+(transform function at file offset `0x8e7cf0`; seed derivation and read/XOR loop in the
+`SFLCFileInputStream` constructor at `0x37c1f0` and its read method at `0x388220`). All 71 sample files
+from the firmware libraries and the *Starsky's Prodigy* bank de-obfuscate to a FLAC stream that passes
+`flac -t`.
+
+**Consequence for writing:** the key depends on the output file's base name, so renaming a `.sflc` file
+corrupts it. The creator therefore obfuscates with the exact name it writes the file under.
+
+User libraries may reference plain, un-obfuscated `.wav` or `.flac` files instead (e.g. the
+`ExampleUserCardContents` download). Both are read.
+
+## 3. Timbre text file
+
+UTF-8 with LF line endings:
+
+```
+Line 1: title (display name)
+Line 2: comment (may be empty; the paragraph separator is "¶" U+00B6; "#tags" are searchable)
+Line 3: SynclavierVirtualInstrumentTimbreVersion000 <gen> 12 24 <mask> 99 <n>
+Line 4+: one self-contained parameter line each
+```
+
+The version header fields: `<gen>` is the writer generation (5/6/7), `12` the number of partial slots,
+`24` the maximum number of harmonics, `<mask>` a capability mask of the form `(2^k - 1) & ~32`, `99` the
+maximum timbre-frame index and `<n>` a writer counter. Only `<gen>` is informative for parsing; the
+creator writes a safe modern header `7 12 24 4063 99 14`.
+
+### 3.1 Line grammar
+
+```
+Synclavier<Keyword> <a> <b> <c> <payload...>
+```
+
+The three leading integers are index fields whose meaning depends on the keyword prefix:
+
+* `TBPI*` — timbre-global, `a=b=c=0`.
+* `PTPI*` — per partial, `a` = partial index (0..11).
+* `EMPI*` — per modulation slot, `a` = slot (0..11).
+* `MIDICCValue` — `c` = MIDI CC number.
+
+Parameter lines are written only when *touched* in the editor (a dirty flag, not "non-default"), so a
+robust reader must not rely on any particular line being present.
+
+### 3.2 Partials
+
+A timbre has up to twelve partials (layers). Each partial has a synth mode (`SynclavierPTPISynthMode`):
+`0` additive/FM, `1` subtractive, `2` sample playback, `4` frame-resynthesis of a sample. A partial is
+marked *active* by the presence of a `SynclavierPTPIVolume` line; the `timbrePartials` bit-mask in
+`_TimbreIndex.tsv` is exactly the set of partials that carry a volume line.
+
+### 3.3 Patch list entry (the sample zones)
+
+Each `SynclavierPTPatchListEntry` maps one sample into one partial. **All zone data must be read from
+these lines only** — the sibling `SynclavierPTPIFile*` scalar lines merely mirror the patch line that is
+currently selected in the editor and are frequently stale.
+
+```
+SynclavierPTPatchListEntry <partial> <entry> <lowKey> <highKey> <rootKey> \
+    <volFrac> <tuneFrac> <start> <end> <loopStart> <loopEnd> <loopBits> <0> \
+    <channels> <frames> <rateHz> <path...>
+```
+
+| Field       | Meaning                                                                    |
+|-------------|----------------------------------------------------------------------------|
+| partial     | partial (layer) index                                                      |
+| entry       | entry index within the partial                                             |
+| lowKey/highKey/rootKey | MIDI key range and the sample's original key                    |
+| volFrac     | volume as a fraction (0.5 neutral): `gain[dB] = 36 * volFrac - 12`          |
+| tuneFrac    | tuning as a fraction (0.5 centered): `tune[cents] = 250 * tuneFrac - 125`   |
+| start / end | play start/end as a fraction of `frames`                                   |
+| loopStart / loopEnd | loop start/end as a fraction of `frames`                           |
+| loopBits    | 0 = no loop, 1 = loop, 3 = loop + cross-fade, 4 = one-shot, 5 = one-shot + loop |
+| channels    | 1 = mono, 2 = stereo                                                        |
+| frames      | number of sample frames (used to turn the fractions into frame positions)  |
+| rateHz      | sample rate                                                                |
+| path        | referenced sample (see §6); may carry a virtual folder prefix and a placeholder extension |
+
+The patch entry itself has no panning; panning is a **per-partial** setting (`PTPIPan`, see §4). Older
+(`gen` 5/6) files write the integer fields as floats. Empty-path placeholder entries occur and are ignored.
+
+## 4. Envelopes, filter and velocity layers
+
+**Amplitude envelope** (per partial): `PTPIVEnvDelay / VEnvAttack / VEnvPeak / VEnvIDecay / VEnvSust /
+VEnvFDecay` — a Synclavier Delay / Attack-to-Peak / Initial-Decay-to-Sustain / Final-Decay (= release)
+envelope; times are in seconds (0..30), levels in percent. Converted to and from the zone amplitude
+envelope.
+
+**Panning** (per partial): `PTPIPan <partial> 0 0 <value>` where `value` is an integer in `[-63..63]`, `0`
+centered. Present only when non-centered (the format omits default values). Mapped to the panning of all
+the partial's zones (`panning = value / 63`); on writing, the average pan of a partial's zones is written
+back as one `PTPIPan` line, and centered partials emit none.
+
+**Per-partial gain and pitch**: on top of the per-patch-entry gain/tuning, a partial has its own gain and
+a three-level pitch offset, all confirmed from the firmware parameter descriptor table and pitch engine
+(`frequency = 440 · 2^(semitones / 12)`):
+* `PTPIVolume` — a dB **attenuation** in `[-50..0]` (`0` = neutral, the common case). Added to the gain of
+  every zone of the partial. On writing, because the patch-entry gain field only reaches down to `-12` dB,
+  a deeper attenuation is split off into `PTPIVolume` and the per-zone remainder stays in the entry.
+* `PTPITune` — a fine tuning in **cents** (`[-125..125]`).
+* `PTPITran` — a coarse transpose in **semitones** (`[-24..24]`).
+* `PTPIOctave` — a coarse octave transpose stored as a **reference frequency** in Hz where `440` (A4) is
+  neutral; its contribution is `12 · log2(Hz / 440)` semitones (always whole octaves, `-72..+24`).
+  Omitted ⇒ neutral (`440`).
+
+  The three pitch terms add up: `extraSemitones = Tran + Tune/100 + 12·log2(Octave/440)`, applied to the
+  tuning of every zone of the partial. On writing, whole semitones beyond the entry tuning field's `±125`
+  cents are split off into `PTPITran` and the fine remainder stays in the entry (octave-sized offsets are
+  written as `PTPITran` too, within its `±24` range).
+
+**Note filter** (timbre-global): `TBPINoteFilterType` is a multi-mode selector encoded as `index / 255`,
+where `index` is `1 = LP12, 2 = HP12, 3 = BP12, 4 = LP24, 5 = HP24, 6 = BP24` — the low three are 2-pole,
+the high three 4-pole, and `1/4` = low-pass, `2/5` = high-pass, `3/6` = band-pass (verified against the
+production 1.18 firmware). `TBPINoteFilterCutoff` (0..1 fraction), `TBPINoteFilterResonance` (0..1), the
+filter envelope `TBPINoteFilterAttack / Decay / Release` (seconds) with the depth from
+`TBPINoteFilterPeakDelta` (octaves; 10 octaves = full model depth), and `TBPINoteFilterPitchTrack`
+(keyboard tracking). Converted as a low-pass, high-pass or band-pass filter (with the matching 2- or
+4-pole slope) with its cutoff envelope. The filter is set both per zone and as the global filter of the
+multi-sample.
+
+**Velocity layers**: the Synclavier has no per-zone velocity field. Instead each partial has a crossfade
+window `PTPIXFStart / XFIn / XFOut / XFEnd` along a *dynamic axis* whose source is `TBPIDynEnvSrc` (`10` =
+velocity, `16` = mod-wheel, `7` = …). When the source is velocity, each partial is a velocity layer:
+`velLow = XFStart`, `velHigh = XFEnd`, with `XFIn`/`XFOut` the cross-fade edges. On writing, a source with
+velocity layers sets `TBPIDynEnvSrc 0 0 0 10` and one partial per layer with the window from the layer's
+velocity range. A timbre has 12 partials, hence at most 12 velocity layers.
+
+Not converted: the `IEnv*` FM/index envelope, the `PTCarrier`/`ModulatorCoeffs`/`Phases` harmonic data,
+the frame partials and the `EMPISource`/`EMPIDest` modulation matrix (whose numeric destination ids shift
+between firmware generations — the trailing symbolic name such as `SynclavierEDFilterCutoff` is the stable
+identifier). These are additive/FM-synthesis specifics that do not map to a generic multi-sample.
+
+## 5. Index files
+
+`_<LibraryName>.tsv` (sample index), tab-separated, one header row then one row per sample:
+
+```
+mFilenameNoExt  mTitle  mComment  mSampleRate  mFrameLength  mChannels  mMIDIKey  mFileHz \
+    mPitchTrack  mMarkStart  mTotalLen  mLoopLen  mLoopXfade  mLoopBits  mMedia  mExtension  mDLMLSB
+```
+
+`_TimbreIndex.tsv` (timbre index):
+
+```
+bankEntry  timbreName  timbreInfo  timbrePartials  timbreDLMLSB
+```
+
+`bankEntry` is the zero-based entry index (see §1 for the file-name mapping), `timbreInfo` is the comment,
+`timbrePartials` the active-partial bit-mask (§3.2).
+
+## 6. Sample resolution
+
+The `path` in a patch entry may contain a virtual folder prefix and a placeholder extension. To find the
+actual file the reader uses the *base name* of the path and looks in the timbre's folder for, in order:
+the exact referenced name (plain user samples), then `<base>.sflc`, `<base>.flac`, `<base>.wav`,
+`<base>.aif(f)`. Names truncated with a trailing `~` and alternative extensions are resolved through the
+`_<LibraryName>.tsv` sample index.
+
+## 7. Mapping to the ConvertWithMoss model
+
+* library folder → a set of multi-samples (each timbre is one `IMultisampleSource`);
+* partial → `IGroup` (layer); patch entry → `ISampleZone`;
+* `lowKey`/`highKey`/`rootKey` → zone key range and root key;
+* `volFrac` → zone gain (dB, via the law above); `tuneFrac` → zone tuning (semitones);
+* per-partial `PTPIVolume` (dB) adds to the zone gain; per-partial `PTPITune` (cents) + `PTPITran`
+  (semitones) + `PTPIOctave` (`12·log2(Hz/440)` semitones) add to the zone tuning (§4); on writing these
+  carry the part of the gain/tuning that does not fit the per-zone entry fields;
+* `start`/`end` fraction × `frames` → zone start/stop; `loopBits` 1/3/5 → a forward loop with
+  `loopStart`/`loopEnd` fraction × `frames`;
+* per-partial `VEnv*` → the zone amplitude envelope; per-partial `PTPIPan` → the zones' panning
+  (`panning = value / 63`); timbre-global `NoteFilter*` → a low-pass, high-pass or band-pass filter with
+  a 2- or 4-pole slope (per zone and as the global filter) with its cutoff envelope (§4);
+* when `TBPIDynEnvSrc == 10`, each partial's `XF*` window → the zones' velocity range (velocity layers);
+  on writing, groups (velocity layers) → partials with `XF*` windows, capped at 12 partials;
+* `#tags` in the comment ↔ category and keywords: on reading, the first tag becomes the category and
+  the remaining tags the keywords; on writing, the category is emitted first as the Regen category tag
+  (mapped to the canonical category list of the Regen manual §3.2, e.g. `Bass` → `#bass`,
+  `Chromatic Percussion` → `#chime`; categories with no equivalent fall back to the sanitized name) and
+  the keywords follow as property tags (all lower-cased, single-token, de-duplicated). The containing
+  folder name → creator.
+
+On writing, the laws are inverted (`volFrac = (dB + 12) / 36`, `tuneFrac = (cents + 125) / 250`), the full
+sample is FLAC-encoded and then obfuscated into a `.sflc` file named after the (sanitized) sample name,
+and the two index files are generated.

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
@@ -87,6 +87,8 @@ import de.mossgrabers.convertwithmoss.format.sfz.SfzCreator;
 import de.mossgrabers.convertwithmoss.format.sfz.SfzDetector;
 import de.mossgrabers.convertwithmoss.format.sxt.SxtCreator;
 import de.mossgrabers.convertwithmoss.format.sxt.SxtDetector;
+import de.mossgrabers.convertwithmoss.format.synclavier.SynclavierRegenCreator;
+import de.mossgrabers.convertwithmoss.format.synclavier.SynclavierRegenDetector;
 import de.mossgrabers.convertwithmoss.format.synthstrom.DelugeCreator;
 import de.mossgrabers.convertwithmoss.format.synthstrom.DelugeDetector;
 import de.mossgrabers.convertwithmoss.format.tal.TALSamplerCreator;
@@ -173,6 +175,7 @@ public class ConverterBackend
             new ZenCoreDetector (notifier),
             new SxtDetector (notifier),
             new SampleFileDetector (notifier),
+            new SynclavierRegenDetector (notifier),
             new SfzDetector (notifier),
             new Sf2Detector (notifier),
             new OmnisphereDetector (notifier),
@@ -205,6 +208,7 @@ public class ConverterBackend
             new MV8000Creator (notifier),
             new ZenCoreCreator (notifier),
             new SxtCreator (notifier),
+            new SynclavierRegenCreator (notifier),
             new WavCreator (notifier),
             new SfzCreator (notifier),
             new Sf2Creator (notifier),

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenCodec.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenCodec.java
@@ -1,0 +1,88 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synclavier;
+
+import java.nio.charset.StandardCharsets;
+
+
+/**
+ * The obfuscation layer of a Synclavier Regen SFLC sample file. An SFLC file is a normal FLAC file
+ * whose bytes are XORed with a key-stream. The key-stream is produced by a full-period linear
+ * congruential generator (LCG) modulo 2^64 which is seeded from the file's base name (the file name
+ * without its extension). Since the operation is a plain XOR, the same method both encrypts and
+ * decrypts. Note that the key-stream depends on the base name, therefore renaming an SFLC file
+ * corrupts it.
+ *
+ * @author Jürgen Moßgraber
+ */
+public final class SynclavierRegenCodec
+{
+    /** The LCG multiplier (congruent 1 modulo 4). */
+    private static final long MULTIPLIER = 0x3357C6A7C5DCC7F5L;
+    /** The LCG increment (odd, therefore the generator has the full period of 2^64). */
+    private static final long INCREMENT  = 0x8D14B6503262BD01L;
+    /** The start value for the seed derivation. */
+    private static final long SEED_BASE  = 0xAEAEE9B5E0E46745L;
+
+
+    /**
+     * Helper class.
+     */
+    private SynclavierRegenCodec ()
+    {
+        // Intentionally empty
+    }
+
+
+    /**
+     * Derive the initial LCG state from the base name of the file.
+     *
+     * @param baseName The base name (file name without the extension)
+     * @return The seed
+     */
+    private static long seed (final String baseName)
+    {
+        long state = SEED_BASE;
+        for (final byte b: baseName.getBytes (StandardCharsets.UTF_8))
+            state = (((b & 0xFFL) ^ state) * MULTIPLIER) + INCREMENT;
+        return state;
+    }
+
+
+    /**
+     * De-/en-crypts the given data. Since the transformation is a symmetric XOR with a key-stream,
+     * the same method is used to convert a FLAC file into an SFLC file and vice versa.
+     *
+     * @param data The data to transform (encrypted or decrypted)
+     * @param baseName The base name of the file (file name without the extension) which is used as
+     *            the key
+     * @return The transformed data (a new array)
+     */
+    public static byte [] transform (final byte [] data, final String baseName)
+    {
+        final byte [] result = new byte [data.length];
+        long state = seed (baseName);
+        for (int i = 0; i < data.length; i++)
+        {
+            state = state * MULTIPLIER + INCREMENT;
+            result[i] = (byte) (data[i] ^ (int) (state & 0xFF));
+        }
+        return result;
+    }
+
+
+    /**
+     * Removes the extension from a file name to form the key for the {@link #transform(byte[], String)}
+     * method.
+     *
+     * @param fileName The file name (must not contain any path)
+     * @return The file name without its extension
+     */
+    public static String baseName (final String fileName)
+    {
+        final int pos = fileName.lastIndexOf ('.');
+        return pos < 0 ? fileName : fileName.substring (0, pos);
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenCreator.java
@@ -1,0 +1,774 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synclavier;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.sound.sampled.UnsupportedAudioFileException;
+
+import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.INotifier;
+import de.mossgrabers.convertwithmoss.core.algorithm.MathUtils;
+import de.mossgrabers.convertwithmoss.core.creator.AbstractCreator;
+import de.mossgrabers.convertwithmoss.core.model.IAudioMetadata;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelopeModulator;
+import de.mossgrabers.convertwithmoss.core.model.IFilter;
+import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.IMetadata;
+import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.core.settings.EmptySettingsUI;
+import de.mossgrabers.convertwithmoss.file.AudioFileUtils;
+
+
+/**
+ * Creator for Synclavier Regen timbres. A timbre is written as a library folder which contains the
+ * timbre text file (<i>NN-Entry.txt</i>), the referenced samples as obfuscated FLAC files
+ * (<i>.sflc</i>, see {@link SynclavierRegenCodec}) and the two bank index files. A partial (= group)
+ * becomes a Synclavier partial, a sample zone becomes a patch list entry.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class SynclavierRegenCreator extends AbstractCreator<EmptySettingsUI>
+{
+    private static final String LINE_FEED           = "\n";
+    private static final String FILTER_PREFIX       = "SynclavierTBPINoteFilter";
+    private static final String AMP_ENVELOPE_PREFIX = "SynclavierPTPIVEnv";
+    private static final String PAN_PARAM           = "SynclavierPTPIPan";
+    /** The partial pan is stored as an integer in the range [-63..63], 0 is centered. */
+    private static final double PAN_RANGE           = 63.0;
+    private static final String TIMBRE_VERSION      = "SynclavierVirtualInstrumentTimbreVersion000 7 12 24 4063 99 14";
+    private static final String SAMPLE_INDEX    = "mFilenameNoExt\tmTitle\tmComment\tmSampleRate\tmFrameLength\tmChannels\tmMIDIKey\tmFileHz\tmPitchTrack\tmMarkStart\tmTotalLen\tmLoopLen\tmLoopXfade\tmLoopBits\tmMedia\tmExtension\tmDLMLSB";
+    private static final String TIMBRE_INDEX    = "bankEntry\ttimbreName\ttimbreInfo\ttimbrePartials\ttimbreDLMLSB";
+    /** The Regen addresses the timbres of a library as 8 banks of 8, so a library holds 64 timbres. */
+    private static final int    MAX_TIMBRES     = 64;
+    /** A Synclavier timbre has at most 12 partials, so at most 12 velocity layers. */
+    private static final int    MAX_PARTIALS    = 12;
+    /** The Regen displays at most 220 characters of a library's Description.txt. */
+    private static final int    MAX_DESCRIPTION_LENGTH = 220;
+
+    /**
+     * Maps the ConvertWithMoss categories to the Regen's canonical category tags (see the Regen
+     * manual, section 3.2 - Tags). Categories without a clear Regen equivalent are not listed and fall
+     * back to the sanitized category name, so a category is always written as at least a custom tag.
+     */
+    private static final Map<String, String> REGEN_CATEGORY_TAGS = new HashMap<> ();
+    static
+    {
+        REGEN_CATEGORY_TAGS.put ("bass", "bass");
+        REGEN_CATEGORY_TAGS.put ("bell", "chime");
+        REGEN_CATEGORY_TAGS.put ("brass", "brass");
+        REGEN_CATEGORY_TAGS.put ("vocal", "vox");
+        REGEN_CATEGORY_TAGS.put ("chromatic percussion", "chime");
+        REGEN_CATEGORY_TAGS.put ("drone", "drone");
+        REGEN_CATEGORY_TAGS.put ("drum", "percussion");
+        REGEN_CATEGORY_TAGS.put ("acoustic drum", "percussion");
+        REGEN_CATEGORY_TAGS.put ("clap", "percussion");
+        REGEN_CATEGORY_TAGS.put ("hi-hat", "percussion");
+        REGEN_CATEGORY_TAGS.put ("kick", "percussion");
+        REGEN_CATEGORY_TAGS.put ("snare", "percussion");
+        REGEN_CATEGORY_TAGS.put ("percussion", "percussion");
+        REGEN_CATEGORY_TAGS.put ("ensemble", "strings");
+        REGEN_CATEGORY_TAGS.put ("strings", "strings");
+        REGEN_CATEGORY_TAGS.put ("fx", "sfx");
+        REGEN_CATEGORY_TAGS.put ("destruction", "sfx");
+        REGEN_CATEGORY_TAGS.put ("keyboard", "keys");
+        REGEN_CATEGORY_TAGS.put ("piano", "keys");
+        REGEN_CATEGORY_TAGS.put ("lead", "lead");
+        REGEN_CATEGORY_TAGS.put ("monosynth", "lead");
+        REGEN_CATEGORY_TAGS.put ("orchestral", "orchestral");
+        REGEN_CATEGORY_TAGS.put ("organ", "organ");
+        REGEN_CATEGORY_TAGS.put ("pad", "pad");
+        REGEN_CATEGORY_TAGS.put ("pipe", "wind");
+        REGEN_CATEGORY_TAGS.put ("winds", "wind");
+        REGEN_CATEGORY_TAGS.put ("loops", "beatloop");
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param notifier The notifier
+     */
+    public SynclavierRegenCreator (final INotifier notifier)
+    {
+        super ("Synclavier Regen", "SynclavierRegen", notifier, EmptySettingsUI.INSTANCE);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean supportsPresetLibraries ()
+    {
+        return true;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void createPreset (final File destinationFolder, final IMultisampleSource multisampleSource) throws IOException
+    {
+        this.writeLibrary (destinationFolder, multisampleSource.getName (), Collections.singletonList (multisampleSource));
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void createPresetLibrary (final File destinationFolder, final List<IMultisampleSource> multisampleSources, final String libraryName) throws IOException
+    {
+        final int total = multisampleSources.size ();
+        if (total <= MAX_TIMBRES)
+        {
+            this.writeLibrary (destinationFolder, libraryName, multisampleSources);
+            return;
+        }
+
+        // A Regen library holds at most 64 timbres (8 banks of 8), so a larger set is written as
+        // several numbered libraries.
+        final int parts = (total + MAX_TIMBRES - 1) / MAX_TIMBRES;
+        this.notifier.log ("IDS_SYNCLAVIER_LIBRARY_SPLIT", Integer.toString (total), Integer.toString (parts));
+        for (int part = 0; part < parts; part++)
+        {
+            final int from = part * MAX_TIMBRES;
+            final int to = Math.min (from + MAX_TIMBRES, total);
+            this.writeLibrary (destinationFolder, libraryName + " " + (part + 1), multisampleSources.subList (from, to));
+        }
+    }
+
+
+    /**
+     * Writes a Synclavier Regen library folder for the given multi-samples.
+     *
+     * @param destinationFolder The folder into which the library folder is created
+     * @param libraryName The name of the library
+     * @param multisampleSources The multi-samples to write (each becomes one timbre)
+     * @throws IOException Could not write a file
+     */
+    private void writeLibrary (final File destinationFolder, final String libraryName, final List<IMultisampleSource> multisampleSources) throws IOException
+    {
+        final String safeLibraryName = createSafeFilename (libraryName);
+        final File libraryFolder = createUniqueFolder (destinationFolder, safeLibraryName);
+        this.notifier.log ("IDS_NOTIFY_STORING", libraryFolder.getAbsolutePath ());
+
+        final Set<String> usedSampleNames = new HashSet<> ();
+        // Maps a sample identity (name plus audio format) to the already written file base name, so
+        // a sample which is used by several partials or timbres is stored only once - just like the
+        // original banks share their samples
+        final Map<String, String> writtenSamples = new HashMap<> ();
+        final StringBuilder sampleIndex = new StringBuilder (SAMPLE_INDEX).append (LINE_FEED);
+        final StringBuilder timbreIndex = new StringBuilder (TIMBRE_INDEX).append (LINE_FEED);
+
+        for (int bankEntry = 0; bankEntry < multisampleSources.size (); bankEntry++)
+        {
+            final IMultisampleSource source = multisampleSources.get (bankEntry);
+            final StringBuilder timbre = new StringBuilder ();
+
+            final IMetadata metadata = source.getMetadata ();
+            final String comment = flattenComment (metadata);
+            timbre.append (source.getName ()).append (LINE_FEED);
+            timbre.append (comment).append (LINE_FEED);
+            timbre.append (TIMBRE_VERSION).append (LINE_FEED);
+
+            int partialMask = 0;
+            final List<IGroup> allGroups = source.getNonEmptyGroups (false);
+            // A timbre has at most 12 partials (= 12 velocity layers)
+            if (allGroups.size () > MAX_PARTIALS)
+                this.notifier.logError ("IDS_SYNCLAVIER_PARTIAL_CAP", source.getName (), Integer.toString (allGroups.size ()));
+            final List<IGroup> groups = allGroups.size () > MAX_PARTIALS ? allGroups.subList (0, MAX_PARTIALS) : allGroups;
+            appendFilter (timbre, source, groups);
+            // Velocity layers are put on separate partials selected by the crossfade (dynamic) axis
+            final boolean velocityLayered = isVelocityLayered (groups);
+            if (velocityLayered)
+                timbre.append ("SynclavierTBPIDynEnvSrc 0 0 0 10").append (LINE_FEED);
+            for (int partial = 0; partial < groups.size (); partial++)
+            {
+                final List<ISampleZone> zones = groups.get (partial).getSampleZones ();
+                // Volume and tuning are split into a shared per-partial part and a per-zone remainder:
+                // the patch entry gain field only reaches down to -12 dB and the tuning field only spans
+                // +-125 cents, so a deeper attenuation goes into the per-partial volume and whole
+                // semitones go into the per-partial transpose (Tran), leaving the fine rest in the entry.
+                final double partialVolume = partialVolume (zones);
+                final int partialTranspose = partialTranspose (zones);
+                for (int entry = 0; entry < zones.size (); entry++)
+                {
+                    final ISampleZone zone = zones.get (entry);
+                    final IAudioMetadata audioMetadata = zone.getSampleData ().getAudioMetadata ();
+
+                    final String identity = zone.getName () + "|" + audioMetadata.getNumberOfSamples () + "|" + audioMetadata.getSampleRate () + "|" + audioMetadata.getChannels ();
+                    String sampleName = writtenSamples.get (identity);
+                    if (sampleName == null)
+                    {
+                        sampleName = uniqueSampleName (usedSampleNames, zone.getName ());
+                        this.writeSample (libraryFolder, sampleName, zone);
+                        sampleIndex.append (sampleRow (sampleName, audioMetadata)).append (LINE_FEED);
+                        writtenSamples.put (identity, sampleName);
+                    }
+                    timbre.append (patchEntry (partial, entry, zone, audioMetadata, safeLibraryName, sampleName, partialVolume, partialTranspose)).append (LINE_FEED);
+                }
+                // The volume line also marks the partial as active (required for the partial bit-mask)
+                timbre.append ("SynclavierPTPIVolume ").append (partial).append (" 0 0 ").append (number (partialVolume)).append (LINE_FEED);
+                timbre.append ("SynclavierPTPISynthMode ").append (partial).append (" 0 0 2").append (LINE_FEED);
+                if (partialTranspose != 0)
+                    timbre.append ("SynclavierPTPITran ").append (partial).append (" 0 0 ").append (number (partialTranspose)).append (LINE_FEED);
+                // The pan is a per-partial setting, so use the average pan of the partial's zones
+                final int pan = partialPan (zones);
+                if (pan != 0)
+                    timbre.append (PAN_PARAM).append (' ').append (partial).append (" 0 0 ").append (number (pan)).append (LINE_FEED);
+                if (!zones.isEmpty ())
+                    appendAmplitudeEnvelope (timbre, partial, zones.get (0));
+                if (velocityLayered)
+                    appendVelocityWindow (timbre, partial, zones);
+                partialMask |= 1 << partial;
+            }
+
+            final String fileName = timbreFileName (bankEntry);
+            try (final FileWriter writer = new FileWriter (new File (libraryFolder, fileName), StandardCharsets.UTF_8))
+            {
+                writer.write (timbre.toString ());
+            }
+
+            timbreIndex.append (bankEntry).append ('\t').append (source.getName ()).append ('\t').append (comment).append ('\t').append (partialMask).append ("\t0").append (LINE_FEED);
+        }
+
+        writeTextFile (new File (libraryFolder, "_" + safeLibraryName + ".tsv"), sampleIndex.toString ());
+        writeTextFile (new File (libraryFolder, "_TimbreIndex.tsv"), timbreIndex.toString ());
+        // The library description is the combined (unique) descriptions of its timbres, exactly as the
+        // SF2 creator forms its library comment, but capped to the Regen's 220 character display limit.
+        // When none of the timbres has a description, no Description.txt is written and the device shows
+        // its own default.
+        final Set<String> descriptions = new LinkedHashSet<> ();
+        for (final IMultisampleSource multisampleSource: multisampleSources)
+        {
+            final String description = multisampleSource.getMetadata ().getDescription ();
+            if (description != null && !description.isBlank ())
+                descriptions.add (description.strip ());
+        }
+        final String libraryDescription = combineDescriptions (descriptions);
+        if (!libraryDescription.isEmpty ())
+            writeTextFile (new File (libraryFolder, "Description.txt"), libraryDescription + LINE_FEED);
+
+        this.progress.notifyDone ();
+    }
+
+
+    /**
+     * Appends the timbre-global note filter. The filter is taken from the source's global filter (as
+     * set by e.g. the EXS24 detector) or, if there is none, from the first zone that carries a filter
+     * (as set by e.g. the SFZ detector). This is the inverse of the filter mapping in
+     * {@link SynclavierRegenDetector}.
+     *
+     * @param timbre The timbre text to append to
+     * @param source The multi-sample source (checked for a global filter)
+     * @param groups The partials (groups) of the timbre (checked for a per-zone filter)
+     */
+    private static void appendFilter (final StringBuilder timbre, final IMultisampleSource source, final List<IGroup> groups)
+    {
+        IFilter filter = source.getGlobalFilter ().orElse (null);
+        if (filter == null)
+            for (final IGroup group: groups)
+            {
+                for (final ISampleZone zone: group.getSampleZones ())
+                {
+                    final Optional<IFilter> optFilter = zone.getFilter ();
+                    if (optFilter.isPresent ())
+                    {
+                        filter = optFilter.get ();
+                        break;
+                    }
+                }
+                if (filter != null)
+                    break;
+            }
+        if (filter == null)
+            return;
+
+        appendGlobal (timbre, "Type", noteFilterTypeIndex (filter) / 255.0);
+        appendGlobal (timbre, "Cutoff", MathUtils.normalizeCutoff (filter.getCutoff ()));
+        appendGlobal (timbre, "Resonance", Math.clamp (filter.getResonance (), 0, 1));
+        appendGlobal (timbre, "PitchTrack", filter.getCutoffKeyTracking ());
+
+        final IEnvelopeModulator cutoffModulator = filter.getCutoffEnvelopeModulator ();
+        final double depth = cutoffModulator.getDepth ();
+        if (!Double.isNaN (depth) && depth != 0)
+            appendGlobal (timbre, "PeakDelta", Math.clamp (depth * 10.0, -10, 10));
+        final IEnvelope filterEnvelope = cutoffModulator.getSource ();
+        appendGlobalTime (timbre, "Attack", filterEnvelope.getAttackTime ());
+        appendGlobalTime (timbre, "Decay", filterEnvelope.getDecayTime ());
+        appendGlobalTime (timbre, "Release", filterEnvelope.getReleaseTime ());
+    }
+
+
+    /**
+     * Appends the per-partial amplitude envelope (Delay, Attack to Peak, Initial Decay to Sustain,
+     * Final Decay = release), the inverse of the amplitude envelope mapping in the detector.
+     *
+     * @param timbre The timbre text to append to
+     * @param partial The partial index
+     * @param zone The first zone of the partial (its envelope is used for the partial)
+     */
+    private static void appendAmplitudeEnvelope (final StringBuilder timbre, final int partial, final ISampleZone zone)
+    {
+        final IEnvelope envelope = zone.getAmplitudeEnvelopeModulator ().getSource ();
+        appendPartialTime (timbre, partial, "Delay", envelope.getDelayTime ());
+        appendPartialTime (timbre, partial, "Attack", envelope.getAttackTime ());
+        appendPartialTime (timbre, partial, "IDecay", envelope.getDecayTime ());
+        appendPartialTime (timbre, partial, "FDecay", envelope.getReleaseTime ());
+        final double peak = envelope.getHoldLevel ();
+        appendPartial (timbre, partial, "Peak", peak < 0 ? 100.0 : Math.clamp (peak * 100.0, 0, 100));
+        final double sustain = envelope.getSustainLevel ();
+        appendPartial (timbre, partial, "Sust", sustain < 0 ? 100.0 : Math.clamp (sustain * 100.0, 0, 100));
+    }
+
+
+    /**
+     * Checks whether the groups form velocity layers, i.e. at least one zone is restricted to a
+     * velocity sub-range.
+     *
+     * @param groups The partials (groups)
+     * @return True if a velocity split is present
+     */
+    private static boolean isVelocityLayered (final List<IGroup> groups)
+    {
+        for (final IGroup group: groups)
+            for (final ISampleZone zone: group.getSampleZones ())
+                if (zone.getVelocityLow () > 0 || zone.getVelocityHigh () < 127)
+                    return true;
+        return false;
+    }
+
+
+    /**
+     * Appends the per-partial crossfade window (XFStart/In/Out/End) that selects the partial by
+     * velocity (the dynamic axis source is set to velocity for the whole timbre). The window comes
+     * from the velocity range of the partial's zones, the fade regions from the velocity cross-fades.
+     *
+     * @param timbre The timbre text to append to
+     * @param partial The partial index
+     * @param zones The zones of the partial
+     */
+    private static void appendVelocityWindow (final StringBuilder timbre, final int partial, final List<ISampleZone> zones)
+    {
+        int low = 127;
+        int high = 0;
+        int fadeIn = 0;
+        int fadeOut = 0;
+        for (final ISampleZone zone: zones)
+        {
+            low = Math.min (low, zone.getVelocityLow ());
+            high = Math.max (high, zone.getVelocityHigh ());
+            fadeIn = Math.max (fadeIn, zone.getVelocityCrossfadeLow ());
+            fadeOut = Math.max (fadeOut, zone.getVelocityCrossfadeHigh ());
+        }
+        if (low > high)
+        {
+            low = 0;
+            high = 127;
+        }
+        final int xfIn = Math.min (high, low + fadeIn);
+        final int xfOut = Math.max (xfIn, high - fadeOut);
+        timbre.append ("SynclavierPTPIXFStart ").append (partial).append (" 0 0 ").append (low).append (LINE_FEED);
+        timbre.append ("SynclavierPTPIXFIn ").append (partial).append (" 0 0 ").append (xfIn).append (LINE_FEED);
+        timbre.append ("SynclavierPTPIXFOut ").append (partial).append (" 0 0 ").append (xfOut).append (LINE_FEED);
+        timbre.append ("SynclavierPTPIXFEnd ").append (partial).append (" 0 0 ").append (high).append (LINE_FEED);
+    }
+
+
+    /**
+     * The Synclavier note-filter type index for a filter. The Regen note filter is multi-mode; the
+     * type field selects one of six variants (value = index / 255): 1 = Low Pass 12 dB, 2 = High Pass
+     * 12 dB, 3 = Band Pass 12 dB, 4 = Low Pass 24 dB, 5 = High Pass 24 dB, 6 = Band Pass 24 dB (12 dB =
+     * 2-pole, 24 dB = 4-pole; recovered from the device firmware). A notch/band-rejection filter has
+     * no Regen equivalent and falls back to low-pass.
+     *
+     * @param filter The filter
+     * @return The type index 1..6
+     */
+    private static int noteFilterTypeIndex (final IFilter filter)
+    {
+        final int mode = switch (filter.getType ())
+        {
+            case HIGH_PASS -> 2;
+            case BAND_PASS -> 3;
+            default -> 1;
+        };
+        return mode + (filter.getPoles () >= 4 ? 3 : 0);
+    }
+
+
+    private static void appendGlobal (final StringBuilder timbre, final String key, final double value)
+    {
+        timbre.append (FILTER_PREFIX).append (key).append (" 0 0 0 ").append (number (value)).append (LINE_FEED);
+    }
+
+
+    private static void appendGlobalTime (final StringBuilder timbre, final String key, final double time)
+    {
+        if (time >= 0)
+            appendGlobal (timbre, key, Math.clamp (time, 0, 30));
+    }
+
+
+    private static void appendPartial (final StringBuilder timbre, final int partial, final String key, final double value)
+    {
+        timbre.append (AMP_ENVELOPE_PREFIX).append (key).append (' ').append (partial).append (" 0 0 ").append (number (value)).append (LINE_FEED);
+    }
+
+
+    private static void appendPartialTime (final StringBuilder timbre, final int partial, final String key, final double time)
+    {
+        if (time >= 0)
+            appendPartial (timbre, partial, key, Math.clamp (time, 0, 30));
+    }
+
+
+    /**
+     * Computes the representative pan of a partial from the average panning of its zones. The
+     * generic model stores panning per zone while a Synclavier partial has a single pan setting, so
+     * the average of the partial's zones is used.
+     *
+     * @param zones The zones of the partial
+     * @return The pan in the range [-63..63], 0 if centered
+     */
+    private static int partialPan (final List<ISampleZone> zones)
+    {
+        if (zones.isEmpty ())
+            return 0;
+        double sum = 0;
+        for (final ISampleZone zone: zones)
+            sum += zone.getPanning ();
+        return (int) Math.round (Math.clamp (sum / zones.size (), -1, 1) * PAN_RANGE);
+    }
+
+
+    /**
+     * Computes the shared per-partial volume (a dB attenuation) so that each zone's remaining gain fits
+     * the patch entry gain field, whose floor is -12 dB. It is how far the quietest zone would underflow
+     * that floor, clamped to the Regen partial-volume range of -50..0 dB. 0 for the common case where no
+     * zone is below -12 dB.
+     *
+     * @param zones The zones of the partial
+     * @return The per-partial volume in dB
+     */
+    private static double partialVolume (final List<ISampleZone> zones)
+    {
+        if (zones.isEmpty ())
+            return 0;
+        double minGain = Double.MAX_VALUE;
+        for (final ISampleZone zone: zones)
+            minGain = Math.min (minGain, zone.getGain ());
+        return Math.clamp (Math.min (0, minGain + 12.0), -50, 0);
+    }
+
+
+    /**
+     * Computes the shared per-partial transpose (whole semitones) from the average tuning of the
+     * partial's zones. Only used when the tuning exceeds what the per-zone patch entry tuning field can
+     * hold (+-125 cents); the per-zone fine remainder stays in the entry. Clamped to the Regen range of
+     * -24..+24 semitones. 0 for the common case of a fine tuning.
+     *
+     * @param zones The zones of the partial
+     * @return The per-partial transpose in semitones
+     */
+    private static int partialTranspose (final List<ISampleZone> zones)
+    {
+        if (zones.isEmpty ())
+            return 0;
+        double sum = 0;
+        for (final ISampleZone zone: zones)
+            sum += zone.getTuning ();
+        final double average = sum / zones.size ();
+        if (Math.abs (average) <= 1.25)
+            return 0;
+        return Math.clamp ((int) Math.round (average), -24, 24);
+    }
+
+
+    private static String number (final double value)
+    {
+        if (value == Math.rint (value) && !Double.isInfinite (value))
+            return String.format (Locale.US, "%.1f", Double.valueOf (value));
+        return String.format (Locale.US, "%.4f", Double.valueOf (value));
+    }
+
+
+    /**
+     * Builds a patch list entry line for a zone.
+     *
+     * @param partial The partial (group) index
+     * @param entry The entry index within the partial
+     * @param zone The sample zone
+     * @param audioMetadata The audio meta data of the sample
+     * @param libraryName The (safe) library name, used as the virtual folder prefix
+     * @param sampleName The (safe) sample base name
+     * @param partialVolume The shared per-partial volume (dB) that is written separately and therefore
+     *            removed from this entry's gain
+     * @param partialTranspose The shared per-partial transpose (semitones) that is written separately
+     *            and therefore removed from this entry's tuning
+     * @return The line
+     */
+    private static String patchEntry (final int partial, final int entry, final ISampleZone zone, final IAudioMetadata audioMetadata, final String libraryName, final String sampleName, final double partialVolume, final int partialTranspose)
+    {
+        final int frames = audioMetadata.getNumberOfSamples ();
+        final int channels = Math.max (1, audioMetadata.getChannels ());
+        final int sampleRate = audioMetadata.getSampleRate ();
+
+        // Reverse the hardware laws: volume fraction from gain (dB) and tuning fraction from cents. The
+        // shared per-partial volume and transpose are removed first as they are written as their own
+        // per-partial lines (SynclavierPTPIVolume / SynclavierPTPITran)
+        final double volumeFraction = Math.clamp ((zone.getGain () - partialVolume + 12.0) / 36.0, 0, 1);
+        final double tuneFraction = Math.clamp (((zone.getTuning () - partialTranspose) * 100.0 + 125.0) / 250.0, 0, 1);
+
+        final double startFraction = frames <= 0 ? 0 : Math.clamp (zone.getStart () / (double) frames, 0, 1);
+        double endFraction = frames <= 0 || zone.getStop () <= 0 ? 1 : Math.clamp (zone.getStop () / (double) frames, 0, 1);
+        if (endFraction <= startFraction)
+            endFraction = 1;
+
+        int loopBits = 0;
+        double loopStartFraction = 0;
+        double loopEndFraction = 1;
+        final List<ISampleLoop> loops = zone.getLoops ();
+        if (!loops.isEmpty () && frames > 0)
+        {
+            final ISampleLoop loop = loops.get (0);
+            loopBits = loop.getCrossfade () > 0 ? 3 : 1;
+            loopStartFraction = Math.clamp (loop.getStart () / (double) frames, 0, 1);
+            loopEndFraction = Math.clamp (loop.getEnd () / (double) frames, 0, 1);
+        }
+
+        final StringBuilder sb = new StringBuilder ("SynclavierPTPatchListEntry ");
+        sb.append (partial).append (' ').append (entry).append (' ');
+        sb.append (zone.getKeyLow ()).append (' ').append (zone.getKeyHigh ()).append (' ').append (zone.getKeyRoot ()).append (' ');
+        sb.append (fraction (volumeFraction)).append (' ').append (fraction (tuneFraction)).append (' ');
+        sb.append (fraction (startFraction)).append (' ').append (fraction (endFraction)).append (' ');
+        sb.append (fraction (loopStartFraction)).append (' ').append (fraction (loopEndFraction)).append (' ');
+        sb.append (loopBits).append (" 0 ").append (channels).append (' ').append (frames).append (' ').append (sampleRate).append (' ');
+        sb.append (libraryName).append ('/').append (sampleName).append (".wav");
+        return sb.toString ();
+    }
+
+
+    /**
+     * Builds a row for the sample index TSV.
+     *
+     * @param sampleName The (safe) sample base name
+     * @param zone The sample zone
+     * @param audioMetadata The audio meta data of the sample
+     * @return The row
+     */
+    private static String sampleRow (final String sampleName, final IAudioMetadata audioMetadata)
+    {
+        final StringBuilder sb = new StringBuilder (sampleName);
+        // mTitle, mComment
+        sb.append ("\t\t");
+        sb.append ('\t').append (audioMetadata.getSampleRate ());
+        sb.append ('\t').append (audioMetadata.getNumberOfSamples ());
+        sb.append ('\t').append (Math.max (1, audioMetadata.getChannels ()));
+        // mMIDIKey, mFileHz, mPitchTrack, mMarkStart, mTotalLen, mLoopLen, mLoopXfade, mLoopBits.
+        // The loop is carried by the timbre's patch list entry, so the index loop columns stay 0.
+        sb.append ("\t0\t0\t0\t0\t0\t0\t0\t0");
+        // mMedia (3 = internal), mExtension, mDLMLSB
+        sb.append ("\t3\t.sflc\t0");
+        return sb.toString ();
+    }
+
+
+    /**
+     * Encodes the sample of a zone as FLAC, obfuscates it and writes it as an SFLC file.
+     *
+     * @param libraryFolder The destination folder
+     * @param sampleName The (safe) sample base name (also the obfuscation key)
+     * @param zone The zone whose sample is written
+     * @throws IOException Could not write the file
+     */
+    private void writeSample (final File libraryFolder, final String sampleName, final ISampleZone zone) throws IOException
+    {
+        final Path tempFile = Files.createTempFile ("CWM-", ".flac");
+        try
+        {
+            AudioFileUtils.compressToFLAC (zone.getSampleData (), FLAC_TARGET_FORMAT, tempFile.toFile ());
+            final byte [] flacData = Files.readAllBytes (tempFile);
+            final byte [] obfuscated = SynclavierRegenCodec.transform (flacData, sampleName);
+            Files.write (new File (libraryFolder, sampleName + ".sflc").toPath (), obfuscated);
+        }
+        catch (final UnsupportedAudioFileException ex)
+        {
+            throw new IOException (ex);
+        }
+        finally
+        {
+            Files.deleteIfExists (tempFile);
+        }
+    }
+
+
+    /**
+     * Maps a bank entry index to the timbre file name. The mapping is
+     * <code>NN = 10 * (be / 8 + 1) + be % 8 + 1</code>.
+     *
+     * @param bankEntry The bank entry index (starting at 0)
+     * @return The file name (e.g. <i>11-Entry.txt</i>)
+     */
+    private static String timbreFileName (final int bankEntry)
+    {
+        final int nn = 10 * (bankEntry / 8 + 1) + bankEntry % 8 + 1;
+        return nn + "-Entry.txt";
+    }
+
+
+    private static String uniqueSampleName (final Set<String> usedNames, final String name)
+    {
+        final String base = createSafeFilename (name);
+        String candidate = base;
+        int counter = 2;
+        while (!usedNames.add (candidate.toLowerCase (Locale.US)))
+        {
+            candidate = base + "-" + counter;
+            counter++;
+        }
+        return candidate;
+    }
+
+
+    /**
+     * Combines several descriptions into one library description, newline-separated, respecting the
+     * Regen's {@link #MAX_DESCRIPTION_LENGTH} character display limit. Whole descriptions are added
+     * until the next one would exceed the limit; if the first description alone is too long it is
+     * truncated.
+     *
+     * @param descriptions The individual (already stripped, non-blank) descriptions
+     * @return The combined description, never longer than {@link #MAX_DESCRIPTION_LENGTH} characters
+     */
+    private static String combineDescriptions (final Set<String> descriptions)
+    {
+        final StringBuilder sb = new StringBuilder ();
+        for (final String description: descriptions)
+        {
+            final int separator = sb.length () == 0 ? 0 : 1;
+            if (sb.length () + separator + description.length () > MAX_DESCRIPTION_LENGTH)
+            {
+                // The first description alone exceeds the limit, so truncate it; otherwise stop adding
+                if (sb.length () == 0)
+                    sb.append (description, 0, MAX_DESCRIPTION_LENGTH);
+                break;
+            }
+            if (separator > 0)
+                sb.append ('\n');
+            sb.append (description);
+        }
+        return sb.toString ();
+    }
+
+
+    /**
+     * Builds the timbre comment from the meta data. The Regen stores the tags as #hash-tags inside the
+     * comment (see the Regen manual, section 3.2): the category becomes the primary category tag, the
+     * keywords become the property tags. On reading, the first tag is taken as the category again, so
+     * the category is written first. Tags are lower-cased and reduced to a single token; duplicates
+     * are removed.
+     *
+     * @param metadata The meta data
+     * @return The comment line (description followed by the #hash-tags)
+     */
+    private static String flattenComment (final IMetadata metadata)
+    {
+        final StringBuilder sb = new StringBuilder ();
+        final String description = metadata.getDescription ();
+        if (description != null && !description.isBlank ())
+            sb.append (description.replace ("\r", "").replace ("\n", "¶"));
+
+        final Set<String> tags = new LinkedHashSet<> ();
+        final String categoryTag = regenCategoryTag (metadata.getCategory ());
+        if (categoryTag != null)
+            tags.add (categoryTag);
+        final String [] keywords = metadata.getKeywords ();
+        if (keywords != null)
+            for (final String keyword: keywords)
+            {
+                final String tag = sanitizeTag (keyword);
+                if (tag != null)
+                    tags.add (tag);
+            }
+        for (final String tag: tags)
+            sb.append (" #").append (tag);
+        return sb.toString ();
+    }
+
+
+    /**
+     * Maps a ConvertWithMoss category to a Regen category tag. Categories with a clear Regen
+     * equivalent are mapped to the canonical tag; the rest fall back to the sanitized category name so
+     * the category is still written as a (custom) tag.
+     *
+     * @param category The category (may be null or "Unknown")
+     * @return The Regen category tag or null if there is no usable category
+     */
+    private static String regenCategoryTag (final String category)
+    {
+        if (category == null || category.isBlank () || "Unknown".equalsIgnoreCase (category))
+            return null;
+        final String mapped = REGEN_CATEGORY_TAGS.get (category.toLowerCase (Locale.US));
+        return mapped != null ? mapped : sanitizeTag (category);
+    }
+
+
+    /**
+     * Sanitizes a tag to the Regen convention: lower-case and reduced to letters and digits (tags are
+     * always shown in lower case and are a single token).
+     *
+     * @param tag The tag text
+     * @return The sanitized tag or null if nothing remains
+     */
+    private static String sanitizeTag (final String tag)
+    {
+        if (tag == null)
+            return null;
+        final String sanitized = tag.toLowerCase (Locale.US).replaceAll ("[^a-z0-9]", "");
+        return sanitized.isBlank () ? null : sanitized;
+    }
+
+
+    private static String fraction (final double value)
+    {
+        return String.format (Locale.US, "%.6f", Double.valueOf (value));
+    }
+
+
+    private static File createUniqueFolder (final File destinationFolder, final String name) throws IOException
+    {
+        File folder = new File (destinationFolder, name);
+        int counter = 2;
+        while (folder.exists ())
+        {
+            folder = new File (destinationFolder, name + " " + counter);
+            counter++;
+        }
+        safeCreateDirectory (folder);
+        return folder;
+    }
+
+
+    private static void writeTextFile (final File file, final String content) throws IOException
+    {
+        try (final FileWriter writer = new FileWriter (file, StandardCharsets.UTF_8))
+        {
+            writer.write (content);
+        }
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenDetector.java
@@ -1,0 +1,760 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synclavier;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.DoubleConsumer;
+
+import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.INotifier;
+import de.mossgrabers.convertwithmoss.core.algorithm.MathUtils;
+import de.mossgrabers.convertwithmoss.core.detector.AbstractDetector;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelopeModulator;
+import de.mossgrabers.convertwithmoss.core.model.IFilter;
+import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.IMetadata;
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
+import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.core.model.enumeration.FilterType;
+import de.mossgrabers.convertwithmoss.core.model.enumeration.LoopType;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultFilter;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultGroup;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleZone;
+import de.mossgrabers.convertwithmoss.core.settings.EmptySettingsUI;
+import de.mossgrabers.tools.FileUtils;
+
+
+/**
+ * Detects recursively Synclavier Regen timbre files in folders. A timbre is stored as a text file
+ * whose name ends with <i>-Entry.txt</i> and which contains the tag
+ * <i>SynclavierVirtualInstrumentTimbreVersion</i>. The referenced samples are stored in the same
+ * folder as obfuscated FLAC files with the ending <i>.sflc</i> (see {@link SynclavierRegenCodec}).
+ *
+ * @author Jürgen Moßgraber
+ */
+public class SynclavierRegenDetector extends AbstractDetector<EmptySettingsUI>
+{
+    private static final String TIMBRE_MAGIC        = "SynclavierVirtualInstrumentTimbreVersion";
+    private static final String ENTRY               = "SynclavierPTPatchListEntry";
+    private static final String AMP_ENVELOPE_PREFIX = "SynclavierPTPIVEnv";
+    private static final String FILTER_PREFIX       = "SynclavierTBPINoteFilter";
+    private static final String CROSSFADE_PREFIX    = "SynclavierPTPIXF";
+    private static final String DYN_ENV_SOURCE      = "SynclavierTBPIDynEnvSrc";
+    private static final int    DYN_SOURCE_VELOCITY = 10;
+    private static final String PAN_PARAM           = "SynclavierPTPIPan";
+    // The partial pan is stored as an integer in the range [-63..63], 0 is centered
+    private static final double PAN_RANGE           = 63.0;
+    // Per-partial gain and pitch (see the firmware parameter descriptor table). All add on top of the
+    // per-patch-entry gain and tuning. Volume is a dB attenuation (-50..0), Tune is cents (+-125), Tran
+    // is semitones (+-24), Octave is a reference frequency (a coarse octave transpose, 440 Hz = neutral)
+    private static final String VOLUME_PARAM        = "SynclavierPTPIVolume";
+    private static final String TUNE_PARAM          = "SynclavierPTPITune";
+    private static final String TRAN_PARAM          = "SynclavierPTPITran";
+    private static final String OCTAVE_PARAM        = "SynclavierPTPIOctave";
+    private static final double OCTAVE_REFERENCE_HZ = 440.0;
+    private static final String PARAGRAPH           = "¶";
+    private static final String SAMPLE_ENDING       = ".sflc";
+    // The audio extensions to probe, the obfuscated SFLC first
+    private static final String [] SAMPLE_ENDINGS = new String []
+    {
+        ".sflc",
+        ".flac",
+        ".wav",
+        ".aif",
+        ".aiff"
+    };
+
+
+    /**
+     * Constructor.
+     *
+     * @param notifier The notifier
+     */
+    public SynclavierRegenDetector (final INotifier notifier)
+    {
+        super ("Synclavier Regen", "SynclavierRegen", notifier, EmptySettingsUI.INSTANCE, "-entry.txt");
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<String> getFileEndings ()
+    {
+        // The detector scans for the timbre files (*-entry.txt, see the constructor) since these hold
+        // the multi-sample mapping. For the format list the SFLC sample extension is shown instead: it
+        // is the extension unique to the Synclavier and the one users recognize.
+        return Set.of (SAMPLE_ENDING);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected List<IMultisampleSource> readPresetFile (final File file)
+    {
+        if (this.waitForDelivery ())
+            return Collections.emptyList ();
+
+        try
+        {
+            final List<String> lines = this.loadTextFile (file).lines ().toList ();
+            final int magicIndex = findMagic (lines);
+            if (magicIndex < 0)
+                // Not a Synclavier timbre file, ignore it silently
+                return Collections.emptyList ();
+
+            return this.parseTimbre (file, lines, magicIndex);
+        }
+        catch (final IOException ex)
+        {
+            this.notifier.logError ("IDS_NOTIFY_ERR_LOAD_FILE", ex);
+            return Collections.emptyList ();
+        }
+    }
+
+
+    /**
+     * Find the line which contains the timbre version tag.
+     *
+     * @param lines All lines of the file
+     * @return The index of the version line or -1 if not present
+     */
+    private static int findMagic (final List<String> lines)
+    {
+        for (int i = 0; i < lines.size (); i++)
+            if (lines.get (i).startsWith (TIMBRE_MAGIC))
+                return i;
+        return -1;
+    }
+
+
+    /**
+     * Parses a timbre text file and creates a multi-sample from it. Each Synclavier <i>partial</i>
+     * becomes a group (layer), each patch list entry becomes a sample zone.
+     *
+     * @param file The timbre file
+     * @param lines All lines of the file
+     * @param magicIndex The index of the version line; the title and comment are stored before it
+     * @return The multi-sample source (a list with a single element) or an empty list
+     * @throws IOException Could not read a sample file
+     */
+    private List<IMultisampleSource> parseTimbre (final File file, final List<String> lines, final int magicIndex) throws IOException
+    {
+        final File folder = file.getParentFile ();
+        final Map<String, String> sampleIndex = readSampleIndex (folder);
+
+        // The title is the first line, everything up to the version tag is the comment
+        String title = magicIndex > 0 ? lines.get (0).trim () : "";
+        if (title.isBlank ())
+            title = FileUtils.getNameWithoutType (file);
+        final StringBuilder commentBuilder = new StringBuilder ();
+        for (int i = 1; i < magicIndex; i++)
+        {
+            if (commentBuilder.length () > 0)
+                commentBuilder.append ('\n');
+            commentBuilder.append (lines.get (i));
+        }
+
+        // Collect the patch list entries per partial. Note: the PTPIFile* scalar lines only mirror
+        // the currently selected patch line in the editor and may be stale, so all zone data is read
+        // exclusively from the patch list entries. In addition collect the per-partial amplitude
+        // envelope (PTPIVEnv*) and the timbre-global note filter (TBPINoteFilter*).
+        final Map<Integer, List<String []>> partials = new TreeMap<> ();
+        final Map<Integer, Map<String, Double>> partialEnvelopes = new TreeMap<> ();
+        final Map<Integer, Map<String, Double>> partialCrossfades = new TreeMap<> ();
+        final Map<Integer, Double> partialPans = new TreeMap<> ();
+        final Map<Integer, Double> partialVolumes = new TreeMap<> ();
+        final Map<Integer, Double> partialTunes = new TreeMap<> ();
+        final Map<Integer, Double> partialTrans = new TreeMap<> ();
+        final Map<Integer, Double> partialOctaves = new TreeMap<> ();
+        final Map<String, Double> filterParameters = new HashMap<> ();
+        int dynamicSource = -1;
+        for (int i = magicIndex + 1; i < lines.size (); i++)
+        {
+            final String line = lines.get (i).trim ();
+            if (line.startsWith (ENTRY))
+            {
+                final String [] tokens = splitEntry (line);
+                if (tokens != null)
+                {
+                    final int partial = parseInt (tokens[0], -1);
+                    if (partial >= 0)
+                        partials.computeIfAbsent (Integer.valueOf (partial), k -> new ArrayList<> ()).add (tokens);
+                }
+            }
+            else if (line.startsWith (AMP_ENVELOPE_PREFIX))
+                collectPartialParameter (partialEnvelopes, line, AMP_ENVELOPE_PREFIX);
+            else if (line.startsWith (CROSSFADE_PREFIX))
+                collectPartialParameter (partialCrossfades, line, CROSSFADE_PREFIX);
+            else if (line.startsWith (PAN_PARAM))
+                collectPartialScalar (partialPans, line);
+            else if (line.startsWith (VOLUME_PARAM))
+                collectPartialScalar (partialVolumes, line);
+            // Note: the Tune / Tran checks must not swallow the stale FileTune editor mirror, which is
+            // why the exact keywords (not a shared prefix) are matched
+            else if (line.startsWith (TUNE_PARAM))
+                collectPartialScalar (partialTunes, line);
+            else if (line.startsWith (TRAN_PARAM))
+                collectPartialScalar (partialTrans, line);
+            else if (line.startsWith (OCTAVE_PARAM))
+                collectPartialScalar (partialOctaves, line);
+            else if (line.startsWith (DYN_ENV_SOURCE))
+            {
+                final String [] tokens = line.split ("\\s+");
+                dynamicSource = parseInt (tokens[tokens.length - 1], -1);
+            }
+            else if (line.startsWith (FILTER_PREFIX))
+                collectGlobalParameter (filterParameters, line, FILTER_PREFIX);
+        }
+
+        if (partials.isEmpty ())
+        {
+            this.notifier.logError ("IDS_SYNCLAVIER_NO_SAMPLES", file.getName ());
+            return Collections.emptyList ();
+        }
+
+        final List<IGroup> groups = new ArrayList<> ();
+        for (final Map.Entry<Integer, List<String []>> partialEntry: partials.entrySet ())
+        {
+            final DefaultGroup group = new DefaultGroup ("Partial " + (partialEntry.getKey ().intValue () + 1));
+            final Map<String, Double> envelope = partialEnvelopes.get (partialEntry.getKey ());
+            // The crossfade window is a velocity split only when the dynamic axis source is velocity
+            final Map<String, Double> crossfade = dynamicSource == DYN_SOURCE_VELOCITY ? partialCrossfades.get (partialEntry.getKey ()) : null;
+            // Pan, volume and the pitch offset are per-partial settings and apply to all the zones. The
+            // partial volume is a dB attenuation added to the zone gain; the partial Tune (cents), Tran
+            // (semitones) and Octave (a reference frequency) add up to a semitone offset on the tuning.
+            final Double partialPan = partialPans.get (partialEntry.getKey ());
+            final Double partialVolume = partialVolumes.get (partialEntry.getKey ());
+            final double pitchOffset = partialPitchOffset (partialEntry.getKey (), partialTunes, partialTrans, partialOctaves);
+            for (final String [] tokens: partialEntry.getValue ())
+            {
+                final ISampleZone zone = this.createZone (folder, sampleIndex, tokens);
+                if (zone != null)
+                {
+                    applyAmplitudeEnvelope (zone, envelope);
+                    if (crossfade != null)
+                        applyVelocityWindow (zone, crossfade);
+                    if (partialPan != null)
+                        zone.setPanning (Math.clamp (partialPan.doubleValue () / PAN_RANGE, -1, 1));
+                    if (partialVolume != null)
+                        zone.setGain (zone.getGain () + partialVolume.doubleValue ());
+                    if (pitchOffset != 0)
+                        zone.setTuning (zone.getTuning () + pitchOffset);
+                    final IFilter zoneFilter = buildFilter (filterParameters);
+                    if (zoneFilter != null)
+                        zone.setFilter (zoneFilter);
+                    group.addSampleZone (zone);
+                }
+            }
+            if (!group.getSampleZones ().isEmpty ())
+                groups.add (group);
+        }
+
+        if (groups.isEmpty ())
+            return Collections.emptyList ();
+
+        final IMultisampleSource multisampleSource = this.createMultisampleSource (file, title, groups);
+        // The note filter is timbre-global; some creators read it per-zone (set above), others read
+        // the global filter of the multi-sample - so set it there as well
+        final IFilter globalFilter = buildFilter (filterParameters);
+        if (globalFilter != null)
+            multisampleSource.setGlobalFilter (globalFilter);
+        final IMetadata metadata = multisampleSource.getMetadata ();
+        applyComment (metadata, commentBuilder.toString ());
+        // The name of the containing folder is a good guess for the bank/library (= creator)
+        if (folder != null)
+            metadata.setCreator (folder.getName ());
+        return Collections.singletonList (multisampleSource);
+    }
+
+
+    /**
+     * Creates a sample zone from a patch list entry.
+     *
+     * @param folder The folder which contains the timbre and its samples
+     * @param sampleIndex Maps a sample base name to its file name (from the bank index), may be empty
+     * @param tokens The tokens of the patch list entry (see {@link #splitEntry(String)})
+     * @return The created zone or null if the referenced sample could not be found
+     * @throws IOException Could not read the sample file
+     */
+    private ISampleZone createZone (final File folder, final Map<String, String> sampleIndex, final String [] tokens) throws IOException
+    {
+        final File sampleFile = this.resolveSample (folder, sampleIndex, tokens[16]);
+        if (sampleFile == null)
+        {
+            this.notifier.logError ("IDS_SYNCLAVIER_SAMPLE_NOT_FOUND", tokens[16]);
+            return null;
+        }
+
+        final ISampleData sampleData = this.openSampleData (sampleFile);
+        final ISampleZone zone = new DefaultSampleZone (FileUtils.getNameWithoutType (sampleFile), sampleData);
+
+        zone.setKeyLow (parseInt (tokens[2], 0));
+        zone.setKeyHigh (parseInt (tokens[3], 127));
+        zone.setKeyRoot (parseInt (tokens[4], 60));
+
+        // Field 5 is the volume as a fraction (0.5 is the neutral default): gain[dB] = 36 * f - 12.
+        // Field 6 is the tuning as a fraction (0.5 is centered): tune[cents] = 250 * f - 125. The
+        // patch list entry has no panning; panning is a per-partial setting (SynclavierPTPIPan) and
+        // is applied to all zones of the partial by the caller.
+        final double volumeFraction = parseDouble (tokens[5], 0.5);
+        zone.setGain (36.0 * volumeFraction - 12.0);
+        final double tuneFraction = parseDouble (tokens[6], 0.5);
+        zone.setTuning ((250.0 * tuneFraction - 125.0) / 100.0);
+
+        // Fields 7 to 10 are the start, end, loop start and loop end as a fraction of the total
+        // length. Field 14 is the number of sample frames
+        final int frames = parseInt (tokens[14], 0);
+        zone.setStart ((int) Math.round (parseDouble (tokens[7], 0) * frames));
+        zone.setStop ((int) Math.round (parseDouble (tokens[8], 1) * frames));
+
+        // Field 11 are the loop bits: 0 = off, 1 = loop, 3 = loop + cross-fade, 4 = one-shot (no
+        // loop), 5 = one-shot + loop
+        final int loopBits = parseInt (tokens[11], 0);
+        if (loopBits == 1 || loopBits == 3 || loopBits == 5)
+        {
+            final ISampleLoop loop = new DefaultSampleLoop ();
+            loop.setType (LoopType.FORWARDS);
+            loop.setStart ((int) Math.round (parseDouble (tokens[9], 0) * frames));
+            loop.setEnd ((int) Math.round (parseDouble (tokens[10], 1) * frames));
+            zone.addLoop (loop);
+        }
+
+        return zone;
+    }
+
+
+    /**
+     * Creates the sample data for the resolved file. Obfuscated <i>.sflc</i> files are handled by
+     * {@link SynclavierRegenSampleData}, plain WAV/FLAC/AIFF files (used by user libraries) are
+     * handled by the standard sample data factory.
+     *
+     * @param sampleFile The resolved sample file
+     * @return The sample data
+     * @throws IOException Could not read the file
+     */
+    private ISampleData openSampleData (final File sampleFile) throws IOException
+    {
+        if (sampleFile.getName ().toLowerCase (Locale.US).endsWith (SAMPLE_ENDING))
+            return new SynclavierRegenSampleData (sampleFile);
+        return createSampleData (sampleFile, this.notifier);
+    }
+
+
+    /**
+     * Resolve the referenced sample to a file on disk. The reference may contain a virtual folder
+     * prefix. Commercial banks store the audio as an obfuscated <i>.sflc</i> file which uses the
+     * referenced base name but ignores the referenced extension; user libraries reference plain
+     * <i>.wav</i>/<i>.flac</i> files directly. Truncated names (ending with <i>~</i>) are resolved
+     * via the bank index if present.
+     *
+     * @param folder The folder to search
+     * @param sampleIndex The bank sample index (base name to file name)
+     * @param reference The referenced sample path
+     * @return The resolved file or null if it does not exist
+     */
+    private File resolveSample (final File folder, final Map<String, String> sampleIndex, final String reference)
+    {
+        String name = reference.replace ('\\', '/');
+        final int slash = name.lastIndexOf ('/');
+        if (slash >= 0)
+            name = name.substring (slash + 1);
+
+        // The exact referenced file (a plain WAV/FLAC in a user library)
+        final File exact = new File (folder, name);
+        if (exact.exists ())
+            return exact;
+
+        String base = name;
+        final int dot = base.lastIndexOf ('.');
+        if (dot >= 0)
+            base = base.substring (0, dot);
+        final boolean truncated = base.endsWith ("~");
+        if (truncated)
+            base = base.substring (0, base.length () - 1);
+
+        // Try the known audio extensions, the obfuscated SFLC first
+        for (final String ending: SAMPLE_ENDINGS)
+        {
+            final File candidate = new File (folder, base + ending);
+            if (candidate.exists ())
+                return candidate;
+        }
+
+        // Consult the bank index (handles truncated names and alternative extensions)
+        final String indexed = sampleIndex.get (base.toLowerCase (Locale.US));
+        if (indexed != null)
+        {
+            final File indexedFile = new File (folder, indexed);
+            if (indexedFile.exists ())
+                return indexedFile;
+        }
+        if (truncated)
+            for (final Map.Entry<String, String> e: sampleIndex.entrySet ())
+                if (e.getKey ().startsWith (base.toLowerCase (Locale.US)))
+                {
+                    final File candidate = new File (folder, e.getValue ());
+                    if (candidate.exists ())
+                        return candidate;
+                }
+
+        // Case-insensitive search in the folder
+        final File [] children = folder.listFiles ();
+        if (children != null)
+            for (final File child: children)
+            {
+                final String childLower = child.getName ().toLowerCase (Locale.US);
+                for (final String ending: SAMPLE_ENDINGS)
+                    if (childLower.equals ((base + ending).toLowerCase (Locale.US)))
+                        return child;
+            }
+        return null;
+    }
+
+
+    /**
+     * Reads the bank sample index TSV file (a file starting with an underscore and having a
+     * <i>mFilenameNoExt</i> column) if present. It maps the lower-cased base name to the full file
+     * name (base name plus the extension from the <i>mExtension</i> column).
+     *
+     * @param folder The folder to look in
+     * @return The map, empty if there is no index
+     */
+    private static Map<String, String> readSampleIndex (final File folder)
+    {
+        final Map<String, String> index = new java.util.HashMap<> ();
+        final File [] children = folder == null ? null : folder.listFiles ();
+        if (children == null)
+            return index;
+        for (final File child: children)
+        {
+            final String name = child.getName ();
+            if (!name.startsWith ("_") || !name.toLowerCase (Locale.US).endsWith (".tsv"))
+                continue;
+            try
+            {
+                final List<String> lines = java.nio.file.Files.readAllLines (child.toPath ());
+                if (lines.isEmpty ())
+                    continue;
+                final String [] header = lines.get (0).split ("\t", -1);
+                int nameColumn = -1;
+                int extColumn = -1;
+                for (int c = 0; c < header.length; c++)
+                {
+                    if ("mFilenameNoExt".equals (header[c]))
+                        nameColumn = c;
+                    else if ("mExtension".equals (header[c]))
+                        extColumn = c;
+                }
+                if (nameColumn < 0)
+                    continue;
+                for (int r = 1; r < lines.size (); r++)
+                {
+                    final String [] columns = lines.get (r).split ("\t", -1);
+                    if (columns.length <= nameColumn || columns[nameColumn].isBlank ())
+                        continue;
+                    final String ext = extColumn >= 0 && extColumn < columns.length && !columns[extColumn].isBlank () ? columns[extColumn] : SAMPLE_ENDING;
+                    index.put (columns[nameColumn].toLowerCase (Locale.US), columns[nameColumn] + ext);
+                }
+            }
+            catch (final IOException _)
+            {
+                // Ignore an unreadable index
+            }
+        }
+        return index;
+    }
+
+
+    /**
+     * Splits a patch list entry line into its 16 leading tokens plus the sample path. The path may
+     * contain spaces, therefore it is treated as the remainder of the line after the sample rate.
+     *
+     * @param line The line to split
+     * @return The 17 tokens (0-15 are the numeric fields, 16 is the path) or null if the line is
+     *         malformed
+     */
+    private static String [] splitEntry (final String line)
+    {
+        // Keyword partial entry keyLow keyHigh root gain pan start end loopStart loopEnd loopMode
+        // flag channels frames sampleRate path...
+        final String rest = line.substring (ENTRY.length ()).trim ();
+        final String [] parts = rest.split ("\\s+", 17);
+        if (parts.length < 17)
+            return null;
+        return parts;
+    }
+
+
+    private static void applyComment (final IMetadata metadata, final String comment)
+    {
+        if (comment == null || comment.isBlank ())
+            return;
+
+        final List<String> keywords = new ArrayList<> ();
+        final StringBuilder description = new StringBuilder ();
+        for (final String token: comment.replace (PARAGRAPH, "\n").split ("\\s+"))
+        {
+            if (token.startsWith ("#") && token.length () > 1)
+                keywords.add (token.substring (1));
+            else
+            {
+                if (description.length () > 0)
+                    description.append (' ');
+                description.append (token);
+            }
+        }
+
+        metadata.setDescription (description.toString ().trim ());
+        if (!keywords.isEmpty ())
+        {
+            metadata.setKeywords (keywords.toArray (new String [keywords.size ()]));
+            metadata.setCategory (keywords.get (0));
+        }
+    }
+
+
+    /**
+     * Collects a per-partial parameter line (e.g. an amplitude envelope stage) into a map keyed by
+     * the partial index and the parameter name (the keyword suffix after the prefix).
+     *
+     * @param map The target map
+     * @param line The line to parse
+     * @param prefix The keyword prefix which is stripped to form the parameter name
+     */
+    private static void collectPartialParameter (final Map<Integer, Map<String, Double>> map, final String line, final String prefix)
+    {
+        final String [] tokens = line.split ("\\s+");
+        if (tokens.length < 5)
+            return;
+        final int partial = parseInt (tokens[1], -1);
+        if (partial < 0)
+            return;
+        final String key = tokens[0].substring (prefix.length ());
+        map.computeIfAbsent (Integer.valueOf (partial), k -> new HashMap<> ()).put (key, Double.valueOf (parseDouble (tokens[tokens.length - 1], 0)));
+    }
+
+
+    /**
+     * Collects a per-partial scalar parameter line (e.g. pan or volume) into a map keyed by the
+     * partial index. The line format is "&lt;keyword&gt; &lt;partial&gt; 0 0 &lt;value&gt;".
+     *
+     * @param map The target map
+     * @param line The line to parse
+     */
+    private static void collectPartialScalar (final Map<Integer, Double> map, final String line)
+    {
+        final String [] tokens = line.split ("\\s+");
+        if (tokens.length < 5)
+            return;
+        final int partial = parseInt (tokens[1], -1);
+        if (partial >= 0)
+            map.put (Integer.valueOf (partial), Double.valueOf (parseDouble (tokens[tokens.length - 1], 0)));
+    }
+
+
+    /**
+     * Computes the additional tuning of a partial in semitones from its Tune (cents), Tran (semitones)
+     * and Octave (a reference frequency where 440 Hz is neutral) parameters. All three add up on top of
+     * the note and per-patch-entry tuning (the firmware pitch engine computes frequency = 440 * 2^(sum
+     * of semitones / 12)).
+     *
+     * @param partial The partial index
+     * @param tunes The collected Tune parameters (cents)
+     * @param trans The collected Tran parameters (semitones)
+     * @param octaves The collected Octave parameters (reference frequency in Hz)
+     * @return The additional tuning in semitones (0 if the partial has none)
+     */
+    private static double partialPitchOffset (final Integer partial, final Map<Integer, Double> tunes, final Map<Integer, Double> trans, final Map<Integer, Double> octaves)
+    {
+        double semitones = 0;
+        final Double tran = trans.get (partial);
+        if (tran != null)
+            semitones += tran.doubleValue ();
+        final Double tune = tunes.get (partial);
+        if (tune != null)
+            semitones += tune.doubleValue () / 100.0;
+        final Double octave = octaves.get (partial);
+        if (octave != null && octave.doubleValue () > 0)
+            semitones += 12.0 * Math.log (octave.doubleValue () / OCTAVE_REFERENCE_HZ) / Math.log (2);
+        return semitones;
+    }
+
+
+    /**
+     * Collects a timbre-global parameter line (e.g. a note filter setting) into a map keyed by the
+     * parameter name (the keyword suffix after the prefix).
+     *
+     * @param map The target map
+     * @param line The line to parse
+     * @param prefix The keyword prefix which is stripped to form the parameter name
+     */
+    private static void collectGlobalParameter (final Map<String, Double> map, final String line, final String prefix)
+    {
+        final String [] tokens = line.split ("\\s+");
+        if (tokens.length < 5)
+            return;
+        map.put (tokens[0].substring (prefix.length ()), Double.valueOf (parseDouble (tokens[tokens.length - 1], 0)));
+    }
+
+
+    /**
+     * Applies the Synclavier amplitude envelope of a partial to a zone. The Synclavier envelope has
+     * a Delay, an Attack to the Peak level, an Initial Decay to the Sustain level and a Final Decay
+     * (= release), all times in seconds and the levels in percent.
+     *
+     * @param zone The zone to update
+     * @param envelope The envelope parameters (may be null)
+     */
+    private static void applyAmplitudeEnvelope (final ISampleZone zone, final Map<String, Double> envelope)
+    {
+        if (envelope == null || envelope.isEmpty ())
+            return;
+
+        final IEnvelope amplitudeEnvelope = zone.getAmplitudeEnvelopeModulator ().getSource ();
+        setTime (envelope, "Delay", amplitudeEnvelope::setDelayTime);
+        setTime (envelope, "Attack", amplitudeEnvelope::setAttackTime);
+        setTime (envelope, "IDecay", amplitudeEnvelope::setDecayTime);
+        setTime (envelope, "FDecay", amplitudeEnvelope::setReleaseTime);
+        final Double peak = envelope.get ("Peak");
+        if (peak != null)
+            amplitudeEnvelope.setHoldLevel (Math.clamp (peak.doubleValue () / 100.0, 0, 1));
+        final Double sustain = envelope.get ("Sust");
+        if (sustain != null)
+            amplitudeEnvelope.setSustainLevel (Math.clamp (sustain.doubleValue () / 100.0, 0, 1));
+    }
+
+
+    /**
+     * Builds an {@link IFilter} from the timbre-global note filter parameters. The Synclavier note
+     * filter is a low-pass filter (with a 2- or 4-pole slope) with a cutoff (a fraction), a resonance
+     * (0..1), a filter envelope (attack, decay, release with a peak depth) and keyboard tracking. A
+     * fresh instance is returned on every call so it can be assigned to several zones.
+     *
+     * @param filterParameters The filter parameters (empty if the timbre has no filter)
+     * @return The filter or null if the timbre has no note filter
+     */
+    private static IFilter buildFilter (final Map<String, Double> filterParameters)
+    {
+        final Double cutoff = filterParameters.get ("Cutoff");
+        if (cutoff == null)
+            return null;
+
+        // The note filter is multi-mode; the type index selects mode and slope (value = index / 255):
+        // 1 = LP 12dB, 2 = HP 12dB, 3 = BP 12dB, 4 = LP 24dB, 5 = HP 24dB, 6 = BP 24dB
+        final Double type = filterParameters.get ("Type");
+        final int typeIndex = type == null ? 1 : (int) Math.round (type.doubleValue () * 255.0);
+        final int poles = typeIndex >= 4 ? 4 : 2;
+        final FilterType filterType = switch (typeIndex)
+        {
+            case 2, 5 -> FilterType.HIGH_PASS;
+            case 3, 6 -> FilterType.BAND_PASS;
+            default -> FilterType.LOW_PASS;
+        };
+        final double resonance = filterParameters.getOrDefault ("Resonance", Double.valueOf (0)).doubleValue ();
+        final IFilter filter = new DefaultFilter (filterType, poles, MathUtils.denormalizeCutoff (Math.clamp (cutoff.doubleValue (), 0, 1)), Math.clamp (resonance, 0, 1));
+
+        // Filter envelope: the times are in seconds, the depth is approximated from the peak delta
+        final IEnvelopeModulator cutoffModulator = filter.getCutoffEnvelopeModulator ();
+        final IEnvelope filterEnvelope = cutoffModulator.getSource ();
+        setTime (filterParameters, "Attack", filterEnvelope::setAttackTime);
+        setTime (filterParameters, "Decay", filterEnvelope::setDecayTime);
+        setTime (filterParameters, "Release", filterEnvelope::setReleaseTime);
+        final Double peakDelta = filterParameters.get ("PeakDelta");
+        if (peakDelta != null)
+            cutoffModulator.setDepth (Math.clamp (peakDelta.doubleValue () / 10.0, -1, 1));
+
+        final Double pitchTrack = filterParameters.get ("PitchTrack");
+        if (pitchTrack != null)
+            filter.setCutoffKeyTracking (Math.clamp (pitchTrack.doubleValue (), 0, 1));
+
+        return filter;
+    }
+
+
+    /**
+     * Applies a per-partial crossfade window (XFStart/In/Out/End) to a zone as its velocity range and
+     * cross-fades. Only called when the dynamic axis source is velocity, so the partials form
+     * velocity layers.
+     *
+     * @param zone The zone to update
+     * @param crossfade The crossfade window parameters (may be null)
+     */
+    private static void applyVelocityWindow (final ISampleZone zone, final Map<String, Double> crossfade)
+    {
+        if (crossfade == null)
+            return;
+        final Double start = crossfade.get ("Start");
+        final Double end = crossfade.get ("End");
+        if (start == null && end == null)
+            return;
+
+        final int low = start == null ? 0 : (int) Math.round (start.doubleValue ());
+        final int high = end == null ? 127 : (int) Math.round (end.doubleValue ());
+        zone.setVelocityLow (Math.clamp (low, 0, 127));
+        zone.setVelocityHigh (Math.clamp (high, 0, 127));
+        final Double in = crossfade.get ("In");
+        if (in != null)
+            zone.setVelocityCrossfadeLow (Math.max (0, (int) Math.round (in.doubleValue ()) - low));
+        final Double out = crossfade.get ("Out");
+        if (out != null)
+            zone.setVelocityCrossfadeHigh (Math.max (0, high - (int) Math.round (out.doubleValue ())));
+    }
+
+
+    private static void setTime (final Map<String, Double> map, final String key, final DoubleConsumer setter)
+    {
+        final Double value = map.get (key);
+        if (value != null)
+            setter.accept (Math.max (0, value.doubleValue ()));
+    }
+
+
+    private static int parseInt (final String text, final int defaultValue)
+    {
+        final String trimmed = text.trim ();
+        try
+        {
+            return Integer.parseInt (trimmed);
+        }
+        catch (final NumberFormatException _)
+        {
+            // Older timbre generations write the integer fields as floats (e.g. "24.000000")
+            try
+            {
+                return (int) Math.round (Double.parseDouble (trimmed));
+            }
+            catch (final NumberFormatException _)
+            {
+                return defaultValue;
+            }
+        }
+    }
+
+
+    private static double parseDouble (final String text, final double defaultValue)
+    {
+        try
+        {
+            return Double.parseDouble (text.trim ());
+        }
+        catch (final NumberFormatException _)
+        {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenSampleData.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synclavier/SynclavierRegenSampleData.java
@@ -1,0 +1,120 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.synclavier;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.zip.ZipFile;
+
+import de.mossgrabers.convertwithmoss.core.model.IMetadata;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.core.model.implementation.AbstractFileSampleData;
+import de.mossgrabers.convertwithmoss.file.AudioFileUtils;
+
+
+/**
+ * The data of a Synclavier Regen SFLC sample file. An SFLC file is a FLAC file whose bytes are
+ * obfuscated with a key-stream derived from the file's base name (see {@link SynclavierRegenCodec}).
+ * The obfuscation is removed and the resulting FLAC stream is then decoded like a normal FLAC file.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class SynclavierRegenSampleData extends AbstractFileSampleData
+{
+    private byte [] flacData = null;
+
+
+    /**
+     * Constructor.
+     *
+     * @param file The file where the sample is stored
+     * @throws IOException Could not read the file
+     */
+    public SynclavierRegenSampleData (final File file) throws IOException
+    {
+        super (file);
+    }
+
+
+    /**
+     * Constructor for a sample stored in a ZIP file.
+     *
+     * @param zipFile The ZIP file which contains the SFLC files
+     * @param zipEntry The relative path in the ZIP where the file is stored
+     * @throws IOException Could not read the file
+     */
+    public SynclavierRegenSampleData (final File zipFile, final File zipEntry) throws IOException
+    {
+        super (zipFile, zipEntry);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void writeSample (final OutputStream outputStream) throws IOException
+    {
+        AudioFileUtils.decompressToWav (new ByteArrayInputStream (this.getDecodedFlac ()), outputStream);
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected void createAudioMetadata () throws IOException
+    {
+        this.audioMetadata = AudioFileUtils.getMetadata (new ByteArrayInputStream (this.getDecodedFlac ()));
+    }
+
+
+    /**
+     * De-obfuscates the SFLC file into a plain FLAC stream. The result is cached.
+     *
+     * @return The FLAC data
+     * @throws IOException Could not read the file
+     */
+    private byte [] getDecodedFlac () throws IOException
+    {
+        if (this.flacData == null)
+            this.flacData = SynclavierRegenCodec.transform (this.readRawData (), SynclavierRegenCodec.baseName (this.filename));
+        return this.flacData;
+    }
+
+
+    /**
+     * Reads the raw (still obfuscated) content of the sample file.
+     *
+     * @return The raw bytes
+     * @throws IOException Could not read the file
+     */
+    private byte [] readRawData () throws IOException
+    {
+        if (this.sampleFile != null)
+            return Files.readAllBytes (this.sampleFile.toPath ());
+
+        try (final ZipFile zf = new ZipFile (this.zipFile); final InputStream in = zf.getInputStream (this.getHarmonizedZipEntry (zf)))
+        {
+            return in.readAllBytes ();
+        }
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void addZoneData (final ISampleZone zone, final boolean addRootKey, final boolean addLoops) throws IOException
+    {
+        // No info available in FLAC
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateMetadata (final IMetadata metadata)
+    {
+        // No meta data available
+    }
+}

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -376,6 +376,11 @@ IDS_ZENCORE_TARGET_DEVICE=Target Device
 IDS_ZENCORE_TARGET_DEVICE_OPTION0=ZEN-Core (KY019)
 IDS_ZENCORE_TARGET_DEVICE_OPTION1=GAIA-2 (MI085)
 
+IDS_SYNCLAVIER_NO_SAMPLES=No patch list entries found in the Synclavier timbre '%1'.\n
+IDS_SYNCLAVIER_SAMPLE_NOT_FOUND=The sample '%1' referenced by the Synclavier timbre could not be found. Skipped.\n
+IDS_SYNCLAVIER_LIBRARY_SPLIT=The set has %1 timbres but a Synclavier Regen library holds only 64, so it is written as %2 numbered libraries.\n
+IDS_SYNCLAVIER_PARTIAL_CAP=The timbre '%1' has %2 layers but a Synclavier timbre has only 12 partials; the extra layers are dropped.\n
+
 IDS_S5XX_VERSION=Detected %1 (%2) sampler disk.\n
 IDS_S5XX_CONVERTING_PATCH=Reading patch '%1'.\n
 


### PR DESCRIPTION
Adds a detector and creator for **Synclavier Regen** libraries.

## Format
A Regen library is a folder placed under `Libraries/` on the device SD card holding one or more *timbres* (`NN-Entry.txt` text files) together with their samples and the `_<name>.tsv` / `_TimbreIndex.tsv` index files. A timbre has up to twelve *partials* (layers); each partial maps its samples across the keyboard via `SynclavierPTPatchListEntry` lines.

Commercial libraries store their samples as `.sflc` files — a normal FLAC file whose bytes are obfuscated with a key-stream keyed by the file's own base name (a full-period 2^64 LCG whose constants were recovered from the device firmware). These are read and written transparently. User libraries that reference plain `.wav`/`.flac` samples are read as well. Samples used by several partials or timbres are stored only once, as in the original libraries.

The reverse-engineered format is documented in `documentation/design/SYNCLAVIER_REGEN_FORMAT.md`, and `README-FORMATS.md` gains a *"Getting a converted library onto the Regen"* section for users.

## Read and written
- name and the comment **#tags** — on writing, the category is written as the Regen's primary (green) category tag, mapped to its canonical tag list (`Bass` → `#bass`, `Chromatic Percussion` → `#chime`, …; a category with no Regen equivalent falls back to its sanitized name), and the keywords as property tags; on reading, the first tag becomes the category and the rest the keywords
- partial/zone layout (partials → groups, patch list entries → sample zones), key ranges, root keys
- per-zone volume (`gain[dB] = 36·f − 12`) and tuning (`tune[cents] = 250·f − 125`)
- **per-partial volume and pitch** — `PTPIVolume` (a −50…0 dB attenuation) folds into the zone gain; `PTPITune` (cents) + `PTPITran` (semitones) + `PTPIOctave` (a reference frequency contributing `12·log2(Hz/440)` semitones) add to the zone tuning. Units confirmed against the firmware parameter descriptor table and pitch engine (`freq = 440·2^(semitones/12)`). On writing they carry the part of the gain/tuning that exceeds the per-zone entry fields (which floor at −12 dB / ±125 cents), so the common case is unchanged and larger values round-trip
- **per-partial panning** (`PTPIPan`, ±63 ↔ the model's ±1)
- sample start and loop (start, end, cross-fade)
- **velocity layers** — each source velocity layer becomes a partial selected by velocity through its crossfade window (`XFStart/In/Out/End`, with the dynamic-axis source `TBPIDynEnvSrc` set to velocity); a timbre has 12 partials, so up to 12 velocity layers
- per-partial amplitude envelope (delay / attack→peak / initial-decay→sustain / final-decay→release)
- timbre-global **multi-mode filter** — low-pass, high-pass or band-pass with a 2- or 4-pole slope (`NoteFilterType` = index/255, where LP12/HP12/BP12/LP24/HP24/BP24 = 1…6, verified against the production 1.18 firmware): cutoff, resonance, filter envelope and keyboard tracking

The filter is set both per zone and as the global filter of the multi-sample, so it is carried into destination formats regardless of whether they read the per-zone or the global filter. The additive/FM synthesis parameters (index envelope, harmonic coefficients, modulation matrix, frame partials) are not converted.

When a folder is converted as a library, all timbres go into one library folder with a shared sample pool; because a Regen library holds at most 64 timbres (8 banks of 8), a larger set is written automatically as several numbered libraries. Mono and stereo samples in 16- or 24-bit at any sample rate are supported.

A library's optional `Description.txt` (the device browser blurb) is written from the converted sounds' descriptions rather than a fixed string: the unique `metadata.getDescription()` of a library's timbres are combined - mirroring how `Sf2Creator` forms its library comment - and capped at the Regen's 220-character display limit (whole descriptions are added until the next would overflow). When no sound has a description, no `Description.txt` is written and the device shows its default. There is no bespoke description option; the description rides the metadata model exactly like every other creator.

## Testing
Software-verified against the freely available libraries and the samples decoded from the device firmware:
- samples decode bit-exact (mono/stereo, 16/24-bit, up to 96 kHz)
- key mapping, loops, tuning, gain, the amplitude envelope and velocity layers round-trip (e.g. a 3-layer source writes three partials with velocity windows 0–42 / 43–85 / 86–127 and reads back to the same ranges)
- **volume + pitch** round-trip: an SFZ with `−30 dB / +7 st / −6 dB, +30 c` writes `entry −12 dB + PTPIVolume −18` / `PTPITran 7` / entry-only, and reads back to the originals; `PTPIOctave` 880 Hz → +1200 c and 110 Hz → −2370 c
- **panning** round-trips: an SFZ with `pan = −100 / 50 / 0` writes `−63 / 32 / (omitted)` and reads back to `−100 / 51 / (omitted)` (the `+1` is the Regen's 63-step pan quantization)
- all six **filter** modes (low-/high-/band-pass × 2-/4-pole) map to the correct `NoteFilterType` index and back; filters from other source formats land in the written timbre (per-zone and global)
- **tags** round-trip: a Bitwig multi-sample with category `Bass` and keywords `vintage`, `warm` writes `#bass #vintage #warm` and reads back to category `bass` with those keywords
- a set of more than 64 timbres splits into valid ≤64-timbre libraries

The unit/combination semantics of the per-partial volume and pitch were reverse-engineered from the production 1.18 firmware (parameter descriptor table + the `exp2f`/`pow(2, x/12)` pitch engine). I do not have Regen hardware, so on-device import of a generated library has not been verified.

