### PR TITLE
Repair the E-mu Emulator rows of the feature matrix

### DIFF
--- a/documentation/SupportedFeaturesSampleFormats.fods
+++ b/documentation/SupportedFeaturesSampleFormats.fods
@@ -3348,588 +3348,437 @@
      <table:table-cell table:style-name="ce11" table:number-columns-repeated="2"/>
      <table:table-cell table:style-name="Default" table:number-columns-repeated="16315"/>
     </table:table-row>
-    <table:table-row table:style-name="ro10">
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>E-mu Emulator III / IIIX / ESI</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
-      <text:p>Read</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>e3b, e3x, esi</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Bank with up to 256 presets and 999 samples</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce12" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>16</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>All</text:p>
-     </table:table-cell>
+    <table:table-row table:style-name="ro6">
+     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>E-mu Emulator III / IIIX / ESI</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Read</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>e3b, e3x, esi</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Bank with up to 256 presets and 999 samples</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce12" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>16</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>All</text:p></table:table-cell>
      <table:table-cell table:style-name="ce3" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
      <table:table-cell table:style-name="ce16" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>E-mu Emulator X</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
-      <text:p>Read</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>exb, ebl</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>exb (bank)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce12" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>E-mu Emulator IV</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
-      <text:p>Read</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>e4b</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Bank with several presets</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce12" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
-      <text:p>16</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>All</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce3"/>
-     <table:table-cell table:style-name="ce16"/>
-     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string">
-      <text:p>Preset name</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>Phdr category,</text:p><text:p>mapped to the</text:p><text:p>model categories</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" table:number-columns-repeated="4"/>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce13"/>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string">
-      <text:p>E5ZL zone</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Zhdr original key</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>ETW key window</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>ETW key fades</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>ETW velocity window</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>ETW velocity fades</text:p>
-     </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce13" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>E5Oc transpose, coarse, fine</text:p>
-     </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce13" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>E5Am volume (dB,</text:p><text:p>-96 to +10)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>E5Am pan</text:p>
-     </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce13" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string">
-      <text:p>EBL loop flag</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>only forwards</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>EBL loop start</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>EBL loop end</text:p>
-     </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce56"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>6-stage envelope</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>velocity to volume cord</text:p>
-     </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce3"/>
-     <table:table-cell table:style-name="ce11"/>
-     <table:table-cell table:number-columns-repeated="3" table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce3"/>
-     <table:table-cell table:style-name="ce63"/>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>Lowpass / Highpass /</text:p><text:p>Bandpass / Contrary BP</text:p><text:p>(effect types skipped)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>2 / 4 / 6</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>E5Fl cutoff</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>6-stage envelope +</text:p><text:p>cord depth</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Preset name (16 characters)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>from filename</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce11" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
-      <text:p>Bank name</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>from filename</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Primary / secondary layer, linked presets</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Preset name (16 characters)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>from filename</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce57" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>Bank name</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>from filename</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Primary / secondary layer, linked presets</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
      <table:table-cell table:style-name="ce4" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Original key</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Note zone key map (MIDI 21-108)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce18" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Velocity range of the layer (per group)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Zone tuning (+/-100 cents)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Non-transpose flag</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Amplifier level</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Zone panorama</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Bank name (read only)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>from filename</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Voices</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
-      <text:p>Generated (&apos;Voice N&apos;)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Root key</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Low / high key</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Low / high velocity</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>Key transpose + coarse</text:p><text:p>+ fine tune, zone fine</text:p><text:p>tune, sample pitch offset</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>Non-transpose flag</text:p><text:p>(on / off)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Voice + zone volume (dB)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Zone pan (-64 ... +63)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Original key</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Note zone key map (MIDI 21-108)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce18" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Velocity range of the layer (per group)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Zone tuning (+/-100 cents)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Non-transpose flag</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Amplifier level</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Zone panorama</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
      <table:table-cell table:style-name="ce4" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Forward</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Loop in release flag</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Forward</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce59" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Loop start</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Loop end</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce9" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Amplifier envelope (attack, hold, decay, sustain, release)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Velocity to amplifier level</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce20" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce9" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Pitch bend range (semitones, per preset)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Same as bend up (per preset)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Auxiliary envelope with pitch destination</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce20" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce9" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>ESI: low-pass, high-pass, band-pass, notch / EIII, EIIIX: low-pass</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>2 / 4 / 6</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Filter cutoff (26 Hz - 74 kHz)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Filter Q</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Filter envelope + amount</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Velocity to filter cutoff</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Filter tracking</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce7" table:number-columns-repeated="16215"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Forward</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Loop in release flag</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Loop start</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Loop end</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce56" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Amplifier envelope (attack, hold, decay, sustain, release)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Velocity to amplifier level</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce77" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce56" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Pitch bend range (semitones, per preset)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Same as bend up (per preset)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Auxiliary envelope with pitch destination</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce77" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce56" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>ESI: low-pass, high-pass, band-pass, notch / EIII, EIIIX: low-pass</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>2 / 4 / 6</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Filter cutoff (26 Hz - 74 kHz)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Filter Q</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Filter envelope + amount</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Velocity to filter cutoff</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Filter tracking</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce67" table:number-columns-repeated="16315"/>
     </table:table-row>
-    <table:table-row table:style-name="ro11">
-     <table:covered-table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string">
-      <text:p>E-mu Emulator III / IIIX / ESI</text:p>
-     </table:covered-table-cell>
-     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
-      <text:p>Write</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>e3x, esi</text:p>
-     </table:table-cell>
-     <table:covered-table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string">
-      <text:p>Bank with up to 256 presets and 999 samples</text:p>
-     </table:covered-table-cell>
+    <table:table-row table:style-name="ro12">
+     <table:covered-table-cell table:style-name="ce2"><text:p>E-mu Emulator III / IIIX / ESI</text:p></table:covered-table-cell>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Write</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>e3x, esi</text:p></table:table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Bank with up to 256 presets and 999 samples</text:p></table:covered-table-cell>
      <table:covered-table-cell table:style-name="ce12"/>
-     <table:covered-table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
-      <text:p>16</text:p>
-     </table:covered-table-cell>
-     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
-      <text:p>Up to 44.1 kHz</text:p>
-     </table:table-cell>
+     <table:covered-table-cell table:style-name="ce16"><text:p>16</text:p></table:covered-table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>Up to 44.1 kHz</text:p></table:table-cell>
      <table:covered-table-cell table:style-name="ce3"/>
      <table:covered-table-cell table:style-name="ce16"/>
-     <table:covered-table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string">
-      <text:p>Preset name (16 characters)</text:p>
-     </table:covered-table-cell>
-     <table:table-cell table:style-name="ce11"/>
-     <table:covered-table-cell table:style-name="ce11"/>
-     <table:table-cell table:style-name="ce11" table:number-columns-repeated="2"/>
-     <table:covered-table-cell table:style-name="ce11"/>
-     <table:table-cell table:style-name="ce23"/>
-     <table:covered-table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string">
-      <text:p>Primary / secondary layer, linked presets</text:p>
-     </table:covered-table-cell>
-     <table:covered-table-cell table:number-columns-repeated="2" table:style-name="ce11"/>
-     <table:table-cell table:style-name="ce23"/>
-     <table:table-cell table:style-name="ce11"/>
-     <table:table-cell table:style-name="ce23"/>
+     <table:covered-table-cell table:style-name="ce4"><text:p>Preset name (16 characters)</text:p></table:covered-table-cell>
+     <table:table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce70"/>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Primary / secondary layer, linked presets</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce70"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce70"/>
+     <table:covered-table-cell table:style-name="ce4"/>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Original key</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Note zone key map (MIDI 21-108)</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce13"/>
+     <table:covered-table-cell table:style-name="ce18"><text:p>Velocity range of the layer (per group)</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce13"/>
+     <table:covered-table-cell table:style-name="ce13"/>
+     <table:covered-table-cell table:style-name="ce13"/>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Zone tuning (+/-100 cents)</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Non-transpose flag</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce13"/>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Amplifier level</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Zone panorama</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce13"/>
+     <table:covered-table-cell table:style-name="ce13"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce70"/>
+     <table:covered-table-cell table:style-name="ce4"/>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Forward</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce56"><text:p>Loop in release flag</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Loop start</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Loop end</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce70"/>
+     <table:covered-table-cell table:style-name="ce56"/>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Amplifier envelope (attack, hold, decay, sustain, release)</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce56"><text:p>Velocity to amplifier level</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce77"/>
+     <table:covered-table-cell table:style-name="ce56"/>
+     <table:covered-table-cell table:style-name="ce63"><text:p>Pitch bend range (semitones, per preset)</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce63"><text:p>Same as bend up (per preset)</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Auxiliary envelope with pitch destination</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce77"/>
+     <table:covered-table-cell table:style-name="ce77"/>
+     <table:covered-table-cell table:style-name="ce56"/>
+     <table:covered-table-cell table:style-name="ce63"><text:p>ESI: low-pass, high-pass, band-pass, notch / EIII, EIIIX: low-pass</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>2 / 4 / 6</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Filter cutoff (26 Hz - 74 kHz)</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Filter Q</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce9"><text:p>Filter envelope + amount</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce56"><text:p>Velocity to filter cutoff</text:p></table:covered-table-cell>
+     <table:covered-table-cell table:style-name="ce56"><text:p>Filter tracking</text:p></table:covered-table-cell>
+     <table:table-cell table:style-name="ce67" table:number-columns-repeated="16315"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro6">
+     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>E-mu Emulator IV</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Read</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>e4b</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Bank with several presets</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce12" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>16</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>All</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce16"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Preset name (16 characters)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>from filename</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce57" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Bank name (read only)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>from filename</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>Voices</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>Generated ('Voice N')</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Original key</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Note zone key map (MIDI 21-108)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce13"/>
-     <table:table-cell table:style-name="ce18" office:value-type="string" calcext:value-type="string">
-      <text:p>Velocity range of the layer (per group)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce13" table:number-columns-repeated="3"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Zone tuning (+/-100 cents)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Non-transpose flag</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce13"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Amplifier level</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Zone panorama</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce13" table:number-columns-repeated="2"/>
-     <table:table-cell table:style-name="ce11" table:number-columns-repeated="2"/>
-     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Root key</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Low / high key</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Low / high velocity</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>Key transpose + coarse</text:p><text:p>+ fine tune, zone fine</text:p><text:p>tune, sample pitch offset</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>Non-transpose flag</text:p><text:p>(on / off)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Voice + zone volume (dB)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Zone pan (-64 ... +63)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
      <table:table-cell table:style-name="ce4"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Forward</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Loop in release flag</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Loop start</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Loop end</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" table:number-columns-repeated="2"/>
-     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Forward</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Loop start</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Loop end</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
      <table:table-cell table:style-name="ce56"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Amplifier envelope (attack, hold, decay, sustain, release)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11"/>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Velocity to amplifier level</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" table:number-columns-repeated="2"/>
-     <table:table-cell table:style-name="ce20"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>6-stage envelope (attack,</text:p><text:p>hold, decay, sustain,</text:p><text:p>release)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Velocity to Amp cord</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce77"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce77"/>
      <table:table-cell table:style-name="ce56"/>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>Pitch bend range (semitones, per preset)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>Same as bend up (per preset)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Auxiliary envelope with pitch destination</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce20" table:number-columns-repeated="2"/>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>Lowpass / Highpass /</text:p><text:p>Bandpass / Contrary BP</text:p><text:p>(effect types skipped)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>2 / 4 / 6</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Cutoff (57 Hz - 20 kHz)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Resonance</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>6-stage envelope +</text:p><text:p>Cord 5 depth</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>Key to Cutoff cord</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce67" table:number-columns-repeated="16315"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro12">
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Write</text:p></table:table-cell>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>16</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>Up to 48 kHz</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce16"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>One voice per zone</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce70"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce4"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>Coarse + fine tune</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>Non-transpose flag</text:p><text:p>(on / off)</text:p></table:table-cell>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce4"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce70"/>
      <table:table-cell table:style-name="ce56"/>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string">
-      <text:p>ESI: low-pass, high-pass, band-pass, notch / EIII, EIIIX: low-pass</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>2 / 4 / 6</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Filter cutoff (26 Hz - 74 kHz)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Filter Q</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Filter envelope + amount</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Velocity to filter cutoff</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string">
-      <text:p>Filter tracking</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce23"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce77"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce77"/>
+     <table:table-cell table:style-name="ce77"/>
      <table:table-cell table:style-name="ce56"/>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>6-stage envelope (attack,</text:p><text:p>hold, decay, sustain,</text:p><text:p>release)</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:covered-table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string">
-      <text:p>Velocity to Amp cord</text:p>
-     </table:covered-table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce20"/>
-     <table:table-cell table:style-name="ce11"/>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce11" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>TODO Check for support</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce20"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>Lowpass / Highpass /</text:p><text:p>Bandpass / Contrary BP</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>Nearest of 2 / 4 / 6</text:p></table:table-cell>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce67" table:number-columns-repeated="16315"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro6">
+     <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>E-mu Emulator X</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Read</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>exb, ebl</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>exb (bank)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce12" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>16</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>All</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce16"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>Preset name</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>Phdr category,</text:p><text:p>mapped to the</text:p><text:p>model categories</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce13"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>E5ZL zone</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>Zhdr original key</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW key window</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW key fades</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW velocity window</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW velocity fades</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>E5Oc transpose, coarse, fine</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>E5Am volume (dB,</text:p><text:p>-96 to +10)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>E5Am pan</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>EBL loop flag</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>only forwards</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>EBL loop start</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>EBL loop end</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce56"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>6-stage envelope</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>velocity to volume cord</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce63"/>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>Lowpass / Highpass /</text:p><text:p>Bandpass / Contrary BP</text:p><text:p>(effect types skipped)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>2 / 4 / 6</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>E5Fl cutoff</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>6-stage envelope +</text:p><text:p>cord depth</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce67" table:number-columns-repeated="16315"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro12">
+     <table:covered-table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Write</text:p></table:table-cell>
      <table:covered-table-cell table:style-name="ce9"/>
-     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>Lowpass / Highpass /</text:p><text:p>Bandpass / Contrary BP</text:p><text:p>(effect types skipped)</text:p>
-     </table:table-cell>
-     <table:covered-table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string">
-      <text:p>2 / 4 / 6</text:p>
-     </table:covered-table-cell>
-     <table:covered-table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string">
-      <text:p>Cutoff (57 Hz - 20 kHz)</text:p>
-     </table:covered-table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>Resonance</text:p>
-     </table:table-cell>
-     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2"><text:p>6-stage envelope +</text:p><text:p>Cord 5 depth</text:p>
-     </table:table-cell>
-     <table:covered-table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string">
-      <text:p>TODO Check for support</text:p>
-     </table:covered-table-cell>
-     <table:covered-table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string">
-      <text:p>Key to Cutoff cord</text:p>
-     </table:covered-table-cell>
-     <table:covered-table-cell table:number-columns-repeated="19"/>
-     <table:table-cell table:number-columns-repeated="4"/>
-     <table:covered-table-cell/>
-     <table:table-cell/>
-     <table:covered-table-cell/>
-     <table:table-cell table:number-columns-repeated="2"/>
-     <table:covered-table-cell table:number-columns-repeated="7"/>
-     <table:table-cell table:number-columns-repeated="2"/>
-     <table:covered-table-cell table:number-columns-repeated="11"/>
-     <table:table-cell table:number-columns-repeated="2"/>
-     <table:covered-table-cell table:number-columns-repeated="28"/>
-     <table:table-cell table:style-name="ce7" table:number-columns-repeated="16215"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>exb (bank)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce12" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string"><text:p>16</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>All</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce16"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>Name</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>Phdr category</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce13"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>E5ZL zone</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>Zhdr original key</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW key window</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW key fades</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW velocity window</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>ETW velocity fades</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>E5Oc coarse, fine</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>E5Am volume (dB,</text:p><text:p>-96 to +10)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>E5Am pan</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce4" office:value-type="string" calcext:value-type="string"><text:p>EBL loop flag</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>only forwards</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>EBL loop start</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>EBL loop end</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce70"/>
+     <table:table-cell table:style-name="ce56"/>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>6-stage envelope</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>velocity to volume cord</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce57"/>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:covered-table-cell table:style-name="ce77"/>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce63"/>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>Lowpass / Highpass /</text:p><text:p>Bandpass / Contrary BP</text:p><text:p>(effect types skipped)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>2 / 4 / 6</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>E5Fl cutoff</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce9" office:value-type="string" calcext:value-type="string"><text:p>6-stage envelope +</text:p><text:p>cord depth</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce57" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce67" table:number-columns-repeated="16315"/>
     </table:table-row>
     <table:table-row table:style-name="ro4">
      <table:table-cell table:style-name="ce3"/>


### PR DESCRIPTION
The three Emulator formats were merged into the sheet one after the other, and every one of those merges appended the new format's cells to the **end of the existing row** rather than adding a row pair of its own. The corruption is visible in the history:

| after | row 25 | cells |
|---|---|---|
| #220 Emulator IV | `E-mu Emulator IV` / Read | 70 |
| #229 Emulator X | `E-mu Emulator X` / Read | 135 |
| #230 Emulator III | `E-mu Emulator III / IIIX / ESI` / Read | 170 |

So on current `main` one row holds three formats side by side - Emulator III in columns 0-6, then Emulator X from column 9, then Emulator IV from column 14. Only the Emulator III has a name, and its own columns are overwritten from column 9 on; the Emulator IV and Emulator X have no rows of their own at all.

This restores them from the last revision in which each format still had its own pair, so the sheet now has six rows in the order of their names:

```
E-mu Emulator III / IIIX / ESI   Read / Write
E-mu Emulator IV                 Read / Write
E-mu Emulator X                  Read / Write
```

Each is the regular width again, the `TODO Check for support` markers are kept, and no other row of the sheet is touched.

Worth knowing for the next format merge: a text union is not a safe conflict resolution for this file. Two branches adding rows at the same anchor produce exactly this - the cells are concatenated into one row instead of the rows being stacked. Taking one side and re-adding the other format's rows afterwards avoids it.
