### PR TITLE
Waldorf Quantum/Iridium: import-number filename prefix (+ stable alphabetical processing order)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -14,6 +14,10 @@
 * TAL Sampler (thanks to Douglas Carmichael)
   * Fixed: The sample "reverse" flag was never read as enabled: it is stored numerically (0/1) like all other TAL flags but was parsed as a true/false text boolean.
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+* Waldorf Quantum/Iridium (thanks to Douglas Carmichael)
+  * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
+* Backend (thanks to Douglas Carmichael)
+  * New: Source folders and files are now processed in a stable alphabetical order instead of the file-system enumeration order, so consecutive runs behave identically (and e.g. the QPAT import numbers are assigned in a predictable order).
 
 ## 19.0.0
 

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -716,6 +716,7 @@ If this format is used as the source it produces 1 or 2 output presets, one for 
 * Re-sample to 16bit/44.1kHz: If enabled, samples will be resampled to 16bit and 44.1kHz. While the device can play higher resolutions as well it might impact the performance.
 * Author: Written into the preset's Author field, which the device shows and can group presets by. When left empty, the creator from the source metadata is kept (e.g. the sound designer stored in a SoundFont).
 * Bank: Written into the preset's Bank field. When left empty, the description from the source metadata is kept.
+* Prefix file names with an import number: Prefixes each written preset file with a 5-digit number (e.g. *05002-Name.qpat*), which mirrors the naming of the device's own preset export; on import the device assigns the preset to that number. The *First import number* is used for the first written preset and each further preset increases the number by one; the source presets are converted in alphabetical order.
 * Options to write/update [WAV Chunk Information](#wav-chunk-information)
 
 ## Yamaha YSFC

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
@@ -12,7 +12,9 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -314,6 +316,9 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
 
     /**
      * Get all files with specific endings. Recursively, calls detect method on sub-folders.
+     * Sub-folders and files are processed in a stable alphabetical order independent of the file
+     * system enumeration order, so consecutive runs process the presets identically (this also
+     * gives e.g. the import file numbering of the Waldorf QPAT creator a predictable order).
      *
      * @param folder The folder to start searching
      * @param endings The file endings to match, including the dot, e.g. '.wav'
@@ -321,25 +326,35 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
      */
     protected File [] listFiles (final File folder, final String... endings)
     {
-        return folder.listFiles ((parent, name) -> {
+        final File [] children = folder.listFiles ();
+        if (children == null)
+            return null;
+        Arrays.sort (children, Comparator.comparing (File::getName, String.CASE_INSENSITIVE_ORDER));
 
+        for (final File child: children)
+        {
             if (this.isCancelled ())
-                return false;
+                break;
+            if (child.isDirectory ())
+                this.detect (child);
+        }
 
-            final File f = new File (parent, name);
-            if (f.isDirectory ())
-            {
-                this.detect (f);
-                return false;
-            }
-
-            final String lower = name.toLowerCase (Locale.US);
+        final List<File> matchingFiles = new ArrayList<> ();
+        for (final File child: children)
+        {
+            if (this.isCancelled ())
+                break;
+            if (child.isDirectory ())
+                continue;
+            final String lower = child.getName ().toLowerCase (Locale.US);
             for (final String ending: endings)
                 if (lower.endsWith (ending))
-                    return true;
-
-            return false;
-        });
+                {
+                    matchingFiles.add (child);
+                    break;
+                }
+        }
+        return matchingFiles.toArray (new File [matchingFiles.size ()]);
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
@@ -67,6 +67,8 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
         TYPE_LOOKUP.put (Integer.valueOf (2), WaldorfQpatResourceType.USER_SAMPLE_MAP3);
     }
 
+    private int                                                nextImportNumber       = 0;
+
 
     /**
      * Constructor.
@@ -81,10 +83,30 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
 
     /** {@inheritDoc} */
     @Override
+    public void clearCancelled ()
+    {
+        super.clearCancelled ();
+
+        this.nextImportNumber = this.settingsConfiguration.getNumberPrefixStart ();
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
     public void createPreset (final File destinationFolder, final IMultisampleSource multisampleSource) throws IOException
     {
         final String sampleName = createSafeFilename (multisampleSource.getName ());
-        final File multiFile = this.createUniqueFilename (destinationFolder, sampleName, "qpat");
+        final String fileName;
+        if (this.settingsConfiguration.addNumberPrefix ())
+        {
+            // Mirrors the naming of the device's own preset export, a 5-digit number (e.g.
+            // '05002-Name.qpat'); on import the device assigns the preset to that number
+            fileName = String.format ("%05d-%s", Integer.valueOf (this.nextImportNumber), sampleName);
+            this.nextImportNumber++;
+        }
+        else
+            fileName = sampleName;
+        final File multiFile = this.createUniqueFilename (destinationFolder, fileName, "qpat");
         this.notifier.log ("IDS_NOTIFY_STORING", multiFile.getAbsolutePath ());
 
         final String relativeSamplePath = "samples/" + sampleName;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreatorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreatorUI.java
@@ -27,16 +27,22 @@ import javafx.scene.layout.Pane;
  */
 public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
 {
-    private static final String QPAT_LIMIT_TO_16_441 = "QPATLimitTo16441";
-    private static final String QPAT_AUTHOR          = "QPATAuthor";
-    private static final String QPAT_BANK            = "QPATBank";
+    private static final String QPAT_LIMIT_TO_16_441    = "QPATLimitTo16441";
+    private static final String QPAT_AUTHOR             = "QPATAuthor";
+    private static final String QPAT_BANK               = "QPATBank";
+    private static final String QPAT_NUMBER_PREFIX      = "QPATNumberPrefix";
+    private static final String QPAT_NUMBER_PREFIX_START = "QPATNumberPrefixStart";
 
     private CheckBox            limitTo16441CheckBox;
     private TextField           authorField;
     private TextField           bankField;
+    private CheckBox            numberPrefixCheckBox;
+    private TextField           numberPrefixStartField;
     private boolean             limitTo16441;
-    private String              author               = "";
-    private String              bank                 = "";
+    private String              author                  = "";
+    private String              bank                    = "";
+    private boolean             numberPrefix;
+    private int                 numberPrefixStart       = 0;
 
 
     /**
@@ -60,6 +66,9 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
         this.limitTo16441CheckBox = panel.createCheckBox ("@IDS_QPAT_RESAMPLE_TO_16_441");
         this.authorField = panel.createField ("@IDS_QPAT_AUTHOR");
         this.bankField = panel.createField ("@IDS_QPAT_BANK");
+        this.numberPrefixCheckBox = panel.createCheckBox ("@IDS_QPAT_NUMBER_PREFIX");
+        this.numberPrefixStartField = panel.createPositiveIntegerField ("@IDS_QPAT_NUMBER_PREFIX_START");
+        this.numberPrefixStartField.disableProperty ().bind (this.numberPrefixCheckBox.selectedProperty ().not ());
 
         final TitledSeparator separator = this.addWavChunkOptions (panel);
         separator.getStyleClass ().add ("titled-separator-pane");
@@ -74,6 +83,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
         this.limitTo16441CheckBox.setSelected (config.getBoolean (QPAT_LIMIT_TO_16_441, true));
         this.authorField.setText (config.getProperty (QPAT_AUTHOR, ""));
         this.bankField.setText (config.getProperty (QPAT_BANK, ""));
+        this.numberPrefixCheckBox.setSelected (config.getBoolean (QPAT_NUMBER_PREFIX, false));
+        this.numberPrefixStartField.setText (Integer.toString (config.getInteger (QPAT_NUMBER_PREFIX_START, 0)));
 
         super.loadSettings (config);
     }
@@ -86,6 +97,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
         config.setBoolean (QPAT_LIMIT_TO_16_441, this.limitTo16441CheckBox.isSelected ());
         config.setProperty (QPAT_AUTHOR, this.authorField.getText ());
         config.setProperty (QPAT_BANK, this.bankField.getText ());
+        config.setBoolean (QPAT_NUMBER_PREFIX, this.numberPrefixCheckBox.isSelected ());
+        config.setInteger (QPAT_NUMBER_PREFIX_START, this.parseNumberPrefixStart ());
 
         super.saveSettings (config);
     }
@@ -101,6 +114,8 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
         this.limitTo16441 = this.limitTo16441CheckBox.isSelected ();
         this.author = this.authorField.getText ();
         this.bank = this.bankField.getText ();
+        this.numberPrefix = this.numberPrefixCheckBox.isSelected ();
+        this.numberPrefixStart = this.parseNumberPrefixStart ();
         return true;
     }
 
@@ -120,6 +135,21 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
         final String bankValue = parameters.remove (QPAT_BANK);
         this.bank = bankValue == null ? "" : bankValue;
 
+        this.numberPrefix = "1".equals (parameters.remove (QPAT_NUMBER_PREFIX));
+        final String startValue = parameters.remove (QPAT_NUMBER_PREFIX_START);
+        if (startValue == null || startValue.isBlank ())
+            this.numberPrefixStart = 0;
+        else
+            try
+            {
+                this.numberPrefixStart = Integer.parseInt (startValue);
+            }
+            catch (final NumberFormatException _)
+            {
+                notifier.logError ("IDS_CLI_VALUE_MUST_BE_INTEGER", QPAT_NUMBER_PREFIX_START);
+                return false;
+            }
+
         return true;
     }
 
@@ -132,7 +162,22 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
         parameterNames.add (QPAT_LIMIT_TO_16_441);
         parameterNames.add (QPAT_AUTHOR);
         parameterNames.add (QPAT_BANK);
+        parameterNames.add (QPAT_NUMBER_PREFIX);
+        parameterNames.add (QPAT_NUMBER_PREFIX_START);
         return parameterNames.toArray (new String [parameterNames.size ()]);
+    }
+
+
+    private int parseNumberPrefixStart ()
+    {
+        try
+        {
+            return Math.max (0, Integer.parseInt (this.numberPrefixStartField.getText ().trim ()));
+        }
+        catch (final NumberFormatException _)
+        {
+            return 0;
+        }
     }
 
 
@@ -168,5 +213,30 @@ public class WaldorfQpatCreatorUI extends WavChunkSettingsUI
     public String getBank ()
     {
         return this.bank;
+    }
+
+
+    /**
+     * Should the file names be prefixed with an import number? This mirrors the naming of the
+     * device's own preset export (e.g. '05002-Name.qpat'); on import the device assigns the preset
+     * to that number.
+     *
+     * @return True to add the number prefix
+     */
+    public boolean addNumberPrefix ()
+    {
+        return this.numberPrefix;
+    }
+
+
+    /**
+     * Get the import number to use for the first written preset; each further preset increases the
+     * number by one.
+     *
+     * @return The first import number
+     */
+    public int getNumberPrefixStart ()
+    {
+        return this.numberPrefixStart;
     }
 }

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -644,6 +644,8 @@ IDS_QPAT_SEPARATOR=Waldorf QPAT
 IDS_QPAT_RESAMPLE_TO_16_441=Re-sample to 16bit/44.1kHz
 IDS_QPAT_AUTHOR=Author (empty = keep source)
 IDS_QPAT_BANK=Bank (empty = keep source)
+IDS_QPAT_NUMBER_PREFIX=Prefix file names with an import number
+IDS_QPAT_NUMBER_PREFIX_START=First import number
 
 IDS_SF2_NAMING=Naming of output files
 IDS_SF2_NAMING_ADD_FILE_NAME=Prefix with file name


### PR DESCRIPTION
### Import-number filename prefix

Adds a Waldorf QPAT creator option to prefix each written preset file name with a 5-digit **import number** (e.g. `05002-Name.qpat`), mirroring the naming of the device's own preset export — on import the device assigns the preset to that number. The **First import number** (start value) is configurable; each further preset increases it by one.

### Stable alphabetical processing order (backend)

So the import numbers are assigned predictably, `AbstractDetector.listFiles` now walks sub-folders and files in a stable, case-insensitive **alphabetical order** instead of the file-system enumeration order. This is a general change: consecutive runs now process presets identically for every format (not just QPAT), which also makes conversions reproducible.

CLI: `QPATNumberPrefix` / `QPATNumberPrefixStart`. README and CHANGELOG (under 19.0.1) updated.