### PR TITLE
TAL Sampler / DecentSampler: fix boolean flags that were never honored

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * DecentSampler (thanks to Douglas Carmichael)
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+* TAL Sampler (thanks to Douglas Carmichael)
+  * Fixed: The sample "reverse" flag was never read as enabled: it is stored numerically (0/1) like all other TAL flags but was parsed as a true/false text boolean.
 
 ## 19.0.0
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 19.0.1 (unreleased)
+
+* DecentSampler (thanks to Douglas Carmichael)
+  * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+
 ## 19.0.0
 
 * New: Added support for the Polyend Tracker (PTI) instrument format (thanks to Douglas Carmichael).

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * DecentSampler (thanks to Douglas Carmichael)
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+  * Fixed: A loop which is explicitly disabled with loopEnabled="false" was still created when loop points were present; loops from the sample file chunks were imported as well in this case. Presets without the loopEnabled attribute are not affected.
 * TAL Sampler (thanks to Douglas Carmichael)
   * Fixed: The sample "reverse" flag was never read as enabled: it is stored numerically (0/1) like all other TAL flags but was parsed as a true/false text boolean.
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -469,8 +469,12 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
         final int loopEnd = (int) Math.round (XMLUtils.getDoubleAttribute (sampleElement, DecentSamplerTag.LOOP_END, -1));
         final int loopCrossfade = XMLUtils.getIntegerAttribute (sampleElement, DecentSamplerTag.LOOP_CROSSFADE, 0);
 
+        // An explicitly disabled loop also suppresses loops from the sample file chunks
+        final String loopEnabledAttribute = sampleElement.getAttribute (DecentSamplerTag.LOOP_ENABLED);
+        final boolean isLoopDisabled = "0".equals (loopEnabledAttribute) || "false".equalsIgnoreCase (loopEnabledAttribute);
+
         DefaultSampleLoop loop = null;
-        if (loopStart >= 0 || loopEnd > 0 || loopCrossfade > 0)
+        if (!isLoopDisabled && (loopStart >= 0 || loopEnd > 0 || loopCrossfade > 0))
         {
             loop = new DefaultSampleLoop ();
             loop.setStart (loopStart);
@@ -483,7 +487,7 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
         {
             final Optional<ISampleData> sampleData = sampleZone.getSampleData ();
             if (sampleData.isPresent ())
-                sampleData.get ().addZoneData (sampleZone, false, loop == null);
+                sampleData.get ().addZoneData (sampleZone, false, !isLoopDisabled && loop == null);
         }
         catch (final IOException ex)
         {

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -339,7 +339,7 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
 
             // Since we cannot support enabling deactivated groups in any way, simply skip them
             final String groupEnabled = groupElement.getAttribute (DecentSamplerTag.GROUP_ENABLED);
-            if (groupEnabled != null && "0".equals (groupEnabled))
+            if (groupEnabled != null && ("0".equals (groupEnabled) || "false".equalsIgnoreCase (groupEnabled)))
                 continue;
 
             final String k = groupElement.getAttribute (DecentSamplerTag.GROUP_NAME);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/tal/TALSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/tal/TALSamplerDetector.java
@@ -220,7 +220,8 @@ public class TALSamplerDetector extends AbstractDetector<MetadataSettingsUI>
 
         zone.setStart ((int) Math.round (XMLUtils.getDoubleAttribute (sampleElement, TALSamplerTag.START_SAMPLE, -1)));
         zone.setStop ((int) Math.round (XMLUtils.getDoubleAttribute (sampleElement, TALSamplerTag.END_SAMPLE, -1)));
-        zone.setReversed (XMLUtils.getBooleanAttribute (sampleElement, TALSamplerTag.REVERSE, false));
+        // The flag is stored numerically (0/1) like all other TAL flags
+        zone.setReversed (XMLUtils.getDoubleAttribute (sampleElement, TALSamplerTag.REVERSE, 0) > 0);
 
         final double layerTranspose = Math.round (XMLUtils.getDoubleAttribute (programElement, TALSamplerTag.LAYER_TRANSPOSE + TALSamplerConstants.LAYERS[groupCounter], 0.5) * 48.0 - 24.0);
         final double sampleTune = Math.round (XMLUtils.getDoubleAttribute (programElement, TALSamplerTag.SAMPLE_TUNE + TALSamplerConstants.LAYERS[groupCounter], 0.5) * 48.0 - 24.0);


### PR DESCRIPTION
Stacked on #195 (contains its commit) - once that one is merged this PR reduces to two commits.

Both fixes are of the same class as #195 and were found by auditing all detectors for boolean attributes which only accept one lexical form:

* **TAL Sampler**: the sample `reverse` flag is stored numerically (0/1) like all other TAL flags - the creator of this application writes it that way as well - but it was read with a true/false text parser (`Boolean.parseBoolean` via `XMLUtils.getBooleanAttribute`), which returns false for "1". Reverse playback was therefore always lost. It is now read numerically like the neighboring flags (e.g. `loopenabled`, `sampleenabled`).
* **DecentSampler**: the `loopEnabled` attribute was never read - a loop was created purely from the presence of loop points, so a loop which the preset explicitly disables with `loopEnabled="false"` was still audible after conversion. An explicitly disabled loop now suppresses the loop points and the loop markers from the sample file chunks as well. Presets without the attribute behave exactly as before (verified: a test preset with two zones converts to loop_mode=no_loop for the disabled one and an unchanged loop_continuous with the original loop points for the other).

Related: #197 documents the same pattern for the Kontakt 5+ group mute/solo state, left as a design question.