### PR TITLE
E-mu Emulator IV: read the full amplitude envelope and the loop of the channel a sample holds

### DIFF
--- a/documentation/design/E4B_FORMAT.md
+++ b/documentation/design/E4B_FORMAT.md
@@ -123,10 +123,19 @@ filters without a model equivalent.
 
 Two 6-stage envelopes as rate/level byte pairs, plus the LFO parameters. The
 amplitude envelope stages are at bytes 0-11 (attack1, attack2, decay1, decay2,
-release1, release2), the filter envelope mirrors this at bytes 14-25. In the
-standard ADSR shape attack 1 rises to full level, decay 1 falls to the sustain
-level (decay 2 holds it) and release 1 falls to silence. An attack 2 stage
-with the same level as attack 1 is a plateau and expresses a hold stage.
+release1, release2), the filter envelope mirrors this at bytes 14-25. Each
+stage ramps to its own level in its own time, so the level a voice really
+sustains at is the one of **decay 2**, not of decay 1.
+
+Mapping the six stages onto the attack/hold/decay/sustain/release of the model
+works exactly as for the Emulator X, whose envelope this is: the two attack
+and the two release times are added up, and a decay 1 stage which stays at the
+level of attack 2 is a plateau and therefore the hold stage, which leaves
+decay 2 as the decay. Only where decay 1 does fall do the two decay times add
+up. Taking decay 1 alone loses the tail of 52% of the voices of the Producer
+Series Vol. 1 and 2 CD-ROMs, and the 8% whose decay 1 holds the peak (a
+plucked instrument which rings and then fades away, e.g. `Nylon Guitar`) end
+up sustaining for ever instead of decaying at all.
 
 The rate <-> time law was calibrated on E4XT hardware by mpc2emu:
 `seconds = 0.0310 * e^(0.0581 * rate)`, rate 0 = instant, 127 = ~47 s. Levels
@@ -209,14 +218,30 @@ are byte offsets relative to the struct start (i.e. 92 = first PCM byte):
 |---|---|---|
 | 0  | 2 | sample index (1-based, big-endian) |
 | 2  | 16 | name, space-padded ASCII; the root note is conventionally appended (e.g. `_C3` for MIDI 60, octave = note/12 - 2) |
-| 22 | 4 | start = 92 |
-| 30 | 4 | end = 92 + PCM bytes - 2 |
-| 38 | 4 | loop start |
-| 46 | 4 | loop end |
+| 22 | 4 | start, left channel = 92 |
+| 26 | 4 | start, right channel |
+| 30 | 4 | end, left channel = 92 + PCM bytes - 2 |
+| 34 | 4 | end, right channel |
+| 38 | 4 | loop start, left channel |
+| 42 | 4 | loop start, right channel |
+| 46 | 4 | loop end, left channel |
+| 50 | 4 | loop end, right channel |
 | 54 | 4 | sample rate - informational only, inherited from the EOS 3 struct |
 | 58 | 2 | pitch offset in 1/64 semitones (signed) |
-| 60 | 2 | options: 0x0020 = mono, 0x0031 = mono with forward loop |
+| 60 | 2 | options: 0x0001 = forward loop, 0x0020 = holds the left channel, 0x0040 = holds the right channel; 0x0020 = mono, 0x0031 = mono with forward loop |
 | 62 | 4 | data offset = 92 |
+
+Every position exists twice, once per channel - the struct is the one of the
+Emulator III. A sample which only holds its **right** channel (option 0x0020
+clear, e.g. options 0x0059) keeps its positions in the second field of each
+pair and leaves the first one with a stale value which does not address the
+sample: the loop start reads as the constant 12 and the same loop end appears
+verbatim on several samples of different lengths. Reading the left fields
+unconditionally therefore gives those samples the loop of an unrelated sample
+or drops it altogether. Of 7835 looped samples on three commercial CD-ROMs
+(Producer Series Vol. 1 and 2, E4 Ultra Production Set) 1402 are right channel
+only, and selecting the pair by the option bit makes all 7835 resolve inside
+their sample.
 
 EOS has exactly one loop type (forward, on/off at the sample level). A forward
 loop shorter than ~84 frames plays an octave low on the hardware (the E4XT

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator4/Emulator4Constants.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator4/Emulator4Constants.java
@@ -64,7 +64,9 @@ public class Emulator4Constants
 
     /** The 'forward loop on' bit of the sample options field. */
     protected static final int     OPTION_LOOP                = 0x0001;
-    /** The sample options of a mono sample without a loop. */
+    /** The 'sample holds its left channel' bit of the sample options field. */
+    protected static final int     OPTION_CHANNEL_LEFT        = 0x0020;
+    /** The sample options of a mono sample without a loop, which is a left channel only. */
     protected static final int     OPTIONS_MONO               = 0x0020;
     /** The sample options of a mono sample with a forward loop. */
     protected static final int     OPTIONS_MONO_LOOP          = 0x0031;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator4/Emulator4Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator4/Emulator4Detector.java
@@ -237,11 +237,16 @@ public class Emulator4Detector extends AbstractDetector<MetadataSettingsUI>
 
         final int sampleIndex = Emulator4Constants.getU16BE (data, offset);
         final String displayName = Emulator4Constants.decodeName (data, offset + 2);
-        final long loopStartOffset = Emulator4Constants.getU32LE (data, offset + 38);
-        final long loopEndOffset = Emulator4Constants.getU32LE (data, offset + 46);
         final int sampleRate = (int) Emulator4Constants.getU32LE (data, offset + 54);
         final int pitchOffset = (short) Emulator4Constants.getU16LE (data, offset + 58);
         final int options = Emulator4Constants.getU16LE (data, offset + 60);
+
+        // This is the sample structure of the Emulator III, which stores all of its positions
+        // twice - once for each channel. Some samples only hold their right channel and use the
+        // second set of positions, exactly as the Emulator III detector already handles it
+        final boolean hasLeftChannel = (options & Emulator4Constants.OPTION_CHANNEL_LEFT) > 0;
+        final long loopStartOffset = Emulator4Constants.getU32LE (data, offset + (hasLeftChannel ? 38 : 42));
+        final long loopEndOffset = Emulator4Constants.getU32LE (data, offset + (hasLeftChannel ? 46 : 50));
 
         final int pcmLength = (size - Emulator4Constants.SAMPLE_HEADER_SIZE) / 2 * 2;
         final int numFrames = pcmLength / 2;
@@ -493,18 +498,30 @@ public class Emulator4Detector extends AbstractDetector<MetadataSettingsUI>
                 filterKeyTracking = Math.clamp (amount / 127.0 * Emulator4Constants.FULL_KEY_TRACKING, 0, 1);
         }
 
-        // The amplitude envelope: 6 rate/level stages in the primary zone table of which the
-        // standard ADSR mapping uses attack 1, decay 1 (its level is the sustain) and release 1
+        // The amplitude envelope: 6 rate/level stages in the primary zone table, which are attack
+        // 1, attack 2, decay 1, decay 2, release 1 and release 2. The model has one attack, hold,
+        // decay and release stage, so the pairs are added up; a decay 1 stage which stays at the
+        // level of attack 2 is a plateau and therefore the hold stage. This is the same envelope
+        // as the one of the Emulator X and is mapped in the same way. Stopping at decay 1 loses
+        // the decay of more than half of the EOS library, and a voice whose decay 1 keeps the peak
+        // - a plucked instrument which rings for a while and then fades away - even sustains
+        // forever instead of ever decaying
         final int pztOffset = offset + Emulator4Constants.VOICE_PZT_OFFSET;
+        final double [] times = new double [6];
+        final int [] levels = new int [6];
+        for (int stage = 0; stage < 6; stage++)
+        {
+            times[stage] = Emulator4Constants.envelopeRateToTime (body[pztOffset + stage * 2] & 0xFF);
+            levels[stage] = body[pztOffset + stage * 2 + 1];
+        }
+
         final IEnvelope amplitudeEnvelope = new DefaultEnvelope ();
-        amplitudeEnvelope.setAttackTime (Emulator4Constants.envelopeRateToTime (body[pztOffset] & 0xFF));
-        // An attack 2 stage with the same level as attack 1 is a plateau, which is a hold stage
-        final double holdTime = Emulator4Constants.envelopeRateToTime (body[pztOffset + 2] & 0xFF);
-        if (holdTime > 0 && body[pztOffset + 1] == body[pztOffset + 3])
-            amplitudeEnvelope.setHoldTime (holdTime);
-        amplitudeEnvelope.setDecayTime (Emulator4Constants.envelopeRateToTime (body[pztOffset + 4] & 0xFF));
-        amplitudeEnvelope.setSustainLevel (Math.clamp (body[pztOffset + 5] / 127.0, 0, 1));
-        amplitudeEnvelope.setReleaseTime (Emulator4Constants.envelopeRateToTime (body[pztOffset + 8] & 0xFF));
+        amplitudeEnvelope.setAttackTime (times[0] + times[1]);
+        final boolean isPlateau = levels[2] == levels[1];
+        amplitudeEnvelope.setHoldTime (isPlateau ? times[2] : 0);
+        amplitudeEnvelope.setDecayTime (isPlateau ? times[3] : times[2] + times[3]);
+        amplitudeEnvelope.setSustainLevel (Math.clamp (levels[3] / 127.0, 0, 1));
+        amplitudeEnvelope.setReleaseTime (times[4] + times[5]);
 
         final IFilter filter = createFilter (body, offset, pztOffset, filterEnvelopeDepth, filterKeyTracking);
 


### PR DESCRIPTION
Two read bugs in the Emulator IV detector, both found while converting the Producer Series CD-ROMs. The sibling E-mu detectors already do the right thing in both cases, so this mostly brings the Emulator IV in line with them.

## The amplitude envelope stopped at decay 1

`parseVoice` read attack from attack 1, decay from decay 1, the sustain level from **decay 1's level** and release from release 1, and never looked at decay 2. Each of the six EOS stages ramps to its own level, so the level a voice really sustains at is the one of decay 2.

Measured over the 4686 voices of Producer Series Vol. 1 and Vol. 2:

| | share |
|---|---|
| decay 2 carries the rest of the fall (tail lost) | 51.9% |
| decay 1 holds the peak, decay 2 is the whole decay (decay lost completely) | 7.7% |
| decay 2 inert, old mapping was already right | 40.5% |

The second row is the audible one: a plucked instrument which rings for a while and then fades away came out sustaining for ever. `Nylon Guitar` stores

```
A1 (0, 0)   A2 (0, 127)   D1 (62, 127) = 1.137 s   D2 (92, 0) = 6.498 s   R1 (20, 0) = 0.099 s
```

which is an instant attack, a 1.137 s hold at full level and then a 6.5 s fall to silence. It was converted as decay 1.137 s to sustain 1.0, so nothing ever faded it out.

`EmulatorXDetector.readEnvelope` already maps this exact envelope correctly, so the six stages are now folded the same way: the two attack and the two release times are added up, a decay 1 stage which stays at the level of attack 2 is a plateau and therefore the hold stage, which leaves decay 2 as the decay, and only where decay 1 does fall do the two decay times add up.

## Loop positions belong to a channel

The E3S1 structure is the one of the Emulator III and stores start, end, loop start and loop end **twice, left channel then right**. In the Emulator IV chunk (2 byte index in front) that puts loop start at 38/42 and loop end at 46/50.

A sample which only holds its right channel keeps its positions in the second field of each pair and leaves the first one with a stale value which does not address the sample: the loop start reads as the constant 12, and one loop end value repeats verbatim across several samples of different lengths (176372 on five unrelated `FBass` samples). Reading the left fields unconditionally therefore gave those samples the loop of an unrelated sample, or dropped it and left a one-shot which stops mid-decay with a click.

`Emulator3Detector` already picks the pair by the channel option bit. The Emulator IV detector now does the same. On Vol. 1 and Vol. 2, 873 of the looped samples are right channel only:

| | count |
|---|---|
| loop dropped entirely | 247 |
| loop kept, but read from the left (wrong) fields | 550 |
| left fields coincidentally equal to the right ones | 76 |

Checked over Vol. 1, Vol. 2 and the E4 Ultra Production Set: 7835 looped samples, of which 1402 are right channel only, and with the channel bit selecting the pair **all 7835 resolve inside their sample, none invalid**. Loop quality was measured as the amplitude step at the seam, `abs(pcm[loopEnd] - pcm[loopStart]) / peak`: median 0.020 of the peak for the left-channel samples and 0.014 for the right-channel ones, against a median of 0.383 for the same samples read from the wrong pair.

## Effect on a conversion

Producer Series Vol. 1 + Vol. 2 to Renoise, 624 instruments and 9954 zones before and after:

| | before | after |
|---|---|---|
| zones with a loop | 8062 | 8365 |
| volume envelopes stuck at full sustain | 1691 | 404 |

No instrument loses a loop and no zone counts change. As a cross-check, the share of volume envelopes at full sustain is 13% for the Emulator III and 34% for the Emulator X on comparable banks; the Emulator IV went from 89% to 20%.

The Emulator III and Emulator X detectors are untouched and cannot be affected - the change is confined to `emulator4/` and neither package references those classes. Both were re-converted anyway (701 instruments from an ESI-32 CD-ROM, 509 from a Mo'Phatt EXB bank) without a change.

`documentation/design/E4B_FORMAT.md` gains the per-channel field table and the envelope mapping. The changelog is unchanged because the Emulator IV entry in 19.2.0 has not been released yet - happy to give it its own line if you prefer.
