### PR TITLE
Elektron Tonverk: fix "template not found" when writing a preset (#203)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -14,6 +14,8 @@
 * TAL Sampler (thanks to Douglas Carmichael)
   * Fixed: The sample "reverse" flag was never read as enabled: it is stored numerically (0/1) like all other TAL flags but was parsed as a true/false text boolean.
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+* Elektron Tonverk Preset (thanks to Douglas Carmichael)
+  * Fixed: Writing a Tonverk preset failed in the packaged application with "Resource '.../tonverk/multi-template.tvpst' not found" (issue #203). The preset template lives in a module package that was not opened - unlike every other template package - and its resource path carried a leading slash that the module class-loader lookup does not accept. The package is now opened and the path corrected.
 
 ## 19.0.0
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/TonverkPresetCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/TonverkPresetCreator.java
@@ -61,8 +61,8 @@ public class TonverkPresetCreator extends AbstractWavCreator<TonverkPresetCreato
     private static final double                 DEFAULT_VELOCITY       = 0.49411765;
     private static final int                    DRUM_VOICE_COUNT       = 8;
     private static final int                    DEFAULT_DRUM_ROOT      = 60;
-    private static final String                 MULTI_TEMPLATE         = "/de/mossgrabers/convertwithmoss/templates/tonverk/multi-template.tvpst";
-    private static final String                 DRUM_TEMPLATE          = "/de/mossgrabers/convertwithmoss/templates/tonverk/drum-template.tvpst";
+    private static final String                 MULTI_TEMPLATE         = "de/mossgrabers/convertwithmoss/templates/tonverk/multi-template.tvpst";
+    private static final String                 DRUM_TEMPLATE          = "de/mossgrabers/convertwithmoss/templates/tonverk/drum-template.tvpst";
 
     /** The absolute device folder under which a preset references its samples. */
     private static final String                 DEVICE_SAMPLE_FOLDER   = "/mnt/sdcard/User/Multi-sampled Instruments/";

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -43,4 +43,5 @@ module de.mossgrabers.convertwithmoss
     opens de.mossgrabers.convertwithmoss.templates.maschine;
     opens de.mossgrabers.convertwithmoss.templates.prt_omn;
     opens de.mossgrabers.convertwithmoss.templates.ysfc;
+    opens de.mossgrabers.convertwithmoss.templates.tonverk;
 }


### PR DESCRIPTION
Fixes #203.

Writing an Elektron Tonverk **preset** failed in the packaged application with:

```
Could not create file: Resource '/de/mossgrabers/convertwithmoss/templates/tonverk/multi-template.tvpst' not found.
```

Two causes, both diverging from how every other template loader in the project works:

1. **`module-info.java` did not `opens` `de.mossgrabers.convertwithmoss.templates.tonverk`.** The template is loaded through uitools' `Functions.textFileFor`, which resolves the resource via a class-loader in the *uitools* module. Under the module path (the jpackage / installer build), a resource in the `convertwithmoss` named module is encapsulated unless its package is opened — and every other template package (`nki`, `adv`, `dspreset`, `maschine`, `prt_omn`, `ysfc`) *is* opened. `tonverk` was missed.
2. **The `MULTI_TEMPLATE` / `DRUM_TEMPLATE` paths had a leading `/`.** Class-loader resource lookup (unlike `Class.getResourceAsStream`) does not accept a leading slash; every other template constant in the project is class-loader-relative (`de/mossgrabers/...`).

Both are needed — I verified that fixing only one still fails. This only reproduces in the **packaged / module-path** build (the DMG/installer), not when running from the classpath in a dev/IDE launch, which is why it slipped through.

**Verified:** converting a sample source with `-d Tonverk` now writes the `.tvpst` (`Storing: Sample_C3.tvpst`) instead of the error.