### PR TITLE
CWITEC TX16Wx: ignore modulation slots which are switched off

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxDetector.java
@@ -789,7 +789,12 @@ public class TX16WxDetector extends AbstractDetector<MetadataWithSearchHeightSet
         final Element modulationElement = XMLUtils.getChildElementByName (soundShapeElement, TX16WxTag.MODULATION);
         if (modulationElement != null)
             for (final Element modulationEntryElement: XMLUtils.getChildElementsByName (modulationElement, TX16WxTag.MODULATION_ENTRY, false))
-                modulators.add (new TX16WxModulator (modulationEntryElement));
+            {
+                // A slot which is switched off is not applied by the sampler either
+                final TX16WxModulator modulator = new TX16WxModulator (modulationEntryElement);
+                if (modulator.isEnabled ())
+                    modulators.add (modulator);
+            }
         return modulators;
     }
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxModulator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxModulator.java
@@ -16,9 +16,10 @@ import org.w3c.dom.Element;
  */
 public class TX16WxModulator
 {
-    private final String source;
-    private final String destination;
-    private final String amount;
+    private final String  source;
+    private final String  destination;
+    private final String  amount;
+    private final boolean isEnabled;
 
 
     /**
@@ -31,6 +32,35 @@ public class TX16WxModulator
         this.source = modulationEntryElement.getAttribute (TX16WxTag.MODULATION_SOURCE);
         this.destination = modulationEntryElement.getAttribute (TX16WxTag.MODULATION_DESTINATION);
         this.amount = modulationEntryElement.getAttribute (TX16WxTag.MODULATION_AMOUNT);
+        this.isEnabled = parseEnabled (modulationEntryElement.getAttribute (TX16WxTag.MODULATION_ENABLED));
+    }
+
+
+    /**
+     * Check if the modulation slot is enabled. A disabled slot is not applied by the sampler.
+     *
+     * @return True if it is enabled
+     */
+    public boolean isEnabled ()
+    {
+        return this.isEnabled;
+    }
+
+
+    /**
+     * Parse the enabled attribute. It is optional, a missing one means that the slot is enabled.
+     * The value is a XML schema boolean, which is written as either 'false' or '0' when the slot is
+     * switched off.
+     *
+     * @param value The attribute value, might be empty
+     * @return True if the slot is enabled
+     */
+    private static boolean parseEnabled (final String value)
+    {
+        if (value == null || value.isBlank ())
+            return true;
+        final String trimmed = value.trim ();
+        return !("false".equalsIgnoreCase (trimmed) || "0".equals (trimmed));
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxTag.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxTag.java
@@ -185,6 +185,8 @@ public class TX16WxTag
     public static final String MODULATION_DESTINATION = "tx:destination";
     /** The modulation amount attribute. */
     public static final String MODULATION_AMOUNT      = "tx:amount";
+    /** The modulation enabled attribute. */
+    public static final String MODULATION_ENABLED     = "tx:enabled";
     /** The modulation source curve tag. */
     public static final String MODULATION_SRC_CURVE   = "tx:src-curve";
     /** The modulation via curve tag. */


### PR DESCRIPTION
A modulation matrix entry of a TX16Wx program carries an `enabled` attribute, but `parseModulators` added every entry it found:

```java
for (final Element modulationEntryElement: XMLUtils.getChildElementsByName (modulationElement, TX16WxTag.MODULATION_ENTRY, false))
    modulators.add (new TX16WxModulator (modulationEntryElement));
```

`TX16WxModulator` read only `source`, `destination` and `amount`, so a slot which the user had switched off in the sampler was still applied on import.

The user manual (7.3.11, "Modulation matrix") describes the attribute as *"Enables/disables this modulation slot"*, and the schema declares it as an optional `xs:boolean` on `<tx:entry>`. A missing attribute therefore still means enabled, and both `false` and `0` switch the slot off.

This is the same handling the other formats with a matrix already have - Logic EXS24 skips an entry whose `MOD*_BYPASS` is set, and Kontakt skips a bypassed modulator.

### Verified

There is no public TX16Wx content to test against, so the programs were written by the converter itself and the pitch-bend entry was then set to 1200 cent, once per variant of the attribute:

| `tx:enabled` | before | after |
|---|---|---|
| *(absent)* | `bend_up=1200` | `bend_up=1200` |
| `"true"` | `bend_up=1200` | `bend_up=1200` |
| `"false"` | `bend_up=1200` | `bend_up=200` (default, slot skipped) |
| `"0"` | `bend_up=1200` | `bend_up=200` (default, slot skipped) |

Reading back 100 converted programs, none of which carry the attribute, gives byte-identical results, so nothing changes for material which does not use the switch.

### Not changed

The `via` attribute is deliberately left alone. It scales the modulation between `amount` and `amount_via` depending on the controller, so `amount` is the value which applies while the controller is at zero - reading it, as the code does, is already the correct always-applied depth. `frozen` only means the source is sampled once at note-on, which does not affect a static conversion.
