### PR TITLE
Added support for a volume LFO (tremolo): DecentSampler, DLS, SFZ, SoundFont 2

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -13,6 +13,7 @@
   * New: Added tooltips to format lists to be able to see the full text of an entry.
 * Backend
   * New: Added support for a LFO (low frequency oscillator) modulating pitch (vibrato) with its rate, depth and delay: DecentSampler, DLS, SFZ, SoundFont 2. Other formats pending.
+  * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -238,7 +238,7 @@ A dspreset file contains a single preset and the description of the multi-sample
 
 There are no metadata fields (category, creator, etc.) specified in the format. Therefore, information is stored and retrieved from Broadcast Audio Extension chunks in the WAV files. If no such chunks are present an [automatic detection](#automatic-metadata-detection) is applied.
 
-A pitch LFO (vibrato) is converted as an `<lfo>` bound to the group tuning, carrying its rate (in Hertz), depth and delay. The oscillator's fade-in has no equivalent and is dropped, and the waveform is mapped to the nearest of sine, square and saw.
+A pitch LFO (vibrato) is converted as an `<lfo>` bound to the group tuning, carrying its rate (in Hertz), depth and delay. The oscillator's fade-in has no equivalent and is dropped, and the waveform is mapped to the nearest of sine, square and saw. A volume LFO (tremolo) is converted as an `<lfo>` bound to the group volume in the same way; since the volume parameter is linear, the depth in decibels is translated into the linear swing whose lowest point lies that many decibels below full volume.
 
 ### Source Options
 
@@ -280,7 +280,7 @@ Both the program (.zbp) as well as the bank (.zbb) are stored as monoliths (zipp
 The DLS format (*.dls) is a standardized file format developed for storing and distributing collections of digital musical instrument sounds, enabling their use in software synthesizers and hardware devices compatible with the MIDI protocol. It encapsulates audio samples, instrument definitions, articulations, and performance parameters into a single file. Developed in the 1990s initially by the Interactive Audio Special Interest Group (IASIG) and later standardized by the MIDI Manufacturers Association (MMA), with the first formal specification released in 1999.
 There is no write support.
 
-The amplitude and pitch envelopes, the sample loops and a pitch LFO (vibrato) are read. The vibrato's depth, its frequency (converted from absolute pitch cents to Hertz) and its start delay are carried over to the pitch LFO. Only a connection which is not modulated by a controller is read as the vibrato; the format normally contains a second one controlled by the modulation wheel, which is the amount the wheel can dial in and would sound permanently if it were converted.
+The amplitude and pitch envelopes, the sample loops and a pitch LFO (vibrato) are read. The vibrato's depth, its frequency (converted from absolute pitch cents to Hertz) and its start delay are carried over to the pitch LFO. Only a connection which is not modulated by a controller is read as the vibrato; the format normally contains a second one controlled by the modulation wheel, which is the amount the wheel can dial in and would sound permanently if it were converted. A volume LFO (tremolo) is read from an uncontrolled connection of the oscillator to the gain under the same rule; it shares the frequency and delay of the vibrato since the format has only one modulation oscillator.
 ## E-mu Emulator IV
 
 The E-mu Emulator IV series (Emulator 4, E4X, E4XT, E4K, e-Synth, e-6400 and the other EOS samplers, 1994-2002) stores its banks in single *.e4b* files which contain all presets, their parameters and the sample data. A preset layers several voices; each voice maps a set of zones (a key/velocity range referencing a sample) and carries the tuning, volume, filter, envelope and modulation settings for them. The format is not documented by E-mu, the layout was reverse-engineered by the mpc2emu project from hardware-saved E4XT banks and commercial EOS CD-ROMs (see *documentation/design/E4B_FORMAT.md*).
@@ -704,7 +704,7 @@ The SFZ file contains only the description of the multi-sample. The related samp
 
 SFZ can only mark a sample as a one-shot (`loop_mode=one_shot`) if it has no loop. A looped zone therefore keeps its loop and is not written as a one-shot.
 
-A pitch LFO (vibrato) is read and written via the `pitchlfo_freq` (Hertz), `pitchlfo_depth` (cent), `pitchlfo_delay` and `pitchlfo_fade` (seconds) opcodes.
+A pitch LFO (vibrato) is read and written via the `pitchlfo_freq` (Hertz), `pitchlfo_depth` (cent), `pitchlfo_delay` and `pitchlfo_fade` (seconds) opcodes. A volume LFO (tremolo) is read and written via the `amplfo_freq` (Hertz), `amplfo_depth` (decibels), `amplfo_delay` and `amplfo_fade` (seconds) opcodes.
 
 ### Source Options
 
@@ -724,7 +724,7 @@ The conversion process creates one destination file for each preset found in a S
 
 There are metadata fields for creator and some description specified in the format. However, additional information like a category is retrieved from Broadcast Audio Extension chunks in the WAV files. If no such chunks are present an [automatic detection](#automatic-metadata-detection) is applied.
 
-The vibrato low frequency oscillator (generators `vibLfoToPitch`, `freqVibLFO` and `delayVibLFO`) is converted to and from the pitch LFO, carrying its depth, rate and delay. The waveform is always a triangle in this format and there is no fade-in.
+The vibrato low frequency oscillator (generators `vibLfoToPitch`, `freqVibLFO` and `delayVibLFO`) is converted to and from the pitch LFO, carrying its depth, rate and delay. The volume modulation of the modulation low frequency oscillator (generators `modLfoToVolume`, `freqModLfo` and `delayModLfo`) is converted to and from the volume LFO (tremolo) in the same way. The waveform is always a triangle in this format and there is no fade-in.
 
 ### Source Options
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/model/ILfoModulator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/model/ILfoModulator.java
@@ -6,12 +6,17 @@ package de.mossgrabers.convertwithmoss.core.model;
 
 /**
  * Interface to a low frequency oscillator modulator. The modulation depth of the pitch modulation
- * maps to -4800..4800 cent, which is the same range as the one of the pitch envelope modulator.
+ * maps to -4800..4800 cent, which is the same range as the one of the pitch envelope modulator. The
+ * modulation depth of the volume modulation maps to -96..96 dB.
  *
  * @author Jürgen Moßgraber
  */
 public interface ILfoModulator extends IModulator
 {
+    /** The maximum depth of a volume modulation in dB. */
+    public static final int MAX_VOLUME_DEPTH = 96;
+
+
     /**
      * Get the modulation source.
      *

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/model/ISampleZone.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/model/ISampleZone.java
@@ -478,6 +478,15 @@ public interface ISampleZone
 
 
     /**
+     * Get the low frequency oscillator modulator for the amplitude, which is commonly called
+     * tremolo. A depth of zero means that there is no tremolo.
+     *
+     * @return The modulator, never null
+     */
+    ILfoModulator getAmplitudeLfoModulator ();
+
+
+    /**
      * Get the pitch modulator.
      *
      * @return The modulator, never null

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/model/implementation/DefaultSampleZone.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/model/implementation/DefaultSampleZone.java
@@ -54,6 +54,7 @@ public class DefaultSampleZone implements ISampleZone
     protected boolean            isReversed                 = false;
     protected IModulator         amplitudeVelocityModulator = new DefaultModulator (1);
     protected IEnvelopeModulator amplitudeEnvelopeModulator = new DefaultEnvelopeModulator (1);
+    protected ILfoModulator      amplitudeLfoModulator      = new DefaultLfoModulator (0);
     protected IEnvelopeModulator pitchModulator             = new DefaultEnvelopeModulator (0);
     protected ILfoModulator      pitchLfoModulator          = new DefaultLfoModulator (0);
     protected IFilter            filter                     = null;
@@ -563,6 +564,14 @@ public class DefaultSampleZone implements ISampleZone
 
     /** {@inheritDoc} */
     @Override
+    public ILfoModulator getAmplitudeLfoModulator ()
+    {
+        return this.amplitudeLfoModulator;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
     public IEnvelopeModulator getPitchEnvelopeModulator ()
     {
         return this.pitchModulator;
@@ -623,6 +632,7 @@ public class DefaultSampleZone implements ISampleZone
         this.isReversed = other.isReversed ();
         this.amplitudeVelocityModulator = other.getAmplitudeVelocityModulator ();
         this.amplitudeEnvelopeModulator = other.getAmplitudeEnvelopeModulator ();
+        this.amplitudeLfoModulator = other.getAmplitudeLfoModulator ();
         this.pitchModulator = other.getPitchEnvelopeModulator ();
         this.pitchLfoModulator = other.getPitchLfoModulator ();
         final Optional<IFilter> filterOpt = other.getFilter ();

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/dls/DlsArticulation.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/dls/DlsArticulation.java
@@ -441,6 +441,19 @@ public class DlsArticulation
 
 
     /**
+     * Convert a relative gain connection value to decibels. The value is stored as a 32-bit fixed
+     * point number with 65536 representing one centibel (1/10 dB).
+     *
+     * @param value The raw 32-bit relative gain value
+     * @return The gain in decibels
+     */
+    public static double relativeGainToDecibels (final int value)
+    {
+        return value / 65536.0 / 10.0;
+    }
+
+
+    /**
      * Normalizes a DLS EG Sustain Level lScale value to the range 0.0..1.0.
      *
      * Per Section 1.7.2.7: Sustain is defined as a percentage of the envelope peak in 0.1%

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/Generator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/sf2/Generator.java
@@ -37,8 +37,16 @@ public class Generator
     /** The ID of the modulation envelope to filter cutoff generator. */
     public static final int     MOD_ENV_TO_FILTER_CUTOFF = 11;
 
+    /** The ID of the modulation low frequency oscillator to volume generator (in centibels). */
+    public static final int     MOD_LFO_TO_VOLUME        = 13;
+
     /** The ID of the panning generator. */
     public static final int     PANNING                  = 17;
+
+    /** The ID of the modulation low frequency oscillator delay generator (in time-cents). */
+    public static final int     DELAY_MOD_LFO            = 21;
+    /** The ID of the modulation low frequency oscillator frequency generator (in absolute cents). */
+    public static final int     FREQ_MOD_LFO             = 22;
 
     /** The ID of the vibrato low frequency oscillator delay generator (in time-cents). */
     public static final int     DELAY_VIB_LFO            = 23;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerCreator.java
@@ -355,6 +355,7 @@ public class DecentSamplerCreator extends AbstractWavCreator<DecentSamplerCreato
             {
                 createPitchModulator (document, modulatorsElement, zones.get (0).getPitchEnvelopeModulator (), groupIndex);
                 createPitchLfoModulator (document, modulatorsElement, zones.get (0).getPitchLfoModulator (), groupIndex);
+                createAmplitudeLfoModulator (document, modulatorsElement, zones.get (0).getAmplitudeLfoModulator (), groupIndex);
             }
         }
 
@@ -580,6 +581,44 @@ public class DecentSamplerCreator extends AbstractWavCreator<DecentSamplerCreato
         // symmetrically
         bindingElement.setAttribute ("translationOutputMin", Integer.toString (-IEnvelope.MAX_ENVELOPE_DEPTH / 100));
         bindingElement.setAttribute ("translationOutputMax", Integer.toString (IEnvelope.MAX_ENVELOPE_DEPTH / 100));
+        bindingElement.setAttribute (TAG_MOD_BEHAVIOR, "add");
+    }
+
+
+    private static void createAmplitudeLfoModulator (final Document document, final Element modulatorsElement, final ILfoModulator amplitudeLfoModulator, final int groupIndex)
+    {
+        final double lfoDepth = amplitudeLfoModulator.getDepth ();
+        if (lfoDepth == 0)
+            return;
+
+        final ILfo amplitudeLfo = amplitudeLfoModulator.getSource ();
+
+        final Element lfoElement = XMLUtils.addElement (document, modulatorsElement, DecentSamplerTag.LFO);
+        lfoElement.setAttribute (DecentSamplerTag.LFO_SHAPE, toLfoShape (amplitudeLfo.getWaveform ()));
+        // The volume parameter is linear with 1 being full volume. The bipolar oscillator swings by
+        // the modulation amount around it, therefore a depth of d dB requires a swing of
+        // 1-10^(-d/20) for its lowest point to be d dB below full volume.
+        final double depthDecibels = Math.abs (lfoDepth) * ILfoModulator.MAX_VOLUME_DEPTH;
+        XMLUtils.setDoubleAttribute (lfoElement, DecentSamplerTag.MOD_AMOUNT, 1.0 - Math.pow (10.0, -depthDecibels / 20.0), 5);
+        final double rate = amplitudeLfo.getRate ();
+        if (rate > 0)
+        {
+            lfoElement.setAttribute (DecentSamplerTag.LFO_FREQUENCY_FORMAT, "hz");
+            XMLUtils.setDoubleAttribute (lfoElement, DecentSamplerTag.LFO_FREQUENCY, rate, 3);
+        }
+        final double delay = amplitudeLfo.getDelay ();
+        if (delay > 0)
+            XMLUtils.setDoubleAttribute (lfoElement, DecentSamplerTag.LFO_DELAY_TIME, delay, 3);
+
+        final Element bindingElement = XMLUtils.addElement (document, lfoElement, DecentSamplerTag.BINDING);
+        bindingElement.setAttribute ("type", "amp");
+        bindingElement.setAttribute (TAG_LEVEL, "group");
+        bindingElement.setAttribute (TAG_GROUP_INDEX, Integer.toString (groupIndex));
+        bindingElement.setAttribute (TAG_PARAMETER, "AMP_VOLUME");
+        bindingElement.setAttribute (TAG_TRANSLATION, "linear");
+        // The oscillator is bipolar, the swing is applied symmetrically around the group volume
+        bindingElement.setAttribute ("translationOutputMin", "-1");
+        bindingElement.setAttribute ("translationOutputMax", "1");
         bindingElement.setAttribute (TAG_MOD_BEHAVIOR, "add");
     }
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -481,6 +481,7 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
         final Optional<IFilter> optFilter = parseFilterEffect (topElement, groupElement);
         final Optional<IEnvelopeModulator> pitchModulation = parsePitchModulation (topElement);
         final Optional<ILfoModulator> pitchLfoModulation = parsePitchLfoModulation (topElement);
+        final Optional<ILfoModulator> amplitudeLfoModulation = parseAmplitudeLfoModulation (topElement);
 
         for (final Element sampleElement: XMLUtils.getChildElementsByName (groupElement, DecentSamplerTag.SAMPLE, false))
         {
@@ -524,6 +525,13 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
                 final ILfoModulator pitchLfoModulator = sampleZone.getPitchLfoModulator ();
                 pitchLfoModulator.setDepth (lfoModulator.getDepth ());
                 pitchLfoModulator.setSource (lfoModulator.getSource ());
+            }
+            if (amplitudeLfoModulation.isPresent ())
+            {
+                final ILfoModulator lfoModulator = amplitudeLfoModulation.get ();
+                final ILfoModulator amplitudeLfoModulator = sampleZone.getAmplitudeLfoModulator ();
+                amplitudeLfoModulator.setDepth (lfoModulator.getDepth ());
+                amplitudeLfoModulator.setSource (lfoModulator.getSource ());
             }
 
             group.addSampleZone (sampleZone);
@@ -702,6 +710,40 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
                     pitchLfo.setRate (XMLUtils.getDoubleAttribute (lfoElement, DecentSamplerTag.LFO_FREQUENCY, -1));
                 pitchLfo.setDelay (XMLUtils.getDoubleAttribute (lfoElement, DecentSamplerTag.LFO_DELAY_TIME, -1));
                 return Optional.of (pitchLfoModulator);
+            }
+        return Optional.empty ();
+    }
+
+
+    private static Optional<ILfoModulator> parseAmplitudeLfoModulation (final Element topElement)
+    {
+        // Parse a low frequency oscillator bound to the group volume (tremolo)
+        final Element modulatorsElement = XMLUtils.getChildElementByName (topElement, DecentSamplerTag.MODULATORS);
+        if (modulatorsElement != null)
+            for (final Element lfoElement: XMLUtils.getChildElementsByName (modulatorsElement, DecentSamplerTag.LFO))
+            {
+                final Element bindingElement = XMLUtils.getChildElementByName (lfoElement, DecentSamplerTag.BINDING);
+                if (bindingElement == null || !"AMP_VOLUME".equals (bindingElement.getAttribute (TAG_PARAMETER)))
+                    continue;
+
+                final double modAmount = XMLUtils.getDoubleAttribute (lfoElement, DecentSamplerTag.MOD_AMOUNT, 0);
+                if (modAmount <= 0)
+                    continue;
+
+                // The volume parameter is linear with 1 being full volume. The bipolar oscillator
+                // swings by the modulation amount around it, therefore a swing of x dips to 1-x
+                // which is -20*log10(1-x) dB below full volume.
+                final double depthDecibels = modAmount >= 1 ? ILfoModulator.MAX_VOLUME_DEPTH : Math.min (-20.0 * Math.log10 (1.0 - modAmount), ILfoModulator.MAX_VOLUME_DEPTH);
+                final ILfoModulator amplitudeLfoModulator = new DefaultLfoModulator (depthDecibels / ILfoModulator.MAX_VOLUME_DEPTH);
+                final ILfo amplitudeLfo = amplitudeLfoModulator.getSource ();
+                amplitudeLfo.setWaveform (toLfoWaveform (lfoElement.getAttribute (DecentSamplerTag.LFO_SHAPE)));
+                // Only a frequency given in Hertz can be converted; a tempo synchronized rate has
+                // no representation without a tempo
+                final String frequencyFormat = lfoElement.getAttribute (DecentSamplerTag.LFO_FREQUENCY_FORMAT);
+                if (frequencyFormat.isEmpty () || "hz".equals (frequencyFormat))
+                    amplitudeLfo.setRate (XMLUtils.getDoubleAttribute (lfoElement, DecentSamplerTag.LFO_FREQUENCY, -1));
+                amplitudeLfo.setDelay (XMLUtils.getDoubleAttribute (lfoElement, DecentSamplerTag.LFO_DELAY_TIME, -1));
+                return Optional.of (amplitudeLfoModulator);
             }
         return Optional.empty ();
     }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/dls/DlsDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/dls/DlsDetector.java
@@ -266,6 +266,27 @@ public class DlsDetector extends AbstractDetector<MetadataSettingsUI>
             }
         }
 
+        // Volume LFO (tremolo). The low frequency oscillator which modulates the gain is the
+        // tremolo; it shares its frequency and delay connections with the vibrato above since the
+        // format has only one modulation oscillator. Only an *uncontrolled* connection is read for
+        // the same reason as for the vibrato.
+        final Optional<DlsArticulation> gainLfoModulation = getUncontrolledArticulation (dlsInstrument, dlsRegion, DlsArticulation.CONN_SRC_LFO, DlsArticulation.CONN_DST_GAIN);
+        if (gainLfoModulation.isPresent ())
+        {
+            final double depthDecibels = DlsArticulation.relativeGainToDecibels (gainLfoModulation.get ().getScale ());
+            if (depthDecibels != 0)
+            {
+                final ILfoModulator amplitudeLfoModulator = zone.getAmplitudeLfoModulator ();
+                amplitudeLfoModulator.setDepth (Math.clamp (depthDecibels, -ILfoModulator.MAX_VOLUME_DEPTH, ILfoModulator.MAX_VOLUME_DEPTH) / ILfoModulator.MAX_VOLUME_DEPTH);
+
+                final ILfo amplitudeLfo = amplitudeLfoModulator.getSource ();
+                final Optional<DlsArticulation> lfoFrequency = getArticulation (dlsInstrument, dlsRegion, DlsArticulation.CONN_SRC_NONE, DlsArticulation.CONN_DST_LFO_FREQUENCY);
+                if (lfoFrequency.isPresent ())
+                    amplitudeLfo.setRate (DlsArticulation.absolutePitchToHertz (lfoFrequency.get ().getScale ()));
+                amplitudeLfo.setDelay (getTime (dlsInstrument, dlsRegion, DlsArticulation.CONN_DST_LFO_STARTDELAY));
+            }
+        }
+
         // Pitch tuning
         final Optional<DlsArticulation> pitchTuning = getArticulation (dlsInstrument, dlsRegion, DlsArticulation.CONN_SRC_NONE, DlsArticulation.CONN_DST_PITCH);
         if (pitchTuning.isPresent ())

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Creator.java
@@ -443,6 +443,27 @@ public class Sf2Creator extends AbstractCreator<Sf2CreatorUI>
                 instrumentZone.addSignedGenerator (Generator.DELAY_VIB_LFO, convertEnvelopeTime (delay));
         }
 
+        // Set the modulation low frequency oscillator to volume from the amplitude modulation
+        // (tremolo). The depth is given in centibels, the fade-in and the waveform have no
+        // equivalent in Sf2.
+        final ILfoModulator amplitudeLfoModulator = sampleZone.getAmplitudeLfoModulator ();
+        final double modLfoDepth = amplitudeLfoModulator.getDepth ();
+        if (modLfoDepth != 0)
+        {
+            instrumentZone.addSignedGenerator (Generator.MOD_LFO_TO_VOLUME, (int) Math.round (modLfoDepth * ILfoModulator.MAX_VOLUME_DEPTH * 10.0));
+            final ILfo amplitudeLfo = amplitudeLfoModulator.getSource ();
+            final double rate = amplitudeLfo.getRate ();
+            if (rate > 0)
+            {
+                // The frequency is stored in absolute cents, see the filter cutoff below
+                final double frequencyCents = Math.log (rate / 8.176) * 1200.0 / Math.log (2);
+                instrumentZone.addSignedGenerator (Generator.FREQ_MOD_LFO, (int) Math.round (frequencyCents));
+            }
+            final double delay = amplitudeLfo.getDelay ();
+            if (delay >= 0)
+                instrumentZone.addSignedGenerator (Generator.DELAY_MOD_LFO, convertEnvelopeTime (delay));
+        }
+
         // Filter settings
         final Optional<IFilter> filterOpt = sampleZone.getFilter ();
         if (filterOpt.isPresent ())

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
@@ -864,6 +864,19 @@ public class Sf2Detector extends AbstractDetector<Sf2DetectorUI>
                 pitchLfo.setDelay (convertEnvelopeTime (generators.getSignedValue (Generator.DELAY_VIB_LFO)));
             }
 
+            // The modulation low frequency oscillator to volume maps to the amplitude modulation
+            // (tremolo). Its waveform is always a triangle and the depth is given in centibels.
+            final ILfoModulator amplitudeLfoModulator = zone.getAmplitudeLfoModulator ();
+            final int modLfoToVolume = generators.getSignedValue (Generator.MOD_LFO_TO_VOLUME).intValue ();
+            amplitudeLfoModulator.setDepth (modLfoToVolume / 10.0 / ILfoModulator.MAX_VOLUME_DEPTH);
+            if (modLfoToVolume != 0)
+            {
+                final ILfo amplitudeLfo = amplitudeLfoModulator.getSource ();
+                // The frequency is stored in absolute cents, see the filter cutoff above
+                amplitudeLfo.setRate (8.176 * Math.pow (2, generators.getSignedValue (Generator.FREQ_MOD_LFO).doubleValue () / 1200.0));
+                amplitudeLfo.setDelay (convertEnvelopeTime (generators.getSignedValue (Generator.DELAY_MOD_LFO)));
+            }
+
             return Optional.of (zone);
         }
         catch (final IOException _)

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzCreator.java
@@ -492,6 +492,23 @@ public class SfzCreator extends AbstractWavCreator<SfzCreatorUI>
 
         if (ampEnvParameterLevel == ParameterLevel.ZONE)
             createVolumeEnvelope (buffer, zone);
+
+        // Amplitude LFO (tremolo)
+
+        final ILfoModulator amplitudeLfoModulator = zone.getAmplitudeLfoModulator ();
+        final double lfoDepth = amplitudeLfoModulator.getDepth ();
+        if (lfoDepth != 0)
+        {
+            final StringBuilder lfoStr = new StringBuilder ();
+            lfoStr.append (SfzOpcode.AMPLFO_DEPTH).append ('=').append (formatDouble (lfoDepth * ILfoModulator.MAX_VOLUME_DEPTH, 2));
+
+            final ILfo amplitudeLfo = amplitudeLfoModulator.getSource ();
+            addLfoTimeAttribute (lfoStr, SfzOpcode.AMPLFO_FREQ, amplitudeLfo.getRate ());
+            addLfoTimeAttribute (lfoStr, SfzOpcode.AMPLFO_DELAY, amplitudeLfo.getDelay ());
+            addLfoTimeAttribute (lfoStr, SfzOpcode.AMPLFO_FADE, amplitudeLfo.getFadeIn ());
+
+            buffer.append (lfoStr).append (LINE_FEED);
+        }
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzDetector.java
@@ -707,6 +707,21 @@ public class SfzDetector extends AbstractDetector<SfzDetectorUI>
         // The key tracking is always relative to the root key of the zone, therefore the center key
         // is only marked as processed
         this.getIntegerValue (SfzOpcode.AMP_KEY_CENTER);
+
+        // Amplitude LFO (tremolo)
+
+        // Without a depth there is no modulation, therefore the oscillator is not read at all
+        final double lfoDepth = this.getDoubleValue (SfzOpcode.AMPLFO_DEPTH, 0);
+        if (lfoDepth != 0)
+        {
+            final ILfoModulator amplitudeLfoModulator = sampleZone.getAmplitudeLfoModulator ();
+            amplitudeLfoModulator.setDepth (lfoDepth / ILfoModulator.MAX_VOLUME_DEPTH);
+
+            final ILfo amplitudeLfo = amplitudeLfoModulator.getSource ();
+            amplitudeLfo.setRate (this.getDoubleValue (SfzOpcode.AMPLFO_FREQ, -1));
+            amplitudeLfo.setDelay (this.getDoubleValue (SfzOpcode.AMPLFO_DELAY, -1));
+            amplitudeLfo.setFadeIn (this.getDoubleValue (SfzOpcode.AMPLFO_FADE, -1));
+        }
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzOpcode.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzOpcode.java
@@ -164,6 +164,15 @@ public class SfzOpcode
     /** SFZ v1. The key at which the amplitude key tracking has no effect. */
     public static final String AMP_KEY_CENTER        = "amp_keycenter";
 
+    /** SFZ v1. The amplitude LFO (tremolo) frequency in Hertz. */
+    public static final String AMPLFO_FREQ           = "amplfo_freq";
+    /** SFZ v1. The amplitude LFO (tremolo) depth in decibels. */
+    public static final String AMPLFO_DEPTH          = "amplfo_depth";
+    /** SFZ v1. The amplitude LFO (tremolo) delay time in seconds. */
+    public static final String AMPLFO_DELAY          = "amplfo_delay";
+    /** SFZ v1. The amplitude LFO (tremolo) fade-in time in seconds. */
+    public static final String AMPLFO_FADE           = "amplfo_fade";
+
     // -----------------------------------------------------------
     // Filter opcodes
 


### PR DESCRIPTION
This is the tremolo counterpart of the pitch LFO (vibrato) from #216/#233: in these formats the volume LFO is a fixed destination as well, so it converts faithfully without needing a mod-matrix representation.

**Model**: `ISampleZone.getAmplitudeLfoModulator ()`, mirroring the pitch LFO modulator. The depth is normalized against a new `ILfoModulator.MAX_VOLUME_DEPTH` of 96 dB, which is the full range of SoundFont's `modLfoToVolume`, so SFZ ↔ SF2 round-trips exactly. A depth of zero (the default) means no tremolo, so formats which do not support it are unaffected.

**Formats** (only those with documented units, like the vibrato):

* **SFZ**: v1 opcodes `amplfo_freq` (Hz), `amplfo_depth` (dB), `amplfo_delay` / `amplfo_fade` (seconds), read and written.
* **SoundFont 2**: `modLfoToVolume` (centibels) with `freqModLfo` / `delayModLfo`, read and written. The converter never used the modulation LFO before, so it coexists with the vibrato LFO in the same zone.
* **DecentSampler**: an `<lfo>` bound to the group volume (`AMP_VOLUME`, documented as modulatable and linear). Since the parameter is linear, a depth of d dB is written as the swing `1 - 10^(-d/20)` whose lowest point lies d dB below full volume; the binding carries an explicit linear translation of ±1 so the depth is self-describing.
* **DLS** (read only): the uncontrolled `LFO → gain` connection, with the same controller guard as the vibrato (the modulation-wheel-controlled amount is not applied as a permanent tremolo). The gain scale is 16.16 fixed-point centibels - validated against the macOS Roland GS set (`gs_instruments.dls`): 46 of 235 presets carry an uncontrolled tremolo of -1.5..+1.7 dB at 0.7-10 Hz, with the strongest depths exactly where they belong: Tremolo Strings, Vibraphone and Church Bell.

**Verification**:

* SFZ→SF2→SFZ and SFZ→DecentSampler→SFZ round-trip exactly (3.00 dB / 5.2 Hz / 0.25 s; SF2 quantizes the rate to absolute cents like the vibrato).
* The triple hop SFZ→SF2→DecentSampler→SFZ keeps the tremolo (3.00 dB / 5.201 Hz / 0.25 s) alongside a vibrato in the same zone.
* Regression: 100 SFZ presets converted to SFZ/SF2/DecentSampler and 30 SF2 presets converted to SFZ are byte-identical to a build of current main; DLS→SFZ differs in exactly the 46 GS presets which carry a tremolo, and every changed line is an added `amplfo_*` opcode.

Renoise support is implemented as well and has been folded into #239 (the same LFO modulation device with `Target` Volume, matching the conventions of the bundled modulation sets). #239 includes this branch via a merge, so merging this PR first shrinks #239 to the Renoise-only changes, while merging #239 first makes this PR redundant.

The feature matrix is not touched, mirroring #233 where you added the vibrato column yourself - happy to add a tremolo column if you tell me the preferred wording.

