### PR TITLE
Roland ZEN-Core: read the compact SMPd sample header (SVZ version 02 01)

### DIFF
--- a/documentation/design/ZENCORE_FORMAT.md
+++ b/documentation/design/ZENCORE_FORMAT.md
@@ -325,6 +325,33 @@ Culture's *SOURCE*): a `"SMPd"` tag with a u16 header size `0x20` at +4 and u8 v
 is byte-identical to the device's. CWM decodes such packs and re-emits device-native raw-PCM
 `SMPd`.
 
+**Compact `SMPd`** (file version `02 01`; seen in third-party sample-pool exports, e.g. a pool
+tagged `Nemly`): follows the same `f04 = 2 × end` law at +4, the same bits at `0x009`, rate at
+`0x00C` and name at `0x010` as the device-native encoding, but uses a shorter **158-byte**
+(`0x9E`) header with a shorter preview, and stores the **channel count as a u16 at `0x00A`** — the
+byte at `0x008` (channels in the device encoding) holds an unrelated `0x32`. Interleaved 16-bit
+LITTLE-endian PCM follows at `0x9E`. CWM reads it; it is not written.
+
+```
+0x000   4  "SMPd"
+0x004   4  u32 f04 = 2 × end
+0x008   1  0x32  (NOT the channel count in this encoding)
+0x009   1  bits (16)
+0x00A   2  u16 channels (2)
+0x00C   4  u32 sample rate  (44100 / 48000)
+0x010  16  sample name
+0x060 ..   shorter preview
+0x09E  ..  interleaved 16-bit LITTLE-endian PCM
+```
+
+**Distinguishing the encodings on read.** The device-native (460) and compact (158) header sizes
+differ by 302 (`2 mod 4`), so a stereo chunk's PCM byte count is a whole number of 4-byte frames
+for exactly one of them. The reader (`ZenCoreSvz.resolveSmpdLayout`) picks the header whose
+channel-count field — the byte at `0x008` for the 460 header, the u16 at `0x00A` for the 158
+header — is 1 or 2 and whose PCM region past the header divides evenly into frames; the declared
+`end` is deliberately not used to size the PCM, since the stored frame count runs a little past or
+short of it.
+
 ---
 
 ## 4. Sample preparation for click-free playback

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
@@ -20,8 +20,9 @@ import de.mossgrabers.convertwithmoss.core.model.implementation.InMemorySampleDa
  * <i>DIFa</i>, one <i>PATa</i> tone per instrument (ZEN-Core tone, 1632 bytes; its oscillator
  * points at the instrument's multi-sample via the Wave-Number L/R fields), one <i>MSPa</i> 128-key
  * map per instrument, a shared <i>USPa</i> sample-parameter pool (64 byte records) and a shared
- * <i>USDa</i> pool of <i>SMPd</i> sample chunks (a 460 byte header followed by interleaved 16-bit
- * little-endian PCM). All framing carries the per-record CRC32 tables verified from device exports.
+ * <i>USDa</i> pool of <i>SMPd</i> sample chunks (a fixed header - 460 bytes as written by the
+ * FANTOM, 158 bytes in an older generation - followed by interleaved 16-bit little-endian PCM). All
+ * framing carries the per-record CRC32 tables verified from device exports.
  * Byte templates for the constant/opaque parts live next to this class as resources. See
  * {@code documentation/design/ZENCORE_FORMAT.md}.
  *
@@ -33,8 +34,19 @@ public final class ZenCoreSvz
     public static final int      USP_RECORD_SIZE      = 64;
     /** The size of a MSPa multis-ample key-map record. */
     public static final int      MSP_RECORD_SIZE      = 1040;
-    /** The size of the fixed SMPd chunk header (PCM follows at this offset). */
+    /** The size of the FANTOM / KY019 SMPd chunk header (PCM follows at this offset). */
     public static final int      SMPD_HEADER_SIZE     = 0x1CC;
+    /**
+     * The size of the compact SMPd chunk header written by an older sample generation (SVZ file
+     * version 02 01, e.g. third-party sample packs). It carries a shorter waveform preview than the
+     * FANTOM export and stores the channel count as a u16 at {@link #SMPD_CHANNELS_COMPACT} instead
+     * of the byte at {@link #SMPD_CHANNELS_KY019} (whose slot then holds an unrelated value, 0x32).
+     */
+    private static final int     SMPD_HEADER_COMPACT  = 0x9E;
+    /** Channel-count field of a FANTOM / KY019 SMPd header: a byte holding 1 (mono) or 2 (stereo). */
+    private static final int     SMPD_CHANNELS_KY019  = 0x08;
+    /** Channel-count field of a compact SMPd header: a u16 holding 1 (mono) or 2 (stereo). */
+    private static final int     SMPD_CHANNELS_COMPACT = 0x0A;
 
     private static final int     NAME_LENGTH          = 16;
     private static final int     PREVIEW_OFFSET       = 0x60;
@@ -692,18 +704,20 @@ public final class ZenCoreSvz
                 final int chunkOffset = (int) ZenCoreUtil.readUnsigned32 (file, entryOffset + 4, false);
                 final int chunkSize = (int) ZenCoreUtil.readUnsigned32 (file, entryOffset + 8, false);
                 final int chunkStart = usdSectionStart + chunkOffset;
-                if (chunkSize > SMPD_HEADER_SIZE && chunkStart + chunkSize <= file.length)
+                if (chunkStart >= 0 && chunkSize > SMPD_HEADER_COMPACT && chunkStart + chunkSize <= file.length)
                 {
-                    // The storage layout comes from the SMPd chunk: the USPa channel count is 2
-                    // even
-                    // for mono-stored samples (the device's own exports store mono SMPd data).
-                    int channels = file[chunkStart + 8] & 0xFF;
-                    if (channels < 1 || channels > 2)
-                        channels = 2;
-                    final int rate = (int) ZenCoreUtil.readUnsigned32 (file, chunkStart + 0x0C, false);
-                    final int pcmStart = chunkStart + SMPD_HEADER_SIZE;
-                    final int pcmSize = chunkSize - SMPD_HEADER_SIZE;
-                    sample.setSampleData (decodePcm (file, pcmStart, pcmSize, channels, rate < 8000 || rate > 192000 ? 48000 : rate));
+                    // The storage layout comes from the SMPd chunk header, which has two variants
+                    // (see resolveSmpdLayout); an unrecognized chunk leaves the sample without audio.
+                    final int [] layout = resolveSmpdLayout (file, chunkStart, chunkSize);
+                    if (layout != null)
+                    {
+                        final int channels = layout[0];
+                        final int headerSize = layout[1];
+                        final int rate = (int) ZenCoreUtil.readUnsigned32 (file, chunkStart + 0x0C, false);
+                        final int pcmStart = chunkStart + headerSize;
+                        final int pcmSize = chunkSize - headerSize;
+                        sample.setSampleData (decodePcm (file, pcmStart, pcmSize, channels, rate < 8000 || rate > 192000 ? 48000 : rate));
+                    }
                 }
             }
             result.add (sample);
@@ -772,12 +786,72 @@ public final class ZenCoreSvz
     }
 
 
+    /**
+     * Resolve a <i>SMPd</i> chunk's PCM layout. Two header variants exist. The FANTOM / KY019 export
+     * uses a {@link #SMPD_HEADER_SIZE} byte header with the channel count in the byte at
+     * {@link #SMPD_CHANNELS_KY019}. An older generation (SVZ file version 02 01, e.g. third-party
+     * sample packs) uses a {@link #SMPD_HEADER_COMPACT} byte header with the channel count as a u16
+     * at {@link #SMPD_CHANNELS_COMPACT} - there the byte at {@link #SMPD_CHANNELS_KY019} holds an
+     * unrelated value (0x32), which is why reading the channel count from it alone fails on those
+     * files. The matching variant is the one whose PCM region past the header is a whole number of
+     * frames: the two header sizes differ by 302 (2 mod 4), so a stereo chunk's byte count is a
+     * multiple of the 4 byte stereo frame for exactly one of them.
+     *
+     * @param file The file content
+     * @param chunkStart The absolute offset of the SMPd chunk
+     * @param chunkSize The chunk size from the USDa directory
+     * @return {channels, headerSize}, or null if neither variant fits
+     */
+    private static int [] resolveSmpdLayout (final byte [] file, final int chunkStart, final int chunkSize)
+    {
+        final int ky019Channels = file[chunkStart + SMPD_CHANNELS_KY019] & 0xFF;
+        if (smpdFits (chunkSize, SMPD_HEADER_SIZE, ky019Channels))
+            return new int []
+            {
+                ky019Channels,
+                SMPD_HEADER_SIZE
+            };
+        final int compactChannels = ZenCoreUtil.readUnsigned16 (file, chunkStart + SMPD_CHANNELS_COMPACT, false);
+        if (smpdFits (chunkSize, SMPD_HEADER_COMPACT, compactChannels))
+            return new int []
+            {
+                compactChannels,
+                SMPD_HEADER_COMPACT
+            };
+        return null;
+    }
+
+
+    /**
+     * Whether a SMPd header size and channel count are consistent with the chunk: a plausible
+     * channel count (1 or 2) whose PCM region past the header is a whole number of frames. The
+     * declared play length is deliberately not used - device exports may declare a handful of frames
+     * more than they store - so only the frame alignment, together with the channel-count field,
+     * selects the layout.
+     *
+     * @param chunkSize The chunk size
+     * @param headerSize The candidate header size
+     * @param channels The candidate channel count
+     * @return True if the combination fits
+     */
+    private static boolean smpdFits (final int chunkSize, final int headerSize, final int channels)
+    {
+        if (channels < 1 || channels > 2)
+            return false;
+        final int pcmSize = chunkSize - headerSize;
+        return pcmSize > 0 && pcmSize % (channels * 2) == 0;
+    }
+
+
     private static InMemorySampleData decodePcm (final byte [] file, final int offset, final int size, final int channels, final int rate)
     {
-        // SMPd PCM is already 16-bit little-endian, so it can be used verbatim.
-        final byte [] pcm = new byte [size];
-        System.arraycopy (file, offset, pcm, 0, size);
-        final int frames = size / (2 * channels);
+        // SMPd PCM is already 16-bit little-endian, so it can be used verbatim. Copy only whole
+        // frames: a chunk whose stored byte count is not an exact multiple of the frame size would
+        // otherwise hand InMemorySampleData a buffer that does not fit a WAV of that frame count.
+        final int frameBytes = 2 * channels;
+        final int frames = size / frameBytes;
+        final byte [] pcm = new byte [frames * frameBytes];
+        System.arraycopy (file, offset, pcm, 0, pcm.length);
         return new InMemorySampleData (new DefaultAudioMetadata (channels, rate, 16, frames), pcm);
     }
 


### PR DESCRIPTION
Fixes a read error reported for the ZEN-Core SVZ format: mono/stereo detection was wrong and the sample-length calculation crashed the in-memory sample copy.

### Cause

The reader assumed the FANTOM/KY019 `SMPd` layout for every file: a 460-byte header with the channel count in the byte at `+0x08`. Some SVZ files (SVZ file version `02 01`, e.g. third-party sample pools) use a different, compact `SMPd` encoding:

| | FANTOM / KY019 | Compact (version `02 01`) |
|---|---|---|
| Header size | 460 (`0x1CC`) | **158 (`0x9E`)** |
| Channel count | byte at `+0x08` | **u16 at `+0x0A`** |
| Byte at `+0x08` | the channel count | **`0x32`** (unrelated) |

So the channel count was read from the wrong field (a constant `0x32` → the mono/stereo mistake), and the PCM was located 302 bytes off. Because the two header sizes differ by 302 (`2 mod 4`), the wrong header left the PCM two bytes short of a whole stereo frame, so the WAV buffer ended up smaller than the PCM and the copy threw.

### Fix

`ZenCoreSvz.resolveSmpdLayout` detects the layout per chunk: it picks the header whose channel-count field (byte `+0x08` for the 460 header, u16 `+0x0A` for the 158 header) is 1 or 2 **and** whose PCM region past the header divides evenly into frames. The 302-byte size gap makes exactly one header valid for a stereo chunk, so no version flag is needed and an unrecognized chunk is left without audio rather than crashing. `decodePcm` now copies only whole frames as a further guard. The declared play length is deliberately not used to size the PCM, since device exports store a few frames more or fewer than `f04 / 2`.

The third `SMPd` encoding is documented in `documentation/design/ZENCORE_FORMAT.md`.

### Verification

Read every sample through the `InMemorySampleData` → WAV path (the reported crash site): 164/164 samples write cleanly across the reported file (32 stereo loops) plus every device export in the reverse-engineering corpus; reverting the fix reproduces the crash on the reported file. No change to the write path — the FANTOM/KY019 exports still read as before (460-byte header, channels at `+0x08`).