### PR TITLE
Keep the dot when making file names safe

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/core/creator/AbstractCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/creator/AbstractCreator.java
@@ -213,7 +213,10 @@ public abstract class AbstractCreator<T extends ICoreTaskSettings> extends Abstr
         // Replace invalid filename characters
         // Windows forbidden: \ / : * ? " < > |
         // Also remove Unix path separator /
-        sanitized = sanitized.replaceAll ("[\\\\/:*?\"<>|&\\.']", "_");
+        // A dot is kept - it is a valid file name character (e.g. "My.Sample") and formats which
+        // use the name as a display label, like the Roland SP-404MK2 pad name, would otherwise
+        // lose it; only leading/trailing dots are stripped below.
+        sanitized = sanitized.replaceAll ("[\\\\/:*?\"<>|&']", "_");
 
         // Remove leading/trailing spaces and dots (Windows issue)
         sanitized = sanitized.replaceAll ("^[ .]+", "");


### PR DESCRIPTION
`createSafeFilename` currently replaces a dot with an underscore, so a name like `My.Sample` becomes `My_Sample`. A dot is a valid file name character on every supported platform, and the surrounding code already handles the cases that actually matter: leading and trailing dots are stripped on the following two lines (the Windows issue), and `createUniqueFilename` appends the extension through `withoutExtensionTail`, so an inner dot cannot collide with the extension logic.

The characters that are genuinely problematic are untouched by this change - `\ / : * ? " < > |` are still replaced, as are `&` and `'`.

This also matters for formats which use the zone name as a *display label* rather than as a file name. `ConverterBackend.ensureSafeSampleFileNames` sanitizes every zone name up front, so such a format cannot opt out: in the Roland SP-404MK2 (#225) the pad name is shown on the device while the audio is stored under a fixed `BANK<b>-<p>.SMP` name, and a pad called `@1prod.mars Gala` currently arrives as `@1prod_mars Gala`.

Split out of #225 so that it can be judged on its own, since it affects the output of every creator. #225 does not depend on it - without this change the SP-404MK2 simply shows underscores in those pad names, and nothing else differs.

Checked that dotted names still round-trip through a file-based format (SFZ -> Bitwig writes `Snare.Tight.multisample` and reads it back as `Snare.Tight`, with no double extension).
