### PR TITLE
Elektron Tonverk: remove the duplicated unknown-machine message key

### DIFF
--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -623,7 +623,7 @@ IDS_DS_ADD_FILTER_TO_GROUPS=Add low-pass filter to all groups if none is present
 IDS_ELEKTRON_RESAMPLE=Compatibility
 IDS_ELEKTRON_CONVERT_TO_24_48=Re-sample to 24bit/48kHz
 
-IDS_TONVERK_UNKNOWN_MACHINE=Unknown Tonverk generator machine '%1'. Only One-Shot, Multi and Drum are supported.\n
+IDS_TONVERK_UNKNOWN_MACHINE=Unknown Tonverk generator machine '%1'. Only One-Shot, Multi, Drum and Grainer are supported.\n
 IDS_TONVERK_EMPTY_OR_CORRUPT=The Tonverk preset file is empty or corrupt and was skipped: %1\n
 IDS_TONVERK_SAMPLE_NOT_FOUND=Could not find the sample referenced by the preset: %1\n
 IDS_TONVERK_DRUM_LIMIT=The source has %1 drums but the Tonverk Drum machine only has %2 voices. The additional drums are dropped.\n
@@ -631,7 +631,6 @@ IDS_TONVERK_OUTPUT_ENGINE=Output Engine
 IDS_TONVERK_ENGINE_MULTI=Multi-Sample
 IDS_TONVERK_ENGINE_DRUM=Drum Kit
 IDS_TONVERK_ENGINE_AUTO=Auto (from source)
-IDS_TONVERK_UNKNOWN_MACHINE=Unknown Tonverk generator machine '%1'. Only One-Shot, Multi, Drum and Grainer are supported.\n
 
 IDS_KMP_OPTIONS=KMP Options
 IDS_KMP_USE_KSC=Use KSC files as the input (otherwise only KMP files are used)


### PR DESCRIPTION
### Problem

`IDS_TONVERK_UNKNOWN_MACHINE` is defined twice in `Strings.properties`:

- line 626 — `Only One-Shot, Multi and Drum are supported.`
- line 634 — `Only One-Shot, Multi, Drum and Grainer are supported.`

Reading the Grainer generator machine (#206) appended a new entry at the end of the Tonverk block rather than updating the existing one.

### Impact

Nothing user visible today. Property loading is last-one-wins, so the Grainer wording is the one that actually loads — I verified this with both `Properties.load` and `PropertyResourceBundle`:

```
Properties.load  -> ... Only One-Shot, Multi, Drum and Grainer are supported.
ResourceBundle   -> ... Only One-Shot, Multi, Drum and Grainer are supported.
```

The stale first entry is dead weight, but it silently shadows the intended one if the order ever changes (a re-sort, a merge, or a translated file that keeps only the first occurrence).

### Fix

Merge the Grainer wording into the original entry and drop the appended duplicate, so the key is defined once and stays grouped with the other Tonverk messages.

Behaviour is unchanged, so there is no CHANGELOG entry. `IDS_TONVERK_UNKNOWN_MACHINE` is now the only duplicated key gone from the file — I checked the remaining ~550 keys and there are no others.