### PR TITLE
AIFF: read little-endian AIFC ('sowt') and fix two AIFF bugs

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -14,6 +14,10 @@
 * TAL Sampler (thanks to Douglas Carmichael)
   * Fixed: The sample "reverse" flag was never read as enabled: it is stored numerically (0/1) like all other TAL flags but was parsed as a true/false text boolean.
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+* AIFF (thanks to Douglas Carmichael)
+  * New: Added support for reading AIFC files with un-compressed PCM sound data, e.g. the little-endian ('sowt') files written by the Elektron Tonverk or the Teenage Engineering OP-1. Compressed AIFC files are still rejected with an error message.
+  * Fixed: Converting an AIFF file with the file ending '.aiff' (instead of '.aif') deleted the source sample file: an internal workaround copies such files to a temporary file but the cleanup deleted the original instead of the temporary copy.
+  * Fixed: Reading the sound data chunk of an AIFF file returned only the first few bytes (the bit resolution was mistaken for the data size), which corrupted the fallback conversion path for AIFF files that the Java sound system cannot read.
 
 ## 19.0.0
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
@@ -565,15 +565,12 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
             // accept all AIFF files
             if (fileEnding.endsWith (".aiff") || fileEnding.endsWith (".aif"))
             {
-                // Check if it is a compressed (= encrypted) AIFC file and report accordingly
+                // Check if it is a compressed (= encrypted) AIFC file and report accordingly.
+                // AIFC files with plain PCM sound data (e.g. little-endian 'sowt') are supported.
                 final AiffFile aiffFile = new AiffFile (sampleFile);
                 final AiffCommonChunk commonChunk = aiffFile.getCommonChunk ();
-                if (commonChunk != null)
-                {
-                    final String compressionType = commonChunk.getCompressionType ();
-                    if (compressionType != null)
-                        throw new IOException (Functions.getMessage ("IDS_ERR_COMPRESSED_AIFF_FILE", sampleFile.getName (), commonChunk.getCompressionName (), compressionType));
-                }
+                if (commonChunk != null && !commonChunk.isPCM ())
+                    throw new IOException (Functions.getMessage ("IDS_ERR_COMPRESSED_AIFF_FILE", sampleFile.getName (), commonChunk.getCompressionName (), commonChunk.getCompressionType ()));
 
                 return new AiffFileSampleData (sampleFile);
             }

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/aiff/AiffCommonChunk.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/aiff/AiffCommonChunk.java
@@ -6,6 +6,7 @@ package de.mossgrabers.convertwithmoss.file.aiff;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Set;
 
 import de.mossgrabers.convertwithmoss.file.StreamUtils;
 import de.mossgrabers.convertwithmoss.file.iff.IffChunk;
@@ -18,12 +19,17 @@ import de.mossgrabers.convertwithmoss.file.iff.IffChunk;
  */
 public class AiffCommonChunk extends AiffChunk
 {
-    int    numChannels;
-    long   numSampleFrames;
-    int    sampleSize;
-    int    sampleRate;
-    String compressionType = null;
-    String compressionName = null;
+    /** The AIFC compression types which mark plain (un-compressed) PCM sound data. */
+    private static final Set<String> PCM_COMPRESSION_TYPES   = Set.of ("NONE", "twos", "sowt", "in24", "in32", "23ni");
+    /** The AIFC compression types which store the PCM sound data in little-endian order. */
+    private static final Set<String> LITTLE_ENDIAN_TYPES     = Set.of ("sowt", "23ni");
+
+    int                              numChannels;
+    long                             numSampleFrames;
+    int                              sampleSize;
+    int                              sampleRate;
+    String                           compressionType = null;
+    String                           compressionName = null;
 
 
     /**
@@ -128,6 +134,31 @@ public class AiffCommonChunk extends AiffChunk
     public String getCompressionName ()
     {
         return this.compressionName;
+    }
+
+
+    /**
+     * Check if the sound data is plain (un-compressed) PCM. This is the case for AIFF files and
+     * for AIFC files with one of the PCM compression types (e.g. 'sowt' which only marks the data
+     * as little-endian).
+     *
+     * @return True if the sound data is plain PCM
+     */
+    public boolean isPCM ()
+    {
+        return this.compressionType == null || PCM_COMPRESSION_TYPES.contains (this.compressionType);
+    }
+
+
+    /**
+     * Check if the PCM sound data is stored in little-endian order (AIFC compression types 'sowt'
+     * and '23ni').
+     *
+     * @return True if the sound data is little-endian
+     */
+    public boolean isLittleEndian ()
+    {
+        return this.compressionType != null && LITTLE_ENDIAN_TYPES.contains (this.compressionType);
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/aiff/AiffFile.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/aiff/AiffFile.java
@@ -208,7 +208,7 @@ public class AiffFile
 
                 case AIFF_CHUNK_SOUND_DATA:
                     this.soundDataChunk = new AiffSoundDataChunk (chunk);
-                    this.soundDataChunk.read (chunk, this.commonChunk == null ? -1 : this.commonChunk.sampleSize);
+                    this.soundDataChunk.read (chunk, this.commonChunk == null ? -1 : (int) (this.commonChunk.numSampleFrames * this.commonChunk.numChannels * Math.ceilDiv (this.commonChunk.sampleSize, 8)));
                     break;
 
                 case AIFF_CHUNK_COMMENT:

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/aiff/AiffFileSampleData.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/aiff/AiffFileSampleData.java
@@ -27,6 +27,7 @@ import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
 import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
 import de.mossgrabers.convertwithmoss.core.model.enumeration.LoopType;
 import de.mossgrabers.convertwithmoss.core.model.implementation.AbstractFileSampleData;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultAudioMetadata;
 import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleLoop;
 import de.mossgrabers.convertwithmoss.file.wav.DataChunk;
 import de.mossgrabers.convertwithmoss.file.wav.WaveFile;
@@ -107,44 +108,125 @@ public class AiffFileSampleData extends AbstractFileSampleData
 
     private void readConvertWrite (final InputStream inputStream, final OutputStream outputStream) throws IOException
     {
-        // Read the input AIFF file
-        try (final InputStream in = new BufferedInputStream (inputStream); final AudioInputStream audioIn = AudioSystem.getAudioInputStream (in))
+        try
         {
-            // Obtains the file types that the system can write from the audio input stream
-            // specified. Check if WAV can be written
-            final AudioFileFormat.Type [] supportedTypes = AudioSystem.getAudioFileTypes (audioIn);
-            if (!Arrays.asList (supportedTypes).contains (AudioFileFormat.Type.AIFF))
-                throw new IOException (Functions.getMessage ("IDS_ERR_AIFF_TO_WAV_NOT_SUPPORTED"));
-
-            // Write the output WAV file
-            AudioSystem.write (audioIn, AudioFileFormat.Type.WAVE, outputStream);
-        }
-        catch (final UnsupportedAudioFileException ex)
-        {
-            final String fileEnding = this.sampleFile.getName ().toLowerCase ();
-            if (fileEnding.endsWith (".aiff") || fileEnding.endsWith (".aif"))
+            // The javax.sound SPI cannot read AIFC files; convert their PCM sound data directly
+            // from the parsed chunks
+            AiffCommonChunk commonChunk = null;
+            try
             {
-                final AiffFile replacementAiffFile = new AiffFile (this.sampleFile);
-                final AiffCommonChunk commonChunk = replacementAiffFile.getCommonChunk ();
-                final WaveFile wavFile = new WaveFile (commonChunk.getNumChannels (), commonChunk.getSampleRate (), commonChunk.getSampleSize (), (int) commonChunk.getNumSampleFrames ());
-                final DataChunk dataChunk = wavFile.getDataChunk ();
-                dataChunk.setData (replacementAiffFile.getSoundDataChunk ().getData ());
-                wavFile.write (outputStream);
+                commonChunk = this.getAiffFile ().getCommonChunk ();
+            }
+            catch (final IOException _)
+            {
+                // Cannot be parsed - let the SPI below try
+            }
+            if (commonChunk != null && commonChunk.getCompressionType () != null)
+            {
+                this.writeFromChunks (outputStream);
                 return;
             }
 
-            throw new IOException (ex);
+            // Read the input AIFF file
+            try (final InputStream in = new BufferedInputStream (inputStream); final AudioInputStream audioIn = AudioSystem.getAudioInputStream (in))
+            {
+                // Obtains the file types that the system can write from the audio input stream
+                // specified. Check if WAV can be written
+                final AudioFileFormat.Type [] supportedTypes = AudioSystem.getAudioFileTypes (audioIn);
+                if (!Arrays.asList (supportedTypes).contains (AudioFileFormat.Type.AIFF))
+                    throw new IOException (Functions.getMessage ("IDS_ERR_AIFF_TO_WAV_NOT_SUPPORTED"));
+
+                // Write the output WAV file
+                AudioSystem.write (audioIn, AudioFileFormat.Type.WAVE, outputStream);
+            }
+            catch (final UnsupportedAudioFileException ex)
+            {
+                final String fileEnding = this.sampleFile.getName ().toLowerCase ();
+                if (fileEnding.endsWith (".aiff") || fileEnding.endsWith (".aif"))
+                {
+                    this.writeFromChunks (outputStream);
+                    return;
+                }
+
+                throw new IOException (ex);
+            }
         }
         finally
         {
-            // Remove the temporary file after usage
+            // Remove the temporary file after usage and restore the original file
             if (this.sourceFile != null)
             {
-                Files.delete (this.sourceFile.toPath ());
+                Files.delete (this.sampleFile.toPath ());
                 this.sampleFile = this.sourceFile;
                 this.sourceFile = null;
             }
         }
+    }
+
+
+    /**
+     * Write the sample as a WAV file converted directly from the parsed AIFF chunks. Used for
+     * files which the javax.sound SPI cannot read, e.g. AIFC files with plain PCM sound data
+     * ('sowt' marks it as little-endian, 'NONE'/'twos' as big-endian).
+     *
+     * @param outputStream Where to write the WAV file to
+     * @throws IOException Could not convert the sound data
+     */
+    private void writeFromChunks (final OutputStream outputStream) throws IOException
+    {
+        final AiffFile aifFile = this.getAiffFile ();
+        final AiffCommonChunk commonChunk = aifFile.getCommonChunk ();
+        final AiffSoundDataChunk soundDataChunk = aifFile.getSoundDataChunk ();
+        if (commonChunk == null || soundDataChunk == null)
+            throw new IOException (Functions.getMessage ("IDS_ERR_SOURCE_FORMAT_NOT_SUPPORTED", this.filename));
+        if (!commonChunk.isPCM ())
+            throw new IOException (Functions.getMessage ("IDS_ERR_COMPRESSED_AIFF_FILE", this.filename, commonChunk.getCompressionName (), commonChunk.getCompressionType ()));
+
+        // WAV stores multi-byte samples in little-endian order and 8-bit samples unsigned
+        byte [] data = soundDataChunk.getSoundData ();
+        final int bytesPerSample = Math.ceilDiv (commonChunk.getSampleSize (), 8);
+        if (bytesPerSample == 1)
+            data = convertSigned8BitToUnsigned (data);
+        else if (!commonChunk.isLittleEndian ())
+            data = swapToLittleEndian (data, bytesPerSample);
+
+        final WaveFile wavFile = new WaveFile (commonChunk.getNumChannels (), commonChunk.getSampleRate (), commonChunk.getSampleSize (), (int) commonChunk.getNumSampleFrames ());
+        final DataChunk dataChunk = wavFile.getDataChunk ();
+        dataChunk.setData (data);
+        wavFile.write (outputStream);
+    }
+
+
+    /**
+     * Swap the byte order of all samples from big-endian to little-endian.
+     *
+     * @param data The sample data
+     * @param bytesPerSample The number of bytes of one sample
+     * @return The swapped data in a new array
+     */
+    private static byte [] swapToLittleEndian (final byte [] data, final int bytesPerSample)
+    {
+        final byte [] result = new byte [data.length];
+        final int limit = data.length - bytesPerSample;
+        for (int offset = 0; offset <= limit; offset += bytesPerSample)
+            for (int i = 0; i < bytesPerSample; i++)
+                result[offset + i] = data[offset + bytesPerSample - 1 - i];
+        return result;
+    }
+
+
+    /**
+     * Convert signed 8-bit samples (AIFF) to unsigned ones (WAV).
+     *
+     * @param data The sample data
+     * @return The converted data in a new array
+     */
+    private static byte [] convertSigned8BitToUnsigned (final byte [] data)
+    {
+        final byte [] result = new byte [data.length];
+        for (int i = 0; i < data.length; i++)
+            result[i] = (byte) (data[i] + 128);
+        return result;
     }
 
 
@@ -213,6 +295,33 @@ public class AiffFileSampleData extends AbstractFileSampleData
             loop.setEnd ((int) endMarker.position);
             loops.add (loop);
         }
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected void createAudioMetadata () throws IOException
+    {
+        // The javax.sound SPI cannot read AIFC files; provide their metadata from the parsed
+        // chunks instead
+        AiffCommonChunk commonChunk = null;
+        try
+        {
+            commonChunk = this.getAiffFile ().getCommonChunk ();
+        }
+        catch (final IOException _)
+        {
+            // Cannot be parsed - let the SPI try
+        }
+        if (commonChunk == null || commonChunk.getCompressionType () == null)
+        {
+            super.createAudioMetadata ();
+            return;
+        }
+
+        if (!commonChunk.isPCM ())
+            throw new IOException (Functions.getMessage ("IDS_ERR_COMPRESSED_AIFF_FILE", this.filename, commonChunk.getCompressionName (), commonChunk.getCompressionType ()));
+        this.audioMetadata = new DefaultAudioMetadata (commonChunk.getNumChannels (), commonChunk.getSampleRate (), commonChunk.getSampleSize (), (int) commonChunk.getNumSampleFrames ());
     }
 
 


### PR DESCRIPTION
### Reading un-compressed AIFC

Adds reading of AIFC files whose sound data is un-compressed PCM — e.g. the little-endian `sowt` files written by the Elektron Tonverk or the Teenage Engineering OP-1. `AiffCommonChunk` now exposes `isPCM()` / `isLittleEndian()`, and the detector only rejects a file when it is *actually* compressed (encrypted) rather than whenever a compression type is present. `AiffFileSampleData` decodes the PCM directly from the parsed chunks (byte-swapping little-endian data), since the `javax.sound` SPI cannot read AIFC.

### Two bug fixes

- Converting an AIFF file with the `.aiff` ending (rather than `.aif`) deleted the **source** sample file: an internal workaround copies such files to a temporary file, but the cleanup removed the original instead of the temporary copy.
- Reading the AIFF sound-data (`SSND`) chunk returned only the first few bytes — the bit resolution was mistaken for the data size — which corrupted the fallback conversion path for AIFF files the Java sound system cannot read directly.