### PR TITLE
Waldorf Quantum/Iridium: add Author and Bank creator options

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -62,6 +62,7 @@
 * TX16W
   * Fixed: First check if the referenced absolute sample file path exists before searching all local folders.
 * Waldorf Quantum/Iridium (thanks to Douglas Carmichael)
+  * New: The preset Author and Bank fields can now be set with the *Author* and *Bank* creator options (or the CLI parameters QPATAuthor / QPATBank); leaving them empty keeps the values from the source. This lets a converted library be tagged so its presets are grouped and browsable by author and bank on the device.
   * New: A layered preset - one that stacks several samples on the same note (e.g. a body plus a swell, common in rompler banks) - is now spread across the three oscillators instead of collapsing into one, so the sound keeps its full body. Each set of zones that would sound simultaneously gets its own oscillator (up to three).
   * Fixed: Sample Loop mode 2 was not set to alternating but backwards.
   * Fixed: Samples were referenced with a leading drive number (an absolute path such as `4:samples/...`). This caused two problems on the device: a preset placed on a drive other than the hard-coded one showed the "Find Sample Map" screen and the samples had to be located by hand, and the device doubled the prefix when using its own "Export -> With Samples" (e.g. `3:2:samples/...`), so the samples could not be backed up. Sample paths are now written relative to the preset, which the device resolves against the folder the preset was loaded from - the samples load automatically on any drive and export/back up cleanly (confirmed on Iridium OS 4).

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -710,6 +710,8 @@ If this format is used as the source it produces 1 or 2 output presets, one for 
 ### Destination Options
 
 * Re-sample to 16bit/44.1kHz: If enabled, samples will be resampled to 16bit and 44.1kHz. While the device can play higher resolutions as well it might impact the performance.
+* Author: Written into the preset's Author field, which the device shows and can group presets by. When left empty, the creator from the source metadata is kept (e.g. the sound designer stored in a SoundFont).
+* Bank: Written into the preset's Bank field. When left empty, the description from the source metadata is kept.
 * Options to write/update [WAV Chunk Information](#wav-chunk-information)
 
 ## Yamaha YSFC

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
@@ -92,7 +92,7 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
         final List<IGroup> groups = reduceGroups (splitLayers (this.combineSplitStereo (multisampleSource)));
         multisampleSource.setGroups (groups);
 
-        storeMultisample (multisampleSource, multiFile, groups, relativeSamplePath);
+        storeMultisample (multisampleSource, multiFile, groups, relativeSamplePath, this.settingsConfiguration.getAuthor (), this.settingsConfiguration.getBank ());
 
         // Store all samples
         final File sampleFolder = new File (destinationFolder, relativeSamplePath);
@@ -116,7 +116,7 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
      * @param relativeSamplePath The relative sample path
      * @throws IOException Could not store the file
      */
-    private static void storeMultisample (final IMultisampleSource multisampleSource, final File multiFile, final List<IGroup> groups, final String relativeSamplePath) throws IOException
+    private static void storeMultisample (final IMultisampleSource multisampleSource, final File multiFile, final List<IGroup> groups, final String relativeSamplePath, final String author, final String bank) throws IOException
     {
         // A zero-attack/zero-decay amplitude envelope that sustains below full level makes the
         // device pop at the start of each note: it snaps to the 100% attack peak and then instantly
@@ -128,7 +128,7 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
 
         try (final FileOutputStream out = new FileOutputStream (multiFile))
         {
-            writeHeader (out, multisampleSource.getMetadata (), multisampleSource.getName ());
+            writeHeader (out, multisampleSource.getMetadata (), multisampleSource.getName (), author, bank);
 
             StreamUtils.writeUnsigned16 (out, parameters.size (), false);
             StreamUtils.padBytes (out, 2);
@@ -704,13 +704,17 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
      * @param name The name of the multi-sample
      * @throws IOException Could not write
      */
-    private static void writeHeader (final OutputStream out, final IMetadata metadata, final String name) throws IOException
+    private static void writeHeader (final OutputStream out, final IMetadata metadata, final String name, final String author, final String bank) throws IOException
     {
         StreamUtils.writeUnsigned32 (out, WaldorfQpatConstants.MAGIC, false);
         StreamUtils.writeUnsigned32 (out, PRESET_VERSION, false);
         StreamUtils.writeAscii (out, StringUtils.fixASCII (name), WaldorfQpatConstants.MAX_STRING_LENGTH);
-        StreamUtils.writeAscii (out, StringUtils.fixASCII (metadata.getCreator ()), WaldorfQpatConstants.MAX_STRING_LENGTH);
-        StreamUtils.writeAscii (out, StringUtils.fixASCII (metadata.getDescription ()).replace ('\r', ' ').replace ('\n', ' '), WaldorfQpatConstants.MAX_STRING_LENGTH);
+        // The author (offset 40) and bank (offset 72) fields are shown by the device. Use the
+        // explicit creator settings when provided, otherwise fall back to the source metadata.
+        final String creator = author != null && !author.isBlank () ? author : metadata.getCreator ();
+        StreamUtils.writeAscii (out, StringUtils.fixASCII (creator), WaldorfQpatConstants.MAX_STRING_LENGTH);
+        final String bankValue = bank != null && !bank.isBlank () ? bank : metadata.getDescription ();
+        StreamUtils.writeAscii (out, StringUtils.fixASCII (bankValue).replace ('\r', ' ').replace ('\n', ' '), WaldorfQpatConstants.MAX_STRING_LENGTH);
 
         final List<String> categories = new ArrayList<> ();
         categories.add (metadata.getCategory ());

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreatorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreatorUI.java
@@ -16,6 +16,7 @@ import de.mossgrabers.tools.ui.control.TitledSeparator;
 import de.mossgrabers.tools.ui.panel.BoxPanel;
 import javafx.geometry.Orientation;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.TextField;
 import javafx.scene.layout.Pane;
 
 
@@ -27,9 +28,15 @@ import javafx.scene.layout.Pane;
 public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
 {
     private static final String QPAT_LIMIT_TO_16_441 = "QPATLimitTo16441";
+    private static final String QPAT_AUTHOR          = "QPATAuthor";
+    private static final String QPAT_BANK            = "QPATBank";
 
     private CheckBox            limitTo16441CheckBox;
+    private TextField           authorField;
+    private TextField           bankField;
     private boolean             limitTo16441;
+    private String              author               = "";
+    private String              bank                 = "";
 
 
     /**
@@ -51,6 +58,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
 
         panel.createSeparator ("@IDS_QPAT_SEPARATOR");
         this.limitTo16441CheckBox = panel.createCheckBox ("@IDS_QPAT_RESAMPLE_TO_16_441");
+        this.authorField = panel.createField ("@IDS_QPAT_AUTHOR");
+        this.bankField = panel.createField ("@IDS_QPAT_BANK");
 
         final TitledSeparator separator = this.addWavChunkOptions (panel);
         separator.getStyleClass ().add ("titled-separator-pane");
@@ -63,6 +72,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
     public void loadSettings (final BasicConfig config)
     {
         this.limitTo16441CheckBox.setSelected (config.getBoolean (QPAT_LIMIT_TO_16_441, true));
+        this.authorField.setText (config.getProperty (QPAT_AUTHOR, ""));
+        this.bankField.setText (config.getProperty (QPAT_BANK, ""));
 
         super.loadSettings (config);
     }
@@ -73,6 +84,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
     public void saveSettings (final BasicConfig config)
     {
         config.setBoolean (QPAT_LIMIT_TO_16_441, this.limitTo16441CheckBox.isSelected ());
+        config.setProperty (QPAT_AUTHOR, this.authorField.getText ());
+        config.setProperty (QPAT_BANK, this.bankField.getText ());
 
         super.saveSettings (config);
     }
@@ -86,6 +99,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
             return false;
 
         this.limitTo16441 = this.limitTo16441CheckBox.isSelected ();
+        this.author = this.authorField.getText ();
+        this.bank = this.bankField.getText ();
         return true;
     }
 
@@ -100,6 +115,11 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
         final String value = parameters.remove (QPAT_LIMIT_TO_16_441);
         this.limitTo16441 = "1".equals (value);
 
+        final String authorValue = parameters.remove (QPAT_AUTHOR);
+        this.author = authorValue == null ? "" : authorValue;
+        final String bankValue = parameters.remove (QPAT_BANK);
+        this.bank = bankValue == null ? "" : bankValue;
+
         return true;
     }
 
@@ -110,6 +130,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
     {
         final List<String> parameterNames = new ArrayList<> (Arrays.asList (super.getCLIParameterNames ()));
         parameterNames.add (QPAT_LIMIT_TO_16_441);
+        parameterNames.add (QPAT_AUTHOR);
+        parameterNames.add (QPAT_BANK);
         return parameterNames.toArray (new String [parameterNames.size ()]);
     }
 
@@ -122,5 +144,29 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
     public boolean limitTo16441 ()
     {
         return this.limitTo16441;
+    }
+
+
+    /**
+     * Get the author (creator) to write into the preset. When not empty it overrides the source
+     * metadata creator; the device shows it as the preset's Author.
+     *
+     * @return The author, or an empty string to keep the source's creator
+     */
+    public String getAuthor ()
+    {
+        return this.author;
+    }
+
+
+    /**
+     * Get the bank to write into the preset. When not empty it overrides the source metadata
+     * description; the device shows it as the preset's Bank.
+     *
+     * @return The bank, or an empty string to keep the source's value
+     */
+    public String getBank ()
+    {
+        return this.bank;
     }
 }

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -621,6 +621,8 @@ IDS_OMNISPHERE_USE_PRESETS=Use Presets files (*.prt_omn) as the input (otherwise
 
 IDS_QPAT_SEPARATOR=Waldorf QPAT
 IDS_QPAT_RESAMPLE_TO_16_441=Re-sample to 16bit/44.1kHz
+IDS_QPAT_AUTHOR=Author (empty = keep source)
+IDS_QPAT_BANK=Bank (empty = keep source)
 
 IDS_SF2_NAMING=Naming of output files
 IDS_SF2_NAMING_ADD_FILE_NAME=Prefix with file name


### PR DESCRIPTION
The Quantum/Iridium shows (and can group presets by) the Author and Bank fields of a preset. ConvertWithMoss fills them from the source metadata: the creator becomes the Author and the description becomes the Bank. For commercial libraries these are usually vendor tags - e.g. converting the E-mu E4 Producer Series SoundFonts puts "www.DigitalSoundFactory.com" into Author and "Copyright: DigitalSoundFactory/E-mu Systems 2007" into Bank (from the SF2's IENG/ICOP INFO fields), which is not very useful for browsing on the device.

This adds *Author* and *Bank* text fields to the Waldorf Quantum/Iridium destination options (CLI: QPATAuthor / QPATBank). When set, they are written into the preset header's author (offset 40) and bank (offset 72) fields, so a converted library can be tagged to group cleanly on the device; when left empty the source metadata is kept exactly as before.

Verified on the E4 Producer Series Keyboards bank: with the options set, the written header carries the given author/bank; without them, the source values are written unchanged. Documented in README-FORMATS and the CHANGELOG.