### PR TITLE
Fix a set of pre-existing bugs (NN-XT loops, EXS24 and DecentSampler group panning, Bliss loops, ...)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -14,6 +14,22 @@
 * TAL Sampler (thanks to Douglas Carmichael)
   * Fixed: The sample "reverse" flag was never read as enabled: it is stored numerically (0/1) like all other TAL flags but was parsed as a true/false text boolean.
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
+* Reason NN-XT (thanks to Douglas Carmichael)
+  * Fixed: All loops were lost when reading a preset: the loop was created but never added to the zone. Writing loops was not affected.
+  * Fixed: The pitch key tracking was never read, so zones with a reduced key tracking (e.g. fixed-pitch percussion) were imported as fully tracking.
+* Logic EXS24 (thanks to Douglas Carmichael)
+  * Fixed: The panning of a group was read as an unsigned value and was not scaled, so a group panned fully left moved all of its zones fully right.
+  * Fixed: The attack time at the lowest velocity was never written and stayed at 0, which gave all written presets an instant attack at low velocity.
+* DecentSampler (thanks to Douglas Carmichael)
+  * Fixed: The panning of a group was not scaled, so any group with a panning moved all of its zones fully to one side.
+* Bliss (thanks to Douglas Carmichael)
+  * Fixed: The loop mode was only written when a zone had a loop, but a missing loop mode is read back as a forward loop, so zones without a loop turned into fully looped ones.
+* Ableton (thanks to Douglas Carmichael)
+  * Fixed: The warning that the round-robin configuration could not be translated was logged when it could be translated and not when it could not. The written file is not affected.
+* 1010music blackbox (thanks to Douglas Carmichael)
+  * Fixed: The choke group attribute of an unused template slot was written as "okegrp" instead of "chokegrp".
+* Backend (thanks to Douglas Carmichael)
+  * Fixed: Copying a sample zone did not copy the sequence position belonging to the play logic and did not copy the velocity modulator of the amplitude.
 
 ## 19.0.0
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/model/implementation/DefaultSampleZone.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/model/implementation/DefaultSampleZone.java
@@ -537,6 +537,7 @@ public class DefaultSampleZone implements ISampleZone
     public void fillMetadata (final ISampleZone other)
     {
         this.playLogic = other.getPlayLogic ();
+        this.sequencePosition = other.getSequencePosition ();
         this.triggerType = other.getTrigger ();
         this.start = other.getStart ();
         this.stop = other.getStop ();
@@ -556,6 +557,7 @@ public class DefaultSampleZone implements ISampleZone
         this.bendUp = other.getBendUp ();
         this.bendDown = other.getBendDown ();
         this.isReversed = other.isReversed ();
+        this.amplitudeVelocityModulator = other.getAmplitudeVelocityModulator ();
         this.amplitudeEnvelopeModulator = other.getAmplitudeEnvelopeModulator ();
         this.pitchModulator = other.getPitchEnvelopeModulator ();
         final Optional<IFilter> filterOpt = other.getFilter ();

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonCreator.java
@@ -346,7 +346,7 @@ public class AbletonCreator extends AbstractWavCreator<AbletonCreatorUI>
         if (!multisampleSource.hasRoundRobin ())
             return false;
         final boolean fullRoundRobin = multisampleSource.isFullRoundRobin ();
-        if (fullRoundRobin)
+        if (!fullRoundRobin)
             this.notifier.logError ("IDS_ADV_ROUND_ROBIN_GROUPS_DO_NOT_MATCH");
         return fullRoundRobin;
     }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/bliss/BlissCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/bliss/BlissCreator.java
@@ -264,9 +264,12 @@ public class BlissCreator extends AbstractCreator<EmptySettingsUI>
         XMLUtils.setIntegerAttribute (zoneElement, "midi_fine_tune", (int) Math.round ((tune - coarseTuning) * 100.0));
         XMLUtils.setIntegerAttribute (zoneElement, "midi_keycents", (int) Math.round (zone.getKeyTracking () * 100.0));
 
-        // Create loop
+        // Create loop. 'loop_mode' must always be written since a missing attribute is not
+        // interpreted as 'no loop' but as a forward loop.
         final List<ISampleLoop> loops = zone.getLoops ();
-        if (!loops.isEmpty ())
+        if (loops.isEmpty ())
+            XMLUtils.setIntegerAttribute (zoneElement, "loop_mode", 0);
+        else
         {
             int loopMode = 1;
             final ISampleLoop loop = loops.get (0);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -367,7 +367,7 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
             final IGroup group = new DefaultGroup (groupName);
 
             final double groupVolumeOffset = parseVolume (groupElement, DecentSamplerTag.VOLUME);
-            final int groupPanningOffset = XMLUtils.getIntegerAttribute (groupElement, DecentSamplerTag.PANNING, 0);
+            final double groupPanningOffset = XMLUtils.getIntegerAttribute (groupElement, DecentSamplerTag.PANNING, 0) / 100.0;
             double groupTuningOffset = XMLUtils.getDoubleAttribute (groupElement, DecentSamplerTag.GROUP_TUNING, 0);
             // Actually not in the specification but support it anyway
             if (groupTuningOffset == 0)
@@ -464,7 +464,7 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
         sampleZone.setStart ((int) Math.round (XMLUtils.getDoubleAttribute (sampleElement, DecentSamplerTag.START, -1)));
         sampleZone.setStop ((int) Math.round (XMLUtils.getDoubleAttribute (sampleElement, DecentSamplerTag.END, -1)));
         sampleZone.setGain (groupVolumeOffset + parseVolume (sampleElement, DecentSamplerTag.VOLUME));
-        sampleZone.setPanning (groupPanningOffset + XMLUtils.getIntegerAttribute (sampleElement, DecentSamplerTag.PANNING, 0) / 100.0);
+        sampleZone.setPanning (Math.clamp (groupPanningOffset + XMLUtils.getIntegerAttribute (sampleElement, DecentSamplerTag.PANNING, 0) / 100.0, -1, 1));
         sampleZone.setTuning (tuningOffset + XMLUtils.getDoubleAttribute (sampleElement, DecentSamplerTag.TUNING, 0));
 
         final String zoneLogic = this.currentGroupsElement.getAttribute (DecentSamplerTag.SEQ_MODE);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Creator.java
@@ -216,6 +216,9 @@ public class EXS24Creator extends AbstractWavCreator<WavChunkSettingsUI>
         final int release = formatEnvTime (envelope.getReleaseTime ());
         parameters.put (envelopeIndex == 1 ? EXS24Parameters.ENV1_DELAY_START : EXS24Parameters.ENV2_DELAY_START, delay);
         parameters.put (envelopeIndex == 1 ? EXS24Parameters.ENV1_ATK_HI_VEL : EXS24Parameters.ENV2_ATK_HI_VEL, attack);
+        // The attack time at the lowest velocity must be set to the same value, otherwise it stays
+        // at 0 and the attack time gets velocity dependent
+        parameters.put (envelopeIndex == 1 ? EXS24Parameters.ENV1_ATK_LO_VEL : EXS24Parameters.ENV2_ATK_LO_VEL, attack);
         parameters.put (envelopeIndex == 1 ? EXS24Parameters.ENV1_HOLD : EXS24Parameters.ENV2_HOLD, hold);
         parameters.put (envelopeIndex == 1 ? EXS24Parameters.ENV1_DECAY : EXS24Parameters.ENV2_DECAY, decay);
         parameters.put (envelopeIndex == 1 ? EXS24Parameters.ENV1_SUSTAIN : EXS24Parameters.ENV2_SUSTAIN, sustain);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Detector.java
@@ -437,7 +437,7 @@ public class EXS24Detector extends AbstractDetector<MetadataWithSearchHeightSett
         if (exs24Group.volume != 0)
             zone.setGain (exs24Group.volume + zone.getGain ());
         if (exs24Group.pan != 0)
-            zone.setPanning (zone.getPanning () + exs24Group.pan);
+            zone.setPanning (Math.clamp (zone.getPanning () + exs24Group.pan / 50.0, -1, 1));
 
         // Zone is completely outside of the groups' velocity range
         if (zone.getVelocityHigh () < exs24Group.minVelocity)

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Group.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Group.java
@@ -103,7 +103,7 @@ class EXS24Group extends EXS24Object
     protected void read (final InputStream in, final boolean isBigEndian) throws IOException
     {
         this.volume = MathUtils.decodeTwosComplement (in.read ());
-        this.pan = in.read ();
+        this.pan = MathUtils.decodeTwosComplement (in.read ());
         this.polyphony = in.read ();
         final int options = in.read ();
         this.mute = (options & 16) > 0; // 0 = OFF, 1 = ON

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Creator.java
@@ -85,7 +85,7 @@ public class Music1010Creator extends AbstractMusic1010Creator
         EMPTY_PARAM_ATTRIBUTES.put ("samtrigtype", "0");
         EMPTY_PARAM_ATTRIBUTES.put ("polymode", "0");
         EMPTY_PARAM_ATTRIBUTES.put ("polymodeslice", "0");
-        EMPTY_PARAM_ATTRIBUTES.put ("okegrp", "0");
+        EMPTY_PARAM_ATTRIBUTES.put ("chokegrp", "0");
         EMPTY_PARAM_ATTRIBUTES.put ("midimode", "0");
         EMPTY_PARAM_ATTRIBUTES.put ("midioutchan", "0");
         EMPTY_PARAM_ATTRIBUTES.put ("padnote", "0");

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sxt/SxtZone.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sxt/SxtZone.java
@@ -464,6 +464,13 @@ class SxtZone
         zone.setBendUp (this.pitchWheelRange * 100);
         zone.setBendDown (-this.pitchWheelRange * 100);
 
+        // The key tracking (the 'K. Track' knob) is stored as the amount of cents by which the
+        // pitch is shifted per key: 0 = all keys play the same pitch, 100 = one semi-tone per key
+        // (which is the normal setting and matches 100% in the model) and 1200 = one octave per
+        // key. The model supports only [0..1] which represents [0..100] %, therefore exaggerated
+        // tracking of more than one semi-tone per key is clamped.
+        zone.setKeyTracking (Math.clamp (this.keyToPitch / 100.0, 0, 1));
+
         // Backwards
         if (this.playMode == 4)
             zone.setReversed (true);
@@ -474,6 +481,7 @@ class SxtZone
             loop.setLoopUntilRelease (this.playMode == 3);
             loop.setStart ((int) this.sampleLoopStart);
             loop.setEnd ((int) this.sampleLoopEnd);
+            zone.addLoop (loop);
         }
 
         if (this.alternateMode > 0)


### PR DESCRIPTION
Seven unrelated bugs found while auditing the format packages. Each is a separate commit, so any of them can be dropped or taken on its own.

### Data loss / wrong output

**Reason NN-XT: all loops are lost on import.** `SxtZone.fillInto` creates the loop, fills in type, start, end and the sustain flag, and then never adds it to the zone - `addLoop` does not appear anywhere in the package. Writing loops was never affected, so this is read-side only.

**Reason NN-XT: pitch key tracking is never read.** `keyToPitch` is parsed and written back but never applied, so a zone with reduced key tracking (fixed-pitch percussion, for example) imports as fully tracking. The value is the pitch shift in cents per key; the documented default of 100 is one semi-tone per key, which is full tracking, so the divisor is 100.

**Logic EXS24: group panning is inverted and saturated.** `EXS24Group.pan` was read with `in.read ()` instead of `MathUtils.decodeTwosComplement` (unlike `volume` on the line above), and then added to the zone panning without applying the `/ 50` scale the zone panning uses. A group panned fully left stores `0xCE`, which read as 206 and added to a `[-1..1]` value pins every zone to fully **right**.

**Logic EXS24: written presets have an instant attack at low velocity.** `ENV1_ATK_LO_VEL` was never written, so it stayed at its default of 0. The EXS24 stores two attack times, one for the lowest and one for the highest velocity; leaving the low one at 0 gives an instant attack at low velocity, which is also the opposite of the usual behaviour where a higher velocity shortens the attack. It is now written with the same value as the high-velocity attack, which disables the velocity dependency. Applied to both envelopes, since the filter envelope has the same defect.

**DecentSampler: group panning saturates.** The group `pan` attribute is in the range -100 to 100 but was added to the already normalized zone panning, so any group with a panning moved all of its zones fully to one side. The surrounding parameters were already declared `double`, so this looks like a missed division.

**Bliss: samples without a loop round-trip into looped ones.** The creator only wrote `loop_mode` inside the `!loops.isEmpty ()` branch, while the detector reads a missing `loop_mode` as 1 (forwards) and then defaults the loop points to the whole sample. I fixed the creator rather than the detector: writing the attribute explicitly is correct whichever default the format really uses, leaves every zone which already round-trips byte-identical, and does not change how third-party files are read.

### Cosmetic / log only

**Ableton: the round-robin warning is inverted.** `IDS_ADV_ROUND_ROBIN_GROUPS_DO_NOT_MATCH` reads "all groups need to be part of round-robin", so the failure case is "some but not all". The check logged it when `isFullRoundRobin ()` was **true**, that is exactly when the translation succeeds, and stayed silent on the lossy partial case. The return value was already correct, so the written file does not change.

**1010music blackbox: misspelled attribute.** `EMPTY_PARAM_ATTRIBUTES` wrote `okegrp` instead of `chokegrp` for unused template slots. Bento does not have the typo.

**Backend: two attributes missing when copying a sample zone.** `fillMetadata` documents that it copies everything except the file name and data, but it copied the play logic without the sequence position that belongs to it, and did not copy the amplitude velocity modulator.

### Notes

Deliberately **not** included, since they need a decision rather than a fix:

* Renoise calls `printUnsupportedElements ()` / `printUnsupportedAttributes ()` but never calls `checkChildTags` / `checkAttributes`, so both reports are always empty. Wiring them up would need roughly 215 names enumerated against the 4779-line XRNI schema, and would otherwise log around 100 false "unsupported" entries on every successful conversion, because Renoise writes `SelectedPresetName`, `MidiInputProperties` and similar into every file.
* The 1010music `// Gain - "gaindb" -> unknown conversion` comment is stale - `BentoCreator` already documents `gaindb` as milli-decibels. It is not wired up here because the write side deliberately stores the gain in the WAV `inst` chunk instead, so reading it from the XML needs a precedence rule first.