### PR TITLE
Roland MV-8000: fix an infinite loop which hangs reading almost any patch

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -14,6 +14,8 @@
 * TAL Sampler (thanks to Douglas Carmichael)
   * Fixed: The sample "reverse" flag was never read as enabled: it is stored numerically (0/1) like all other TAL flags but was parsed as a true/false text boolean.
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+* Roland MV-8000/MV-8800 (thanks to Douglas Carmichael)
+  * Fixed: Reading a patch could hang with full CPU load and no output. The loop over the sample slots did not advance on an empty slot, and since a patch rarely uses all of its slots this affected almost every patch.
 
 ## 19.0.0
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Detector.java
@@ -167,32 +167,40 @@ public class MV8000Detector extends AbstractDetector<MetadataSettingsUI>
         {
             final MV8000Smt slot = partial.getSmtSlot (slotIndex);
             final int sampleId = slot.getSampleId ();
-            if (sampleId != 0)
+
+            // An empty slot is skipped. Note that the index must be increased in every branch
+            // below, otherwise the loop never terminates
+            if (sampleId == 0)
             {
-                final MV8000Sample sample = samplesByID.get (Integer.valueOf (sampleId));
-                if (sample == null)
-                    this.notifier.logError ("IDS_MV8000_SAMPLE_MISSING", Integer.toString (sampleId), partial.getName ());
-                else
-                {
-                    // Combine a left/right mono pair in 2 consecutive slots into 1 stereo zone
-                    MV8000Sample rightSample = null;
-                    if (slotIndex + 1 < MV8000Partial.NUM_SMT_SLOTS && sample.isStereoLeft ())
-                    {
-                        final MV8000Smt nextSlot = partial.getSmtSlot (slotIndex + 1);
-                        final MV8000Sample nextSample = samplesByID.get (Integer.valueOf (nextSlot.getSampleId ()));
-                        if (nextSample != null && nextSample.isStereoRightOf (sample) && nextSlot.getVelocityLow () == slot.getVelocityLow () && nextSlot.getVelocityHigh () == slot.getVelocityHigh ())
-                            rightSample = nextSample;
-                    }
-
-                    final ISampleZone zone = createZone (slot, sample, rightSample, keyLow, keyHigh);
-                    zone.getAmplitudeEnvelopeModulator ().setSource (amplitudeEnvelope);
-                    zone.getAmplitudeVelocityModulator ().setDepth (partial.getTvaVelocityCurve () == 0 ? 0 : 1);
-                    createFilter (zone, partial);
-                    groups.get (slotIndex).addSampleZone (zone);
-
-                    slotIndex += rightSample == null ? 1 : 2;
-                }
+                slotIndex++;
+                continue;
             }
+
+            final MV8000Sample sample = samplesByID.get (Integer.valueOf (sampleId));
+            if (sample == null)
+            {
+                this.notifier.logError ("IDS_MV8000_SAMPLE_MISSING", Integer.toString (sampleId), partial.getName ());
+                slotIndex++;
+                continue;
+            }
+
+            // Combine a left/right mono pair in 2 consecutive slots into 1 stereo zone
+            MV8000Sample rightSample = null;
+            if (slotIndex + 1 < MV8000Partial.NUM_SMT_SLOTS && sample.isStereoLeft ())
+            {
+                final MV8000Smt nextSlot = partial.getSmtSlot (slotIndex + 1);
+                final MV8000Sample nextSample = samplesByID.get (Integer.valueOf (nextSlot.getSampleId ()));
+                if (nextSample != null && nextSample.isStereoRightOf (sample) && nextSlot.getVelocityLow () == slot.getVelocityLow () && nextSlot.getVelocityHigh () == slot.getVelocityHigh ())
+                    rightSample = nextSample;
+            }
+
+            final ISampleZone zone = createZone (slot, sample, rightSample, keyLow, keyHigh);
+            zone.getAmplitudeEnvelopeModulator ().setSource (amplitudeEnvelope);
+            zone.getAmplitudeVelocityModulator ().setDepth (partial.getTvaVelocityCurve () == 0 ? 0 : 1);
+            createFilter (zone, partial);
+            groups.get (slotIndex).addSampleZone (zone);
+
+            slotIndex += rightSample == null ? 1 : 2;
         }
     }
 


### PR DESCRIPTION
Reading an MV-8000 patch can hang forever at full CPU load with no output and no error. It affects almost every patch, so the format is effectively unusable as a source.

### Cause

`MV8000Detector.createZones` walks the SMT slots with a `while` loop, but `slotIndex` is only increased inside the innermost `else` branch:

```java
while (slotIndex < MV8000Partial.NUM_SMT_SLOTS)
{
    if (sampleId != 0)
    {
        if (sample == null)
            this.notifier.logError (...);      // index not increased
        else
            slotIndex += rightSample == null ? 1 : 2;
    }
                                               // empty slot: index not increased
}
```

An empty slot (`sampleId == 0`) therefore spins forever without producing any output, and a slot whose sample is missing repeats the same error endlessly. Since a patch rarely uses all of its slots, the first unused slot hangs the conversion.

### Fix

The index is now increased in every branch, using an early `continue` for the two skip cases. Nothing else changed - the stereo pairing and the zone creation are untouched.

### Verification

Against the 103 MV-8000 factory patches:

* before: hangs on the first patch (`STR_Symph.MV0`), never terminates. A thread dump shows the worker `RUNNABLE` in `createZones` burning 33.7 s of CPU in 33.8 s elapsed.
* after: all 103 patches are read and the run finishes normally.