### PR TITLE
CRITICAL: DecentSampler: skip groups disabled with enabled="false"

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 19.0.1 (unreleased)
+
+* DecentSampler (thanks to Douglas Carmichael)
+  * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+
 ## 19.0.0
 
 * New: Added support for the Polyend Tracker (PTI) instrument format (thanks to Douglas Carmichael).

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -339,7 +339,7 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
 
             // Since we cannot support enabling deactivated groups in any way, simply skip them
             final String groupEnabled = groupElement.getAttribute (DecentSamplerTag.GROUP_ENABLED);
-            if (groupEnabled != null && "0".equals (groupEnabled))
+            if (groupEnabled != null && ("0".equals (groupEnabled) || "false".equalsIgnoreCase (groupEnabled)))
                 continue;
 
             final String k = groupElement.getAttribute (DecentSamplerTag.GROUP_NAME);


### PR DESCRIPTION
Marked critical since this ships in the just-released 19.0.0.

`DecentSamplerDetector.parseGroups` only skips a disabled group when the attribute is written as `enabled="0"`, but DecentSampler presets in the wild write `enabled="false"`.

Impact: kit-switcher libraries (each kit is a group, the preset UI enables exactly one of them via ENABLED bindings, all others carry `enabled="false"`) are converted with every kit included - all zones stacked on the same keys and playing simultaneously. Example: "80s hits SSS043" (Subsocial Studios) contains 23 kit groups with 1277 samples in total; the converted preset fires ~23 drum samples per note, sounds badly detuned/phasey and the output file is 348 MB instead of 5 MB.

The fix is one line: also treat `"false"` (case-insensitive) as disabled.

Verified with the kit above: the conversion now contains exactly the 40 zones of the single enabled group and the result was confirmed lossless and correctly mapped (Renoise destination, `flac -t` plus byte-compare of the decoded PCM against the source WAVs).