### PR TITLE
DLS: fix the pitch scale conversions which saturated

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/dls/DlsDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/dls/DlsDetector.java
@@ -235,7 +235,10 @@ public class DlsDetector extends AbstractDetector<MetadataSettingsUI>
         {
             final IEnvelope pitchEnvelope = createEnvelope (dlsInstrument, dlsRegion, true);
             final IEnvelopeModulator pitchEnvelopeModulator = zone.getPitchEnvelopeModulator ();
-            pitchEnvelopeModulator.setDepth (normalizeEG2ToPitch (pitchModulation.get ().getScale ()));
+            // The scale is a relative pitch in cent, stored as a 32-bit fixed point number with
+            // 65536 representing one cent
+            final double depthCents = pitchModulation.get ().getScale () / 65536.0;
+            pitchEnvelopeModulator.setDepth (Math.clamp (depthCents, -IEnvelope.MAX_ENVELOPE_DEPTH, IEnvelope.MAX_ENVELOPE_DEPTH) / IEnvelope.MAX_ENVELOPE_DEPTH);
             pitchEnvelopeModulator.setSource (pitchEnvelope);
         }
 
@@ -243,7 +246,8 @@ public class DlsDetector extends AbstractDetector<MetadataSettingsUI>
         final Optional<DlsArticulation> pitchTuning = getArticulation (dlsInstrument, dlsRegion, DlsArticulation.CONN_SRC_NONE, DlsArticulation.CONN_DST_PITCH);
         if (pitchTuning.isPresent ())
         {
-            final double tuning = normalizeEG2ToPitch (pitchTuning.get ().getScale ());
+            // The scale is a relative pitch in cent (65536 per cent), the tuning is in semi-tones
+            final double tuning = pitchTuning.get ().getScale () / 65536.0 / 100.0;
             zone.setTuning (zone.getTuning () + tuning);
         }
 
@@ -281,10 +285,7 @@ public class DlsDetector extends AbstractDetector<MetadataSettingsUI>
         if (isEnvelope1)
             sustain = getLevel (dlsInstrument, dlsRegion, DlsArticulation.CONN_DST_EG1_SUSTAINLEVEL);
         else
-        {
-            final Optional<DlsArticulation> articulation = getArticulation (dlsInstrument, dlsRegion, DlsArticulation.CONN_SRC_NONE, DlsArticulation.CONN_DST_EG2_SUSTAINLEVEL);
-            sustain = articulation.isEmpty () ? -1 : normalizeEG2ToPitch (articulation.get ().getScale ());
-        }
+            sustain = getLevel (dlsInstrument, dlsRegion, DlsArticulation.CONN_DST_EG2_SUSTAINLEVEL);
 
         final IEnvelope envelope = new DefaultEnvelope ();
         if (delay >= 0)
@@ -345,17 +346,5 @@ public class DlsDetector extends AbstractDetector<MetadataSettingsUI>
     private static double normalizeKeyNumberToGain (final int scale)
     {
         return Math.clamp (scale / (655360.0 * 127.0), -1, 1);
-    }
-
-
-    /**
-     * Normalizes a DLS Modulation EG to Pitch lScale value to the range 0.0..1.0.
-     *
-     * @param cents The raw 32-bit signed relative pitch value
-     * @return Normalized value in range [0.0, 1.0]
-     */
-    public static double normalizeEG2ToPitch (final int cents)
-    {
-        return Math.clamp (cents, -1200, 1200) / 1200.0;
     }
 }


### PR DESCRIPTION
`DlsDetector.normalizeEG2ToPitch` clamps the raw 32-bit connection value to ±1200 and divides by 1200 — but that value is a relative pitch stored as a fixed point number with **65536 representing one cent**, the same convention the file's own `absoluteTimeToSeconds` already divides out. So every non-zero value saturates to full scale.

The helper was used for three different quantities, each with a different correct unit, so all three were wrong:

* **Pitch envelope depth** — now divided by 65536 and normalized over `MAX_ENVELOPE_DEPTH` like every other format, so a one-octave envelope is 1200 cent rather than ten octaves.
* **Pitch tuning** — now converted to semi-tones (65536 per cent, 100 cent per semi-tone).
* **Modulation-envelope sustain** — now routed through the sustain-level conversion, the same path the first envelope already uses. This branch is currently unreached (the envelope is only ever built for EG1), but fixing it lets the broken helper be removed.

The now-unused `normalizeEG2ToPitch` is deleted. One file, `DlsDetector.java`.

### Validation

Measured against the Roland GS set that ships with macOS (`gs_instruments.dls`), converted DLS → SFZ before and after:

* Before, **522 zones** wrote their pitch-envelope depth as exactly `pitcheg_depth=±12000` (the saturated maximum, ten octaves).
* After, those same 522 zones spread across their real values — `1200`, `1000`, `200`, `-95`, `-63`, `-29`, ... cent — matching the raw connection values decoded straight from the file.
* The full before/after diff touches **only** `pitcheg_depth`; loops, key ranges, amplitude envelopes and everything else are byte-identical, so there is no collateral change.

The tuning and sustain paths are not exercised by this particular set (it has no region-level pitch tuning connection, and the sustain branch is unreached as noted), so their fix is by unit analysis rather than a visible diff here.

### Note

Independent of #216 (the pitch-LFO PR): different concern, and #216 touches `DlsDetector` only by adding a separate block, so the two can merge in either order.
