### PR TITLE
DecentSampler: add source option "Create one multi-sample per group"

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 19.0.1 (unreleased)
+
+* DecentSampler (thanks to Douglas Carmichael)
+  * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+
 ## 19.0.0
 
 * New: Added support for the Polyend Tracker (PTI) instrument format (thanks to Douglas Carmichael).

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 19.0.1 (unreleased)
 
 * DecentSampler (thanks to Douglas Carmichael)
+  * New: Added a source option "Create one multi-sample per group": creates a separate multi-sample for each group (disabled groups included), e.g. for presets which contain several alternative kits as groups and switch between them via their user interface.
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 
 ## 19.0.0

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -227,6 +227,7 @@ There are no metadata fields (category, creator, etc.) specified in the format. 
 
 ### Source Options
 
+* Create one multi-sample per group: Creates a separate multi-sample for each group instead of one multi-sample which contains all groups. Intended for presets which contain several alternative kits or articulations as groups and switch between them via their user interface (only one group is enabled at a time). Disabled groups are converted as well when this option is enabled; when it is off, only the enabled groups are converted.
 * Log unused XML elements and attributes: If enabled the XML elements and attributes which are not used in the translation process are logged.
 
 ### Destination Options

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -339,7 +339,7 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
 
             // Since we cannot support enabling deactivated groups in any way, simply skip them
             final String groupEnabled = groupElement.getAttribute (DecentSamplerTag.GROUP_ENABLED);
-            if (groupEnabled != null && "0".equals (groupEnabled))
+            if (groupEnabled != null && ("0".equals (groupEnabled) || "false".equalsIgnoreCase (groupEnabled)))
                 continue;
 
             final String k = groupElement.getAttribute (DecentSamplerTag.GROUP_NAME);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -254,6 +254,21 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
 
         final double globalTuningOffset = XMLUtils.getDoubleAttribute (groupsElement, DecentSamplerTag.GLOBAL_TUNING, 0);
         final List<IGroup> groups = this.parseGroups (topElement, groupsElement, basePath, isLibrary ? sourceFile : null, globalTuningOffset);
+
+        // Create one multi-sample per group, e.g. for presets which contain several alternative
+        // kits as groups and switch between them via their user interface
+        if (this.settingsConfiguration.isMultisamplePerGroup () && groups.size () > 1)
+        {
+            final List<IMultisampleSource> multisampleSources = new ArrayList<> (groups.size ());
+            for (final IGroup group: groups)
+            {
+                final IMultisampleSource multisampleSource = this.createMultisampleSource (sourceFile, presetName + " - " + group.getName (), Collections.singletonList (group));
+                parseEffects (topElement, multisampleSource);
+                multisampleSources.add (multisampleSource);
+            }
+            return multisampleSources;
+        }
+
         final IMultisampleSource multisampleSource = this.createMultisampleSource (sourceFile, presetName, groups);
         parseEffects (topElement, multisampleSource);
         return Collections.singletonList (multisampleSource);
@@ -337,10 +352,15 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
 
             this.checkAttributes (DecentSamplerTag.GROUP, groupElement.getAttributes (), DecentSamplerTag.getAttributes (DecentSamplerTag.GROUP));
 
-            // Since we cannot support enabling deactivated groups in any way, simply skip them
-            final String groupEnabled = groupElement.getAttribute (DecentSamplerTag.GROUP_ENABLED);
-            if (groupEnabled != null && ("0".equals (groupEnabled) || "false".equalsIgnoreCase (groupEnabled)))
-                continue;
+            // Since we cannot support enabling deactivated groups in any way, simply skip them.
+            // Except when each group becomes its own multi-sample: presets which contain several
+            // alternative kits as groups enable only one of them, but all kits are wanted then
+            if (!this.settingsConfiguration.isMultisamplePerGroup ())
+            {
+                final String groupEnabled = groupElement.getAttribute (DecentSamplerTag.GROUP_ENABLED);
+                if (groupEnabled != null && ("0".equals (groupEnabled) || "false".equalsIgnoreCase (groupEnabled)))
+                    continue;
+            }
 
             final String k = groupElement.getAttribute (DecentSamplerTag.GROUP_NAME);
             final String groupName = k == null || k.isBlank () ? "Group " + groupCounter : k;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetectorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetectorUI.java
@@ -26,9 +26,12 @@ import javafx.scene.layout.Pane;
 public class DecentSamplerDetectorUI extends MetadataSettingsUI
 {
     private static final String DECENT_SAMPLER_LOG_UNSUPPORTED_ATTRIBUTES = "DecentSamplerLogUnsupportedAttributes";
+    private static final String DECENT_SAMPLER_MULTISAMPLE_PER_GROUP      = "DecentSamplerMultisamplePerGroup";
 
     private CheckBox            logUnsupportedAttributesCheckBox;
     private boolean             logUnsupportedAttributes;
+    private CheckBox            multisamplePerGroupCheckBox;
+    private boolean             multisamplePerGroup;
 
 
     /**
@@ -53,6 +56,7 @@ public class DecentSamplerDetectorUI extends MetadataSettingsUI
 
         panel.createSeparator ("@IDS_DS_OPTIONS");
 
+        this.multisamplePerGroupCheckBox = panel.createCheckBox ("@IDS_DS_MULTISAMPLE_PER_GROUP", "@IDS_DS_MULTISAMPLE_PER_GROUP_TOOLTIP");
         this.logUnsupportedAttributesCheckBox = panel.createCheckBox ("@IDS_DS_LOG_UNSUPPORTED_ATTRIBUTES");
 
         // -----------------------------------------------------------
@@ -71,6 +75,7 @@ public class DecentSamplerDetectorUI extends MetadataSettingsUI
         super.saveSettings (config);
 
         config.setBoolean (DECENT_SAMPLER_LOG_UNSUPPORTED_ATTRIBUTES, this.logUnsupportedAttributesCheckBox.isSelected ());
+        config.setBoolean (DECENT_SAMPLER_MULTISAMPLE_PER_GROUP, this.multisamplePerGroupCheckBox.isSelected ());
     }
 
 
@@ -81,6 +86,7 @@ public class DecentSamplerDetectorUI extends MetadataSettingsUI
         super.loadSettings (config);
 
         this.logUnsupportedAttributesCheckBox.setSelected (config.getBoolean (DECENT_SAMPLER_LOG_UNSUPPORTED_ATTRIBUTES, false));
+        this.multisamplePerGroupCheckBox.setSelected (config.getBoolean (DECENT_SAMPLER_MULTISAMPLE_PER_GROUP, false));
     }
 
 
@@ -92,6 +98,7 @@ public class DecentSamplerDetectorUI extends MetadataSettingsUI
             return false;
 
         this.logUnsupportedAttributes = this.logUnsupportedAttributesCheckBox.isSelected ();
+        this.multisamplePerGroup = this.multisamplePerGroupCheckBox.isSelected ();
         return true;
     }
 
@@ -105,6 +112,9 @@ public class DecentSamplerDetectorUI extends MetadataSettingsUI
 
         final String value = parameters.remove (DECENT_SAMPLER_LOG_UNSUPPORTED_ATTRIBUTES);
         this.logUnsupportedAttributes = "1".equals (value);
+
+        final String multisamplePerGroupValue = parameters.remove (DECENT_SAMPLER_MULTISAMPLE_PER_GROUP);
+        this.multisamplePerGroup = "1".equals (multisamplePerGroupValue);
         return true;
     }
 
@@ -115,6 +125,7 @@ public class DecentSamplerDetectorUI extends MetadataSettingsUI
     {
         final List<String> parameterNames = new ArrayList<> (Arrays.asList (super.getCLIParameterNames ()));
         parameterNames.add (DECENT_SAMPLER_LOG_UNSUPPORTED_ATTRIBUTES);
+        parameterNames.add (DECENT_SAMPLER_MULTISAMPLE_PER_GROUP);
         return parameterNames.toArray (new String [parameterNames.size ()]);
     }
 
@@ -127,5 +138,16 @@ public class DecentSamplerDetectorUI extends MetadataSettingsUI
     public boolean logUnsupportedAttributes ()
     {
         return this.logUnsupportedAttributes;
+    }
+
+
+    /**
+     * Should a separate multi-sample be created for each group?
+     *
+     * @return True to create one multi-sample per group
+     */
+    public boolean isMultisamplePerGroup ()
+    {
+        return this.multisamplePerGroup;
     }
 }

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -175,6 +175,8 @@ IDS_DLS_FOUND_INSTRUMENT=Detected instrument '%1'.\n
 
 IDS_DS_UNKNOWN_TRIGGER=Unknown trigger type: %1\n
 IDS_DS_OPTIONS=Options
+IDS_DS_MULTISAMPLE_PER_GROUP=Create one multi-sample per group
+IDS_DS_MULTISAMPLE_PER_GROUP_TOOLTIP=Creates a separate multi-sample for each group instead of one multi-sample which contains all groups. Intended for presets which contain several alternative kits or articulations as groups and switch between them via their user interface. Disabled groups are converted as well when this option is enabled.
 IDS_DS_LOG_UNSUPPORTED_ATTRIBUTES=Log unused XML elements and attributes
 IDS_DS_COULD_NOT_CREATE_TEMPLATE_DIR=Could not create directory.
 IDS_DS_TEMPLATE_DIR_IS_FILE=Selected path is not a directory.


### PR DESCRIPTION
Stacked on #195 (contains its commit) - please merge that one first, this PR then reduces to a single commit.

Many DecentSampler libraries pack several alternative kits or articulations into one preset: each kit is a group, only one group is enabled and the preset UI switches between them by toggling the groups' ENABLED state. After #195 such a preset correctly converts to just the enabled kit - but the other kits become unreachable.

This adds an opt-in source option "Create one multi-sample per group" (CLI: `DecentSamplerMultisamplePerGroup=1`, off by default): every group becomes its own multi-sample named `<preset name> - <group name>`, and disabled groups are included as well in this mode, so every kit of such a preset ends up as its own preset. With the option off the behavior is unchanged.

Documented in README-FORMATS.md, CHANGELOG entry added.

Verified with "80s hits SSS043" (23 kit groups, 1277 samples): the option produces 23 presets whose zone counts add up to exactly 1277, each mapped and lossless; without the option the preset converts to the single enabled kit (40 zones) as before.