### PR TITLE
List the three E-mu Emulators together in the format menus

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
@@ -167,11 +167,11 @@ public class ConverterBackend
         this.detectors.add (new DecentSamplerDetector (notifier));
         this.detectors.add (new DlsDetector (notifier));
         this.detectors.add (new DistingExDetector (notifier));
+        this.detectors.add (new Emulator3Detector (notifier));
         this.detectors.add (new Emulator4Detector (notifier));
+        this.detectors.add (new EmulatorXDetector (notifier));
         this.detectors.add (new TonverkMultiDetector (notifier));
         this.detectors.add (new TonverkPresetDetector (notifier));
-        this.detectors.add (new Emulator3Detector (notifier));
-        this.detectors.add (new EmulatorXDetector (notifier));
         this.detectors.add (new EnsoniqEpsAsrDetector (notifier));
         this.detectors.add (new MirageDetector (notifier));
         this.detectors.add (new FairlightCmi3Detector (notifier));
@@ -211,11 +211,11 @@ public class ConverterBackend
         this.creators.add (new TX16WxCreator (notifier));
         this.creators.add (new DecentSamplerCreator (notifier));
         this.creators.add (new DistingExCreator (notifier));
+        this.creators.add (new Emulator3Creator (notifier));
         this.creators.add (new Emulator4Creator (notifier));
+        this.creators.add (new EmulatorXCreator (notifier));
         this.creators.add (new TonverkMultiCreator (notifier));
         this.creators.add (new TonverkPresetCreator (notifier));
-        this.creators.add (new Emulator3Creator (notifier));
-        this.creators.add (new EmulatorXCreator (notifier));
         this.creators.add (new KMPCreator (notifier));
         this.creators.add (new KorgmultisampleCreator (notifier));
         this.creators.add (new KurzweilCreator (notifier));


### PR DESCRIPTION
The source and destination menus follow the order in which the formats are registered in `ConverterBackend`, and the three E-mu Emulators ended up in two places once all of them had been merged:

```
Expert Sleepers Disting EX
E-mu Emulator IV              <- with the Disting EX
Elektron Tonverk Multisample
Elektron Tonverk Preset
E-mu Emulator III             <- behind the Elektron entries
E-mu Emulator X
Ensoniq EPS/EPS16+/ASR-10
```

Each of the three was added by a separate PR against a `main` which did not have the other two, so none of them could place its entry next to the others. They are now registered as one block, in the order of their names, at the position the Emulator IV already had:

```
Expert Sleepers Disting EX
E-mu Emulator III
E-mu Emulator IV
E-mu Emulator X
Elektron Tonverk Multisample
Elektron Tonverk Preset
```

Registration order only - four moved lines in each of the two lists, no behaviour change.
