### PR TITLE
Roland ZEN-Core: read SVZ packs from Roland's SF2-to-SVZ converter

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -87,6 +87,8 @@
   * Fixed: Reading a patch could hang with full CPU load and no output. The loop over the sample slots did not advance on an empty slot, and since a patch rarely uses all of its slots this affected almost every patch.
 * Roland S-7xx
   * Fixed: The two envelope time key-follow fields were read as unsigned although they are signed.
+* Roland ZEN-Core
+  * Fixed: SVZ sample packs produced by Roland's own SF2-to-SVZ converter (e.g. the commercial "ARP Solina Strings" / Vulture Culture SOURCE packs) could not be read - their samples were detected as "50 channels" and the length calculation failed. These chunks embed a complete WAV file rather than raw PCM; the embedded WAV is now read directly.
 
 ## 19.0.0
 

--- a/documentation/design/ZENCORE_FORMAT.md
+++ b/documentation/design/ZENCORE_FORMAT.md
@@ -318,13 +318,15 @@ computes `frames = f04 >> 1` regardless of the channel count, then allocates
 in 512-byte blocks with a fixed 64-frame allocation margin past the declared extent for the
 voice engine's read-ahead.
 
-**Roland SF2→SVZ converter `SMPd`** (reference only; not written by CWM): the output format of
-Roland's own SF2→SVZ converter, as shipped in commercial third-party packs (e.g. Vulture
-Culture's *SOURCE*): a `"SMPd"` tag with a u16 header size `0x20` at +4 and u8 version `1` at
-+6 (the device firmware validates exactly these fields), followed by a complete embedded
-`RIFF`/`WAVE` file at 0x20 (44100 Hz), and the `USDa` directory CRCs are 0. The `USPa` record
-is byte-identical to the device's. CWM decodes such packs and re-emits device-native raw-PCM
-`SMPd`.
+**Roland SF2→SVZ converter `SMPd`** (read by CWM; not written): the output of Roland's own
+SF2→SVZ converter, as shipped in commercial third-party packs (e.g. Vulture Culture's *SOURCE*,
+"ARP Solina Strings"). The header is 0x20 bytes - the sample name at 0x10, the rate at 0x0C, and
+the byte at 0x08 holding an unrelated `0x32` (NOT the channel count, which is the trap that made
+these files read as "50 channels") - followed by a **complete embedded `RIFF`/`WAVE` file at
+0x20** (PCM, 44100 Hz) rather than raw PCM, and the `USDa` directory CRCs are 0. The `USPa`
+record is byte-identical to the device's. CWM detects the variant by the `RIFF`/`WAVE` signature
+at 0x20 and reads the audio with the standard WAV reader (see `ZenCoreSvz.isEmbeddedWaveChunk` /
+`readEmbeddedWave`); it always writes the device-native raw-PCM `SMPd`.
 
 **Compact `SMPd`** (file version `02 01`; seen in third-party sample-pool exports, e.g. a pool
 tagged `Nemly`): follows the same `f04 = 2 × end` law at +4, the same bits at `0x009`, rate at

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSample.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSample.java
@@ -4,7 +4,7 @@
 
 package de.mossgrabers.convertwithmoss.format.roland.zencore;
 
-import de.mossgrabers.convertwithmoss.core.model.implementation.InMemorySampleData;
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
 
 
 /**
@@ -27,7 +27,7 @@ public class ZenCoreSample
     private int                startPoint         = 0;
     private int                loopStart          = 0;
     private int                endPoint           = 0;
-    private InMemorySampleData sampleData;
+    private ISampleData sampleData;
 
 
     /**
@@ -233,7 +233,7 @@ public class ZenCoreSample
      *
      * @return The sample data (or null if not resolved)
      */
-    public InMemorySampleData getSampleData ()
+    public ISampleData getSampleData ()
     {
         return this.sampleData;
     }
@@ -244,7 +244,7 @@ public class ZenCoreSample
      *
      * @param sampleData The sample data
      */
-    public void setSampleData (final InMemorySampleData sampleData)
+    public void setSampleData (final ISampleData sampleData)
     {
         this.sampleData = sampleData;
     }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
@@ -4,6 +4,7 @@
 
 package de.mossgrabers.convertwithmoss.format.roland.zencore;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,8 +12,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
 import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultAudioMetadata;
 import de.mossgrabers.convertwithmoss.core.model.implementation.InMemorySampleData;
+import de.mossgrabers.convertwithmoss.format.wav.WavFileSampleData;
 import de.mossgrabers.tools.Pair;
 
 
@@ -50,6 +53,11 @@ public final class ZenCoreSvz
     private static final int     SMPD_CHANNELS_KY019   = 0x08;
     /** Channel-count field of a compact SMPd header: a u16 holding 1 (mono) or 2 (stereo). */
     private static final int     SMPD_CHANNELS_COMPACT = 0x0A;
+    /**
+     * Offset of the embedded RIFF/WAVE file in a SF2-to-SVZ converter SMPd chunk: a 0x20 byte header
+     * followed by a complete WAV file rather than raw PCM.
+     */
+    private static final int     SMPD_EMBEDDED_WAVE    = 0x20;
 
     private static final int     NAME_LENGTH           = 16;
     private static final int     PREVIEW_OFFSET        = 0x60;
@@ -717,19 +725,36 @@ public final class ZenCoreSvz
                 final int chunkStart = usdSectionStart + chunkOffset;
                 if (chunkStart >= 0 && chunkSize > SMPD_HEADER_COMPACT && chunkStart + chunkSize <= file.length)
                 {
-                    // The storage layout comes from the SMPd chunk header, which has two variants
-                    // (see resolveSmpdLayout); an unrecognized chunk leaves the sample without
-                    // audio.
-                    final Optional<Pair<Integer, Integer>> layout = resolveSmpdLayout (file, chunkStart, chunkSize);
-                    if (layout.isPresent ())
+                    // A third SMPd variant - the output of Roland's SF2-to-SVZ converter, used by
+                    // some commercial packs - embeds a complete RIFF/WAVE file after a 0x20 byte
+                    // header instead of raw PCM (its byte at 0x08 is an unrelated 0x32, so the
+                    // raw-PCM channel detection cannot be used); it is read with the standard WAV
+                    // reader. Otherwise the header is one of the two raw-PCM variants (see
+                    // resolveSmpdLayout); an unrecognized chunk leaves the sample without audio.
+                    if (isEmbeddedWaveChunk (file, chunkStart))
                     {
-                        final Pair<Integer, Integer> pair = layout.get ();
-                        final int channels = pair.getKey ().intValue ();
-                        final int headerSize = pair.getValue ().intValue ();
-                        final int rate = (int) ZenCoreUtil.readUnsigned32 (file, chunkStart + 0x0C, false);
-                        final int pcmStart = chunkStart + headerSize;
-                        final int pcmSize = chunkSize - headerSize;
-                        sample.setSampleData (decodePcm (file, pcmStart, pcmSize, channels, rate < 8000 || rate > 192000 ? 48000 : rate));
+                        try
+                        {
+                            sample.setSampleData (readEmbeddedWave (file, chunkStart, chunkSize));
+                        }
+                        catch (final IOException ex)
+                        {
+                            // A malformed embedded WAV leaves the sample without audio.
+                        }
+                    }
+                    else
+                    {
+                        final Optional<Pair<Integer, Integer>> layout = resolveSmpdLayout (file, chunkStart, chunkSize);
+                        if (layout.isPresent ())
+                        {
+                            final Pair<Integer, Integer> pair = layout.get ();
+                            final int channels = pair.getKey ().intValue ();
+                            final int headerSize = pair.getValue ().intValue ();
+                            final int rate = (int) ZenCoreUtil.readUnsigned32 (file, chunkStart + 0x0C, false);
+                            final int pcmStart = chunkStart + headerSize;
+                            final int pcmSize = chunkSize - headerSize;
+                            sample.setSampleData (decodePcm (file, pcmStart, pcmSize, channels, rate < 8000 || rate > 192000 ? 48000 : rate));
+                        }
                     }
                 }
             }
@@ -796,6 +821,41 @@ public final class ZenCoreSvz
         for (int i = 0; i < count; i++)
             values[i] = ZenCoreUtil.readUnsigned16 (file, offset + i * 2, false);
         return values;
+    }
+
+
+    /**
+     * Whether a SMPd chunk is the SF2-to-SVZ converter variant, which embeds a complete RIFF/WAVE
+     * file after a {@link #SMPD_EMBEDDED_WAVE} byte header instead of raw PCM. Detected by the
+     * RIFF/WAVE signature at that offset.
+     *
+     * @param file The file content
+     * @param chunkStart The absolute offset of the SMPd chunk
+     * @return True if the chunk embeds a RIFF/WAVE file
+     */
+    private static boolean isEmbeddedWaveChunk (final byte [] file, final int chunkStart)
+    {
+        final int riff = chunkStart + SMPD_EMBEDDED_WAVE;
+        return riff + 12 <= file.length && file[riff] == 'R' && file[riff + 1] == 'I' && file[riff + 2] == 'F' && file[riff + 3] == 'F' && file[riff + 8] == 'W' && file[riff + 9] == 'A' && file[riff + 10] == 'V' && file[riff + 11] == 'E';
+    }
+
+
+    /**
+     * Read the embedded RIFF/WAVE file of a SF2-to-SVZ converter SMPd chunk (the audio follows the
+     * {@link #SMPD_EMBEDDED_WAVE} byte header) with the standard WAV reader.
+     *
+     * @param file The file content
+     * @param chunkStart The absolute offset of the SMPd chunk
+     * @param chunkSize The chunk size from the USDa directory
+     * @return The sample data
+     * @throws IOException The embedded WAV could not be read
+     */
+    private static ISampleData readEmbeddedWave (final byte [] file, final int chunkStart, final int chunkSize) throws IOException
+    {
+        final int waveStart = chunkStart + SMPD_EMBEDDED_WAVE;
+        final byte [] wave = new byte [chunkStart + chunkSize - waveStart];
+        System.arraycopy (file, waveStart, wave, 0, wave.length);
+        return new WavFileSampleData (new ByteArrayInputStream (wave));
     }
 
 


### PR DESCRIPTION
Follow-up to the SVZ read fix (#204). That handled the compact (version `02 01`) sample header; this handles the **third** SMPd variant, reported after #204: SVZ packs produced by **Roland's own SF2-to-SVZ converter** (shipped in commercial packs such as *ARP Solina Strings* / Vulture Culture's *SOURCE*).

### Cause

These `SMPd` chunks embed a **complete RIFF/WAVE file** after a 0x20-byte header instead of raw PCM. The byte at `0x08` is an unrelated `0x32`, so the raw-PCM channel detection read the samples as **"50 channels"** and the length calculation failed.

### Fix

Detect the variant by the `RIFF`/`WAVE` signature at offset `0x20`, and read the embedded WAV with the standard `WavFileSampleData` reader (channels, rate, bits and PCM all come from the embedded `fmt `/`data` chunks). `ZenCoreSample` now holds an `ISampleData`, so a sample carries either the raw-PCM result (`InMemorySampleData`) or the embedded-WAV result (`WavFileSampleData`). The two existing raw-PCM variants — FANTOM/KY019 (460-byte header) and the compact `02 01` (158-byte header) — are unchanged.

### Verified

- Converter pack `ARP Solina Strings.svz` (61 zones) now reads as **2 ch / 44100 / 16-bit** with real audio, instead of failing.
- No regression: the compact pack (`02_Melodic.svz`) and a KY019 device export (`EOH_BANK.svz`) still read correctly (2 ch, correct rates).

The design spec (`ZENCORE_FORMAT.md` §3.4) is updated to document this as a read variant. This closes the reporter's remaining "channels = 50" case from the #204 thread.