### PR TITLE
E-mu Emulator X: do not report an unassigned zone as a missing sample

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulatorx/EmulatorXDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulatorx/EmulatorXDetector.java
@@ -381,7 +381,11 @@ public class EmulatorXDetector extends AbstractDetector<MetadataSettingsUI>
             if (zoneHeader == null || !child.isList (EmulatorXConstants.WINDOW_LIST_TYPE))
                 continue;
 
-            final Integer sampleIndex = Integer.valueOf (zoneHeader.getU16 (EmulatorXConstants.ZONE_SAMPLE_INDEX));
+            // The sample indices are 1-based, index 0 means that the zone has no sample assigned
+            final int index = zoneHeader.getU16 (EmulatorXConstants.ZONE_SAMPLE_INDEX);
+            if (index == 0)
+                continue;
+            final Integer sampleIndex = Integer.valueOf (index);
             final EmulatorXSampleFile sampleFile = samples.get (sampleIndex);
             if (sampleFile == null)
             {


### PR DESCRIPTION
Found while going through the Mo'Phatt bank from your test files.

The sample index of a zone is 1-based, and an index of 0 means the zone has no sample assigned. Such a zone was looked up like any other and then reported as an error:

```
Sample with index 0 referenced by preset 'bts:The Ultimate' not found. Skipped.
Sample with index 0 referenced by preset 'kit:UainT@&#!' not found. Skipped.
...
```

which makes a perfectly good bank look broken. An index of 0 is now skipped silently, the same way the Emulator IV detector already handles it.

What remains reported for that bank is genuine and worth keeping:

* `45 sample(s) of the bank are missing in the sample pool` - the archive really is incomplete. The bank references indices 1742, 1759, 1760 ... whose `.ebl` files are not there, while the pool instead holds 45 files (indices 1-45, *Clap Group*, *Congas 1*, *Congas 2* ...) which the bank never references.
* `Sample with index 371 referenced by preset 'hit:All 2' not found` - a dangling reference in the bank itself; index 371 is not in the bank's own table of contents either.

Preset count is unchanged at 509.
