### PR TITLE
TAL Sampler: read the pitch envelope depth from the correct matrix row

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/tal/TALSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/tal/TALSamplerDetector.java
@@ -341,7 +341,7 @@ public class TALSamplerDetector extends AbstractDetector<MetadataSettingsUI>
         // Envelope 3 needs to be set to modulate the global pitch
         double globalPitchEnvelopeDepth = -1;
         for (final TALSamplerModulator modulator: modulators)
-            if (modulator.isSource (TALSamplerModulator.SOURCE_ID_ENV3) || modulator.isDestination (TALSamplerModulator.DEST_ID_TUNE_A, TALSamplerModulator.DEST_ID_MASTER_TUNE))
+            if (modulator.isSource (TALSamplerModulator.SOURCE_ID_ENV3) && modulator.isDestination (TALSamplerModulator.DEST_ID_TUNE_A, TALSamplerModulator.DEST_ID_MASTER_TUNE))
             {
                 globalPitchEnvelopeDepth = modulator.getModAmount ();
                 break;


### PR DESCRIPTION
The lookup which finds the modulation routing envelope 3 to the global pitch combines its two conditions with a logical **OR** instead of an **AND**:

```java
if (modulator.isSource (SOURCE_ID_ENV3) || modulator.isDestination (DEST_ID_TUNE_A, DEST_ID_MASTER_TUNE))
```

so it accepts the first row which is *either* sourced from envelope 3 *or* targets a tuning parameter, and takes its amount as the depth of the pitch envelope. The two comparable lookups in the same method (`isDestination (VOLUME_A) && isSource (VELOCITY)` and `isDestination (CUTOFF) && isSource (VELOCITY)`) use AND, so this one is the outlier.

The practical effect is that a row like *LFO → Master Tune* supplies the depth of a pitch envelope which the preset does not have.

### Measured

The 214 TAL Sampler presets of the Goldbaby BlueWave library:

| | presets |
|---|---|
| no envelope 3 → tuning row exists, but a depth of 0.5–1.0 is taken from another row | **207** |
| such a row exists, but a different row is read first | 7 |
| unaffected | 0 |

The row picked up instead is the same one in almost every case — source id 3 targeting Master Tune, in presets named `…RiseLFO…`, `…FallLFO…`, `…randLFO…`.

Converting one folder of eight presets to SFZ, before and after:

| | zones with a pitch envelope |
|---|---|
| before | 1006, at depths of 5359 to 12000 cent (4.5 to 10 octaves) |
| after | 296 |

Six of the eight presets lose the pitch envelope completely, which is correct — they have no envelope 3 to tuning modulation. The remaining two really do have one and keep their envelope, now with the amount of the correct row. Nothing other than the pitch envelope differs between the two runs.

### Note

Found while auditing the readers for a related question on #216 (whether a modulation amount that is gated behind a controller can be read as one which is always applied). This one is independent of that PR and of the format's mod matrix having no "via" column — it is purely the operator.
