### PR TITLE
Fix the doubled-up file name when a library name is typed with its ending

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -24,6 +24,7 @@
   * New: Added an opt-in metadata option "Category tag at name start declares the category" (off by default): many commercial libraries prefix each preset name with its category (e.g. 'PAD Solina', 'BASS Growler'). When enabled, such a prefix takes precedence over keyword matches elsewhere in the name, which could otherwise win accidentally (e.g. 'BELL Vibrato Strings' was detected as Strings instead of Bell), and common abbreviations (BRAS, DRM, FLUT, GRAN, ORG, PERC, PHYS, PLUK, POLY, REES, STRG, SWEP, VOC) are recognized as well. Also added 'Reese' as a Bass category tag (thanks to Douglas Carmichael).
   * New: Added an opt-in *Snap loops to zero-crossings* processing option.
   * Fixed: Ignores hidden files/folders and the known Windows system folders when checking for empty-folder (thanks to Douglas Carmichael).
+  * Fixed: A library name typed with its file ending (e.g. "MyLibrary.xrni") produced a doubled-up file name ("MyLibrary_xrni.xrni") - the ending is now recognized for every destination format (thanks to Douglas Carmichael).
   * Fixed: The "Trim start and end" processing option cut the audio to the zone's start/end but left the loop points at their old positions, so a trimmed sample with a non-zero start got a displaced loop - the loop end could even point past the end of the trimmed audio. The loop points now move with the cut (thanks to Douglas Carmichael).
   * Fixed: Fixed some potential NullPointerExceptions.
 * 1010music (thanks to Douglas Carmichael)

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/creator/AbstractCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/creator/AbstractCreator.java
@@ -575,12 +575,13 @@ public abstract class AbstractCreator<T extends ICoreTaskSettings> extends Abstr
     protected File createUniqueFilename (final File destinationFolder, final String sampleName, final String extension)
     {
         final String ext = extension.isBlank () ? "" : "." + extension;
-        File multiFile = new File (destinationFolder, sampleName + ext);
+        final String name = withoutExtensionTail (sampleName, extension);
+        File multiFile = new File (destinationFolder, name + ext);
         int counter = 1;
         while (multiFile.exists ())
         {
             counter++;
-            multiFile = new File (destinationFolder, sampleName + " (" + counter + ")" + ext);
+            multiFile = new File (destinationFolder, name + " (" + counter + ")" + ext);
         }
         return multiFile;
     }
@@ -597,14 +598,38 @@ public abstract class AbstractCreator<T extends ICoreTaskSettings> extends Abstr
      */
     protected File createUniqueFilename (final File destinationFolder, final String sampleName, final String extension, final List<String> existingAbsoluteFilenames)
     {
-        File multiFile = new File (destinationFolder, sampleName + extension);
+        final String name = withoutExtensionTail (sampleName, extension);
+        File multiFile = new File (destinationFolder, name + extension);
         int counter = 1;
         while (existingAbsoluteFilenames.contains (multiFile.getAbsolutePath ()))
         {
             counter++;
-            multiFile = new File (destinationFolder, sampleName + " (" + counter + ")" + extension);
+            multiFile = new File (destinationFolder, name + " (" + counter + ")" + extension);
         }
         return multiFile;
+    }
+
+
+    /**
+     * Remove a doubled-up file ending from a name. A library name is free text from the user
+     * interface - typed with the file ending (e.g. "MyLibrary.xrni") it would otherwise come out
+     * as "MyLibrary_xrni.xrni", since the name sanitizing replaces the dot with an underscore
+     * before the name reaches the creator; both spellings are therefore handled. Only a tail that
+     * matches the extension actually being appended is removed.
+     *
+     * @param name The file name, without the extension that will be appended
+     * @param extension The extension that will be appended, with or without a leading dot
+     * @return The name without a trailing '.extension' or '_extension'
+     */
+    private static String withoutExtensionTail (final String name, final String extension)
+    {
+        final String bare = extension.startsWith (".") ? extension.substring (1) : extension;
+        if (bare.isBlank ())
+            return name;
+        final int tailLength = bare.length () + 1;
+        if (name.length () > tailLength && (name.regionMatches (true, name.length () - tailLength, "." + bare, 0, tailLength) || name.regionMatches (true, name.length () - tailLength, "_" + bare, 0, tailLength)))
+            return name.substring (0, name.length () - tailLength);
+        return name;
     }
 
 


### PR DESCRIPTION
The library name is free text from the user interface — typed with its file ending (e.g. `MyLibrary.xrni`), it produced a doubled-up file name (`MyLibrary_xrni.xrni`): the name sanitizing replaces the dot with an underscore before the name reaches the creator, and the creator then appends the ending again.

`AbstractCreator.createUniqueFilename` (both overloads) now removes a trailing `.ending`/`_ending` from the name when — and only when — it matches the extension actually being appended, fixing the library naming of every destination format in one place.

| typed library name | before | after |
|---|---|---|
| `TestLib.sf2` → SF2 | `TestLib_sf2.sf2` | `TestLib.sf2` |
| `TestLib.dslibrary` → DecentSampler | `TestLib_dslibrary.dslibrary` | `TestLib.dslibrary` |
| `TestLib` (no ending) | `TestLib.sf2` | `TestLib.sf2` (unchanged) |

Preset file names are unaffected unless they carry exactly such a tail — in which case the doubled ending (e.g. a source named `X.sf2` written as `X.sf2.sf2`) is fixed as well.
