### PR TITLE
Synthstrom Deluge: kit consolidation + natural-pitch fix

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Synthstrom Deluge (thanks to Douglas Carmichael)
   * New: Added an Output Type creator option (Synth/Kit, CLI DelugeOutputType) to write a drum kit instead of a synth (sound) preset. A kit writes one drum per note, consolidating velocity layers and round-robins to the loudest layer (a Deluge drum is a single sample). The type is chosen explicitly because a one-sample-per-note layout is not necessarily a kit (e.g. a per-note synth bass).
+  * New: Added a "Consolidate kit" option (CLI DelugeConsolidateKit) which reduces a drum kit to one drum per type (kick, snare, hi-hat, ...) ordered by drum role following the factory TR-808 layout (kick on the lowest row), so a beat can be programmed without switching rows. The consolidated drums are labelled by their role for a clean read-out on the device.
+  * Fixed: Kit drums were pitched by their keyboard mapping note, so a drum mapped to e.g. note 35 played 25 semitones too low (audible on toms). Kit drums now play at their natural pitch (transpose 0), like the factory kits; only an explicit detune is kept.
 * DecentSampler (thanks to Douglas Carmichael)
   * New: Added a source option "Create one multi-sample per group": creates a separate multi-sample for each group (disabled groups included), e.g. for presets which contain several alternative kits as groups and switch between them via their user interface.
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -690,6 +690,7 @@ The Deluge has no loop cross-fade parameter of its own, so - exactly like the Re
 ### Destination Options
 
 * Output Type: Choose whether to write a *Synth (Sound)* preset (the default) or a *Drum Kit*. A kit writes one drum per sample; use it for drum/percussion sets. CLI: `DelugeOutputType=kit` (or `sound`).
+* Consolidate kit (one drum per type): For a *Drum Kit*, reduce the kit to a single drum per recognized type (kick, snare, hi-hat, tom, ...) and order the drums by drum role - kick on the lowest row - following the factory TR-808 layout, so a beat can be programmed without switching rows. Several drums of the same type are reduced to the first; unrecognized drums are all kept and appended at the end. Each consolidated drum is labelled by its role (Kick, Snare, Hat Closed, ...) for a clean read-out on the device, while the sample files keep their original names. CLI: `DelugeConsolidateKit=1`.
 * Options to write/update [WAV Chunk Information](#wav-chunk-information).
 
 ### Limitations

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -105,6 +106,16 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
             return;
         }
 
+        // Consolidate a kit to one drum per type (kick, snare, hat, ...), ordered by drum role
+        // so the essential drums sit on the lowest rows for beat programming without scrolling
+        if (createKit && this.settingsConfiguration.isConsolidateKit ())
+        {
+            final List<ISampleZone> compact = consolidateByRole (zones);
+            this.notifier.log ("IDS_DELUGE_KIT_CONSOLIDATED", Integer.toString (zones.size ()), Integer.toString (compact.size ()));
+            zones.clear ();
+            zones.addAll (compact);
+        }
+
         // A kit holds at most one drum per note (36 up to 127); drop the surplus and say so
         if (createKit && zones.size () > MAX_KIT_DRUMS)
         {
@@ -155,7 +166,7 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
         this.writeSamples (sampleFolder, createTemporarySource (multisampleSource, zones));
 
         // Create and store the XML document referencing the samples by their card-relative path
-        final Optional<String> metadata = createKit ? this.createKitDocument (zones, relativeSampleFolder) : this.createSoundDocument (zones, relativeSampleFolder);
+        final Optional<String> metadata = createKit ? this.createKitDocument (zones, relativeSampleFolder, this.settingsConfiguration.isConsolidateKit ()) : this.createSoundDocument (zones, relativeSampleFolder);
         if (metadata.isEmpty ())
             return;
         try (final FileWriter writer = new FileWriter (presetFile, StandardCharsets.UTF_8))
@@ -217,6 +228,174 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
             lastKeyHigh = keyHigh;
         }
         return result;
+    }
+
+
+    /**
+     * The role of a drum in a kit. The declaration order is the order in which the drums are
+     * written, i.e. the row order on the device (kick on the lowest row), following the layout
+     * of the factory TR-808 kit.
+     */
+    private enum DrumRole
+    {
+        KICK, SNARE, TOM, HAT_CLOSED, HAT_OPEN, CLAP, RIM, COWBELL, CLAVE, CONGA, BONGO, TIMBALE, MARACA, SHAKER, CABASA, TAMBOURINE, GUIRO, TRIANGLE, BLOCK, BELL, CRASH, SPLASH, CHINA, RIDE, CYMBAL
+    }
+
+
+    /**
+     * Get the human-readable label for a drum role, used as the drum name on the device.
+     *
+     * @param role The role
+     * @return The label
+     */
+    private static String roleLabel (final DrumRole role)
+    {
+        return switch (role)
+        {
+            case KICK -> "Kick";
+            case SNARE -> "Snare";
+            case TOM -> "Tom";
+            case HAT_CLOSED -> "Hat Closed";
+            case HAT_OPEN -> "Hat Open";
+            case CLAP -> "Clap";
+            case RIM -> "Rim";
+            case COWBELL -> "Cowbell";
+            case CLAVE -> "Clave";
+            case CONGA -> "Conga";
+            case BONGO -> "Bongo";
+            case TIMBALE -> "Timbale";
+            case MARACA -> "Maraca";
+            case SHAKER -> "Shaker";
+            case CABASA -> "Cabasa";
+            case TAMBOURINE -> "Tambourine";
+            case GUIRO -> "Guiro";
+            case TRIANGLE -> "Triangle";
+            case BLOCK -> "Wood Block";
+            case BELL -> "Bell";
+            case CRASH -> "Crash";
+            case SPLASH -> "Splash";
+            case CHINA -> "China";
+            case RIDE -> "Ride";
+            case CYMBAL -> "Cymbal";
+        };
+    }
+
+
+    /**
+     * Consolidate the drums of a kit to one per recognized type, ordered by drum role. Several
+     * drums of the same type (e.g. three kicks, five toms) are reduced to the first one; drums
+     * whose type is not recognized are all kept and appended in their original order.
+     *
+     * @param zones The drum zones (already one per note)
+     * @return The consolidated, role-ordered zones
+     */
+    private static List<ISampleZone> consolidateByRole (final List<ISampleZone> zones)
+    {
+        final EnumMap<DrumRole, ISampleZone> byRole = new EnumMap<> (DrumRole.class);
+        final List<ISampleZone> others = new ArrayList<> ();
+        for (final ISampleZone zone: zones)
+        {
+            final DrumRole role = classifyDrum (zone.getName ());
+            if (role == null)
+                others.add (zone);
+            else
+                byRole.putIfAbsent (role, zone);
+        }
+
+        final List<ISampleZone> result = new ArrayList<> (byRole.size () + others.size ());
+        result.addAll (byRole.values ());
+        result.addAll (others);
+        return result;
+    }
+
+
+    /**
+     * Classify a drum by its name into a role. Handles full names (kick, snare, tom, ...), the
+     * numbered variants many kits use (kic2, sna3) and the four-character truncations the Deluge
+     * factory kits store (e.g. cras, cowb, tamb, shak, bloc, caba, tria, spla, chin). Names that
+     * cannot be identified return null and are kept as-is.
+     *
+     * @param name The drum/zone name
+     * @return The role or null if the name is not recognized
+     */
+    private static DrumRole classifyDrum (final String name)
+    {
+        final String n = name.toLowerCase (Locale.ENGLISH);
+
+        // Kick (kick, kic2..kic5, bass drum). A bare "bass" is intentionally not matched since it
+        // is more likely a melodic bass hit than a bass drum
+        if (n.contains ("kick") || n.contains ("kic") || n.contains ("bassdrum") || n.contains ("bass drum"))
+            return DrumRole.KICK;
+        // Clap / finger snap (checked before snare so "snap" is not read as a snare)
+        if (n.contains ("clap") || n.contains ("snap") || n.contains ("hclap"))
+            return DrumRole.CLAP;
+        // Snare (snare, snar, sna2..sna5)
+        if (n.contains ("snar") || n.contains ("sna") || n.contains ("snr"))
+            return DrumRole.SNARE;
+        // Hi-hat (hatc, hato, hat2, hh) - open or closed
+        if (n.contains ("hat") || n.contains ("hihat") || n.contains ("hi-hat") || n.contains ("hh"))
+            return isOpenHat (n) ? DrumRole.HAT_OPEN : DrumRole.HAT_CLOSED;
+        // Rim / side stick
+        if (n.contains ("rim") || n.contains ("sidestick") || n.contains ("side stick") || n.contains ("xstick") || n.contains ("cross stick"))
+            return DrumRole.RIM;
+        // Tom (toml, tomm, tomh, tomt, tomb)
+        if (n.contains ("tom"))
+            return DrumRole.TOM;
+        // Timbale (timl, timh)
+        if (n.contains ("timbale") || n.contains ("timb") || n.contains ("timl") || n.contains ("timh"))
+            return DrumRole.TIMBALE;
+        // Conga (conl, conm, conh)
+        if (n.contains ("conga") || n.contains ("cong") || n.contains ("conl") || n.contains ("conm") || n.contains ("conh"))
+            return DrumRole.CONGA;
+        if (n.contains ("bongo") || n.contains ("bong"))
+            return DrumRole.BONGO;
+        // Cowbell (before bell)
+        if (n.contains ("cowbell") || n.contains ("cowb") || n.contains ("cow bell"))
+            return DrumRole.COWBELL;
+        if (n.contains ("clave") || n.contains ("clav"))
+            return DrumRole.CLAVE;
+        if (n.contains ("maraca") || n.contains ("marac"))
+            return DrumRole.MARACA;
+        if (n.contains ("shaker") || n.contains ("shake") || n.contains ("shak"))
+            return DrumRole.SHAKER;
+        if (n.contains ("cabasa") || n.contains ("caba"))
+            return DrumRole.CABASA;
+        if (n.contains ("tambourine") || n.contains ("tambo") || n.contains ("tamb"))
+            return DrumRole.TAMBOURINE;
+        if (n.contains ("guiro") || n.contains ("guir"))
+            return DrumRole.GUIRO;
+        if (n.contains ("triangle") || n.contains ("tria") || n.contains ("trng"))
+            return DrumRole.TRIANGLE;
+        // Wood block
+        if (n.contains ("woodblock") || n.contains ("wood block") || n.contains ("block") || n.contains ("bloc") || n.contains ("wood") || n.contains ("wdblk"))
+            return DrumRole.BLOCK;
+        // Bell / chime (after cowbell)
+        if (n.contains ("bell") || n.contains ("chime") || n.contains ("chim"))
+            return DrumRole.BELL;
+        // Cymbals - specific ones before the generic cymbal
+        if (n.contains ("crash") || n.contains ("cras"))
+            return DrumRole.CRASH;
+        if (n.contains ("splash") || n.contains ("spla"))
+            return DrumRole.SPLASH;
+        if (n.contains ("china") || n.contains ("chin"))
+            return DrumRole.CHINA;
+        if (n.contains ("ride"))
+            return DrumRole.RIDE;
+        if (n.contains ("cymbal") || n.contains ("cymb") || n.contains ("cym"))
+            return DrumRole.CYMBAL;
+        return null;
+    }
+
+
+    /**
+     * Determine whether a hi-hat name denotes an open hi-hat (as opposed to a closed one).
+     *
+     * @param lowerCaseName The already lower-cased name
+     * @return True for an open hi-hat
+     */
+    private static boolean isOpenHat (final String lowerCaseName)
+    {
+        return lowerCaseName.contains ("open") || lowerCaseName.contains ("hato") || lowerCaseName.contains (" oh") || lowerCaseName.contains ("ohh") || lowerCaseName.endsWith (" o") || lowerCaseName.contains (" o ");
     }
 
 
@@ -288,7 +467,7 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
         soundElement.setAttribute (DelugeTag.FIRMWARE_VERSION, DelugeTag.FIRMWARE_VERSION_VALUE);
         soundElement.setAttribute (DelugeTag.EARLIEST_COMPATIBLE_FIRMWARE, DelugeTag.EARLIEST_COMPATIBLE_VALUE);
 
-        writeSound (document, soundElement, zones, relativeSampleFolder);
+        writeSound (document, soundElement, zones, relativeSampleFolder, false);
 
         return this.createXMLString (document);
     }
@@ -303,7 +482,7 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
      * @param relativeSampleFolder The card-relative path of the sample folder
      * @return The XML document as a string
      */
-    private Optional<String> createKitDocument (final List<ISampleZone> zones, final String relativeSampleFolder)
+    private Optional<String> createKitDocument (final List<ISampleZone> zones, final String relativeSampleFolder, final boolean useRoleLabels)
     {
         final Optional<Document> optionalDocument = this.createXMLDocument ();
         if (optionalDocument.isEmpty ())
@@ -324,8 +503,13 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
         for (final ISampleZone zone: zones)
         {
             final Element drumSound = XMLUtils.addElement (document, soundSources, DelugeTag.SOUND);
-            XMLUtils.addTextElement (document, drumSound, DelugeTag.NAME, createSafeFilename (zone.getName ()));
-            writeSound (document, drumSound, Collections.singletonList (zone), relativeSampleFolder);
+            // When consolidating, label each drum by its role (Kick, Snare, ...) for a clean
+            // read-out on the device; the sample file keeps its original name. Unrecognized
+            // drums and non-consolidated kits keep their sample-derived name.
+            final DrumRole role = useRoleLabels ? classifyDrum (zone.getName ()) : null;
+            final String drumName = role == null ? createSafeFilename (zone.getName ()) : roleLabel (role);
+            XMLUtils.addTextElement (document, drumSound, DelugeTag.NAME, drumName);
+            writeSound (document, drumSound, Collections.singletonList (zone), relativeSampleFolder, true);
         }
 
         return this.createXMLString (document);
@@ -342,7 +526,7 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
      *            a drum)
      * @param relativeSampleFolder The card-relative path of the sample folder
      */
-    private static void writeSound (final Document document, final Element soundElement, final List<ISampleZone> zones, final String relativeSampleFolder)
+    private static void writeSound (final Document document, final Element soundElement, final List<ISampleZone> zones, final String relativeSampleFolder, final boolean isKit)
     {
         final boolean anyLoop = zones.stream ().anyMatch (zone -> !zone.getLoops ().isEmpty ());
         final boolean reversed = zones.stream ().anyMatch (ISampleZone::isReversed);
@@ -356,7 +540,7 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
         XMLUtils.addTextElement (document, osc1, DelugeTag.TIME_STRETCH_AMOUNT, "0");
 
         if (zones.size () == 1)
-            writeZone (document, osc1, zones.get (0), relativeSampleFolder, -1);
+            writeZone (document, osc1, zones.get (0), relativeSampleFolder, -1, isKit);
         else
         {
             final Element sampleRanges = XMLUtils.addElement (document, osc1, DelugeTag.SAMPLE_RANGES);
@@ -365,7 +549,7 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
                 final Element sampleRange = XMLUtils.addElement (document, sampleRanges, DelugeTag.SAMPLE_RANGE);
                 // The last (highest) range does not store the top note - it covers everything above
                 final int topNote = i == zones.size () - 1 ? -1 : limitToDefault (zones.get (i).getKeyHigh (), 127);
-                writeZone (document, sampleRange, zones.get (i), relativeSampleFolder, topNote);
+                writeZone (document, sampleRange, zones.get (i), relativeSampleFolder, topNote, isKit);
             }
         }
 
@@ -425,14 +609,18 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
      * @param relativeSampleFolder The card-relative path of the sample folder
      * @param topNote The top note of the range or -1 if it should not be written
      */
-    private static void writeZone (final Document document, final Element parent, final ISampleZone zone, final String relativeSampleFolder, final int topNote)
+    private static void writeZone (final Document document, final Element parent, final ISampleZone zone, final String relativeSampleFolder, final int topNote, final boolean isKit)
     {
         if (topNote >= 0)
             XMLUtils.addTextElement (document, parent, DelugeTag.RANGE_TOP_NOTE, Integer.toString (topNote));
 
         XMLUtils.addTextElement (document, parent, DelugeTag.FILE_NAME, relativeSampleFolder + "/" + createSafeFilename (zone.getName ()) + ".wav");
 
-        final double rootNote = (zone.getKeyRoot () < 0 ? limitToDefault (zone.getKeyHigh (), DelugeValues.REFERENCE_NOTE) : zone.getKeyRoot ()) + zone.getTuning ();
+        // A synth maps the sample across the keyboard, so its transpose follows the root note. A
+        // kit drum is triggered by its own pad and must play at its natural pitch (like the
+        // factory kits, which use transpose 0), so the keyboard mapping note is ignored and only
+        // an explicit detune is kept
+        final double rootNote = isKit ? DelugeValues.REFERENCE_NOTE + zone.getTuning () : (zone.getKeyRoot () < 0 ? limitToDefault (zone.getKeyHigh (), DelugeValues.REFERENCE_NOTE) : zone.getKeyRoot ()) + zone.getTuning ();
         final int [] transposeCents = DelugeValues.transposeCentsFromRootNote (rootNote);
         XMLUtils.addTextElement (document, parent, DelugeTag.TRANSPOSE_OSC, Integer.toString (transposeCents[0]));
         XMLUtils.addTextElement (document, parent, DelugeTag.CENTS, Integer.toString (transposeCents[1]));

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreatorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreatorUI.java
@@ -15,6 +15,7 @@ import de.mossgrabers.tools.ui.BasicConfig;
 import de.mossgrabers.tools.ui.Functions;
 import de.mossgrabers.tools.ui.panel.BoxPanel;
 import javafx.geometry.Orientation;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.layout.Pane;
 
@@ -37,10 +38,13 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
     }
 
 
-    private static final String OUTPUT_TYPE = "OutputType";
+    private static final String OUTPUT_TYPE     = "OutputType";
+    private static final String CONSOLIDATE_KIT = "ConsolidateKit";
 
     private ComboBox<String>    outputTypeBox;
-    private OutputType          outputType  = OutputType.SOUND;
+    private CheckBox            consolidateKitBox;
+    private OutputType          outputType      = OutputType.SOUND;
+    private boolean             consolidateKit;
 
 
     /**
@@ -65,6 +69,7 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
         this.outputTypeBox.getItems ().addAll (Functions.getText ("@IDS_DELUGE_TYPE_SOUND"), Functions.getText ("@IDS_DELUGE_TYPE_KIT"));
         this.outputTypeBox.setMaxWidth (Double.MAX_VALUE);
         panel.addComponent (this.outputTypeBox);
+        this.consolidateKitBox = panel.createCheckBox ("@IDS_DELUGE_CONSOLIDATE_KIT", "@IDS_DELUGE_CONSOLIDATE_KIT_TOOLTIP");
 
         this.addWavChunkOptions (panel).getStyleClass ().add ("titled-separator-pane");
         return panel.getPane ();
@@ -76,6 +81,7 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
     public void loadSettings (final BasicConfig config)
     {
         this.outputTypeBox.getSelectionModel ().select (config.getInteger (this.prefix + OUTPUT_TYPE, 0));
+        this.consolidateKitBox.setSelected (config.getBoolean (this.prefix + CONSOLIDATE_KIT, false));
 
         super.loadSettings (config);
     }
@@ -86,6 +92,7 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
     public void saveSettings (final BasicConfig config)
     {
         config.setInteger (this.prefix + OUTPUT_TYPE, this.outputTypeBox.getSelectionModel ().getSelectedIndex ());
+        config.setBoolean (this.prefix + CONSOLIDATE_KIT, this.consolidateKitBox.isSelected ());
 
         super.saveSettings (config);
     }
@@ -99,6 +106,7 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
             return false;
 
         this.outputType = indexToType (this.outputTypeBox.getSelectionModel ().getSelectedIndex ());
+        this.consolidateKit = this.consolidateKitBox.isSelected ();
         return true;
     }
 
@@ -111,6 +119,7 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
             return false;
 
         this.outputType = parseType (parameters.remove (this.prefix + OUTPUT_TYPE));
+        this.consolidateKit = "1".equals (parameters.remove (this.prefix + CONSOLIDATE_KIT));
         return true;
     }
 
@@ -121,6 +130,7 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
     {
         final List<String> parameterNames = new ArrayList<> (Arrays.asList (super.getCLIParameterNames ()));
         parameterNames.add (this.prefix + OUTPUT_TYPE);
+        parameterNames.add (this.prefix + CONSOLIDATE_KIT);
         return parameterNames.toArray (new String [parameterNames.size ()]);
     }
 
@@ -133,6 +143,17 @@ public class DelugeCreatorUI extends WavChunkSettingsUI
     public OutputType getOutputType ()
     {
         return this.outputType;
+    }
+
+
+    /**
+     * Should a drum kit be consolidated to one drum per type, ordered by drum role?
+     *
+     * @return True to consolidate
+     */
+    public boolean isConsolidateKit ()
+    {
+        return this.consolidateKit;
     }
 
 

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -190,6 +190,9 @@ IDS_DELUGE_TYPE_KIT=Drum (Kit)
 IDS_DELUGE_CREATE_KIT=Create a drum kit
 IDS_DELUGE_CREATE_KIT_TOOLTIP=Write a drum kit (one drum per sample) instead of a synth sound preset.
 IDS_DELUGE_KIT_TOO_MANY_DRUMS=The kit has %1 drums but only %2 fit (one per note); the surplus drums are dropped.\n
+IDS_DELUGE_CONSOLIDATE_KIT=Consolidate kit (one drum per type)
+IDS_DELUGE_CONSOLIDATE_KIT_TOOLTIP=Reduce a drum kit to one drum per type (kick, snare, hi-hat, ...) and order them by drum role (kick on the lowest row), following the factory TR-808 layout. Intended for large kits so a beat can be programmed without switching rows.
+IDS_DELUGE_KIT_CONSOLIDATED=Consolidated the kit from %1 to %2 drums (one per type).\n
 IDS_DELUGE_NOT_A_DELUGE_FILE=This is not a Deluge KIT or SOUND file.\n
 IDS_DELUGE_NO_SAMPLE_REFS=The file does not references any samples.\n
 


### PR DESCRIPTION
Stacked on #200 (drum-kit output) - please merge that first; this PR then reduces to a single commit.

A prototype for compacting large drum kits into a Deluge-friendly layout. Opt-in (CLI `DelugeConsolidateKit=1`, off by default), only meaningful when Output Type = Kit.

What it does:
* Reduces the kit to one drum per recognized type (several kicks/snares/toms collapse to the first).
* Orders the drums by drum role - kick on the lowest row - following the factory **TR-808** layout, so kick/snare/tom/hats sit on the lowest rows and a beat can be programmed without scrolling through rows.
* Unrecognized drums are all kept and appended after the recognized ones (nothing is silently dropped; a summary is logged).

The classifier recognizes drum types from the name, handling full names, numbered variants (`kic2`, `sna3`) and the four-character truncations the Deluge factory kits store (`cras`, `cowb`, `tamb`, `shak`, `bloc`, `caba`, `tria`, `spla`, `chin`, `timl`/`timh`, ...). I surveyed the drum-name vocabulary across all 43 factory kits on a card to build it, so it is not 808-specific.

Validated by converting a 40-drum DecentSampler kit (-> 15 drums) and by round-tripping the factory R-50 kit through the detector (19 -> 16 drums, correctly classified and role-ordered).

This is explicitly a **prototype for feedback** - the drum-role order and the type vocabulary are easy to tune. Documented in README-FORMATS.md, CHANGELOG entry added.