### PR TITLE
Roland ZEN-Core: read every tone of a bank instead of only the first

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -19,6 +19,8 @@
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.
 * Kurzweil K2x00
   * Fixed: An envelope stage with both a zero time and a zero level is unused on the device and keeps the level of the previous stage, but was read literally. A program which leaves its decay stage unused - like the reported FM basses, which sustain at the attack level and only fade out with a long release - was therefore converted to a silent preset. Additionally, the attack velocity is now converted as a cutoff modulation source of the F1 slot in both directions; the same programs open their nearly closed cutoff by velocity and converted very dull without it.
+* Roland ZEN-Core
+  * Fixed: A bank (a SVZ which holds one tone per preset, as written by the preset library destination) was read as one single multi-sample: all samples of the file were merged into it and only the shaping of its first tone was applied, so every preset but the first was lost. Each tone is now read as a multi-sample of its own, built from the multi-samples which its partials play. A SVZ with one tone is unchanged.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreDetector.java
@@ -7,6 +7,7 @@ package de.mossgrabers.convertwithmoss.format.roland.zencore;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -84,16 +85,44 @@ public class ZenCoreDetector extends AbstractDetector<MetadataSettingsUI>
             return Collections.emptyList ();
         }
 
-        final Optional<ZenCoreKeyMap> keyMap = ZenCoreSvz.readKeyMap (container);
+        // A bank holds one tone per preset, all of them sharing the sample pool of the file. Each
+        // tone becomes a multi-sample of its own, built from the multi-samples which its partials
+        // play - otherwise all presets of a bank would be flattened into one.
+        final List<SvzInstrument> tones = ZenCoreSvz.readTones (container);
+        final List<ZenCoreKeyMap> keyMaps = ZenCoreSvz.readKeyMaps (container);
+        final String fileName = FileUtils.getNameWithoutType (svzFile);
+        final List<IMultisampleSource> multisampleSources = new ArrayList<> ();
+
+        if (tones.size () > 1)
+        {
+            for (final SvzInstrument tone: tones)
+            {
+                final IGroup toneGroup = new DefaultGroup ("Samples");
+                for (final int waveNumber: tone.waveNumbers)
+                    if (waveNumber > 0 && waveNumber <= keyMaps.size ())
+                        buildZonesFromKeyMap (toneGroup, samples, keyMaps.get (waveNumber - 1));
+                if (toneGroup.getSampleZones ().isEmpty ())
+                    continue;
+                applyToneShaping (toneGroup, tone);
+                final String toneName = tone.name == null || tone.name.isBlank () ? fileName : tone.name;
+                multisampleSources.add (this.createMultisampleSource (svzFile, toneName, List.of (toneGroup)));
+                this.notifier.log ("IDS_ZENCORE_READING_SVZ", toneName, Integer.toString (toneGroup.getSampleZones ().size ()));
+            }
+            if (!multisampleSources.isEmpty ())
+                return multisampleSources;
+        }
+
+        // One tone, or a file which only holds user samples: everything of the file becomes one
+        // multi-sample which is named after the file
         final IGroup group = new DefaultGroup ("Samples");
-        if (keyMap.isEmpty ())
+        if (keyMaps.isEmpty ())
         {
             for (final ZenCoreSample sample: samples)
                 if (sample.getSampleData () != null)
                     group.addSampleZone (createZone (sample, sample.getOriginalKey (), sample.getOriginalKey ()));
         }
         else
-            buildZonesFromKeyMap (group, samples, keyMap.get ());
+            buildZonesFromKeyMap (group, samples, keyMaps.get (0));
 
         if (group.getSampleZones ().isEmpty ())
         {
@@ -101,15 +130,13 @@ public class ZenCoreDetector extends AbstractDetector<MetadataSettingsUI>
             return Collections.emptyList ();
         }
 
-        // Carry the first tone's shaping back into the model, so ZEN-Core sources convert with
-        // their filter and envelopes instead of pipeline defaults - the times through the same
+        // Carry the tone's shaping back into the model, so ZEN-Core sources convert with their
+        // filter and envelopes instead of pipeline defaults - the times through the same
         // hardware-calibrated law the writer uses.
-        final Optional<SvzInstrument> tone = ZenCoreSvz.readTone (container);
-        if (tone.isPresent ())
-            applyToneShaping (group, tone.get ());
-        final String name = FileUtils.getNameWithoutType (svzFile);
-        this.notifier.log ("IDS_ZENCORE_READING_SVZ", name, Integer.toString (group.getSampleZones ().size ()));
-        return Collections.singletonList (this.createMultisampleSource (svzFile, name, List.of (group)));
+        if (!tones.isEmpty ())
+            applyToneShaping (group, tones.get (0));
+        this.notifier.log ("IDS_ZENCORE_READING_SVZ", fileName, Integer.toString (group.getSampleZones ().size ()));
+        return Collections.singletonList (this.createMultisampleSource (svzFile, fileName, List.of (group)));
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -269,6 +270,8 @@ public final class ZenCoreSvz
          * partial has its own multi-sample, pan and velocity window.
          */
         public List<SvzPartial> partials;
+        /** The wave numbers of the multi-samples which the partials of the tone play (read side). */
+        public int []           waveNumbers      = new int [0];
 
         // ----------------------------------------------------------------------------------------
         // Optional Partial-1 tone parameters taken from the source; -1 keeps the template default
@@ -772,10 +775,27 @@ public final class ZenCoreSvz
      */
     public static Optional<ZenCoreKeyMap> readKeyMap (final ZenCoreContainer container)
     {
+        final List<ZenCoreKeyMap> keyMaps = readKeyMaps (container);
+        return keyMaps.isEmpty () ? Optional.empty () : Optional.of (keyMaps.get (0));
+    }
+
+
+    /**
+     * Read all multi-samples of the <i>MSPa</i> section. A tone references them by their wave
+     * number, which is the position in this list plus one, see buildTone.
+     *
+     * @param container The SVZ container
+     * @return The multi-samples in the order in which they are stored
+     */
+    public static List<ZenCoreKeyMap> readKeyMaps (final ZenCoreContainer container)
+    {
         final ZenCoreContainer.Section msp = container.getSection ("MSPa");
         if (msp == null || msp.getCount () == 0)
-            return Optional.empty ();
-        return Optional.of (new ZenCoreKeyMap (msp.getFile (), msp.getDataStart ()));
+            return Collections.emptyList ();
+        final List<ZenCoreKeyMap> keyMaps = new ArrayList<> (msp.getCount ());
+        for (int i = 0; i < msp.getCount (); i++)
+            keyMaps.add (new ZenCoreKeyMap (msp.getFile (), msp.getDataStart () + i * msp.getUnitSize ()));
+        return keyMaps;
     }
 
 
@@ -790,12 +810,66 @@ public final class ZenCoreSvz
      */
     public static Optional<SvzInstrument> readTone (final ZenCoreContainer container)
     {
+        final List<SvzInstrument> tones = readTones (container);
+        return tones.isEmpty () ? Optional.empty () : Optional.of (tones.get (0));
+    }
+
+
+    /**
+     * Read all tones of the <i>PATa</i> section. A preset file holds one tone, a bank holds one per
+     * preset - all of them sharing the sample pool of the file - which is why each tone names the
+     * multi-samples it plays in {@link SvzInstrument#waveNumbers}.
+     *
+     * @param container The SVZ container
+     * @return The tones in the order in which they are stored, empty if the container holds none
+     */
+    public static List<SvzInstrument> readTones (final ZenCoreContainer container)
+    {
         final ZenCoreContainer.Section pat = container.getSection ("PATa");
         if (pat == null || pat.getCount () == 0)
-            return Optional.empty ();
-        final byte [] file = pat.getFile ();
-        final int r = pat.getDataStart ();
+            return Collections.emptyList ();
+        final List<SvzInstrument> tones = new ArrayList<> (pat.getCount ());
+        for (int i = 0; i < pat.getCount (); i++)
+            tones.add (readTone (pat.getFile (), pat.getDataStart () + i * pat.getUnitSize ()));
+        return tones;
+    }
+
+
+    /**
+     * Read one tone record.
+     *
+     * @param file The content of the SVZ file
+     * @param r The offset of the tone record
+     * @return The tone
+     */
+    private static SvzInstrument readTone (final byte [] file, final int r)
+    {
         final SvzInstrument tone = new SvzInstrument ();
+        tone.name = ZenCoreUtil.readName (file, r, NAME_LENGTH);
+
+        // The multi-samples which the enabled partials play. A partial whose wave group is zero is
+        // switched off and plays nothing, see buildTone.
+        final List<Integer> waves = new ArrayList<> ();
+        for (int p = 0; p < 4; p++)
+        {
+            final int oscBase = p * PAT_PARTIAL_STRIDE;
+            if (file[r + PAT_WAVE_GROUP + oscBase] == 0)
+                continue;
+            for (final int offset: new int []
+            {
+                PAT_WAVE_L,
+                PAT_WAVE_R
+            })
+            {
+                final int wave = ZenCoreUtil.readUnsigned16 (file, r + offset + oscBase, false);
+                if (wave > 0 && !waves.contains (Integer.valueOf (wave)))
+                    waves.add (Integer.valueOf (wave));
+            }
+        }
+        tone.waveNumbers = new int [waves.size ()];
+        for (int i = 0; i < waves.size (); i++)
+            tone.waveNumbers[i] = waves.get (i).intValue ();
+
         tone.filterType = ZenCoreUtil.readUnsigned16 (file, r + PAT_FILTER_TYPE, false) / 0x100;
         tone.cutoff = ZenCoreUtil.readUnsigned16 (file, r + PAT_CUTOFF, false);
         tone.resonance = ZenCoreUtil.readUnsigned16 (file, r + PAT_RESONANCE, false);
@@ -811,7 +885,7 @@ public final class ZenCoreSvz
         tone.filterEnvDepth = file[r + PAT_FILTER_ENV_DEPTH];
         tone.filterEnvTimes = readEnvBlock (file, r + PAT_FILTER_ENV_TIME, 4);
         tone.filterEnvLevels = readEnvBlock (file, r + PAT_FILTER_ENV_LEVEL, 5);
-        return Optional.of (tone);
+        return tone;
     }
 
 


### PR DESCRIPTION
A ZEN-Core SVZ can hold one tone per preset, all of them sharing the sample pool of the file. That is exactly what the preset library destination of ConvertWithMoss writes - `ZenCoreCreator.createPresetLibrary` documents itself as "a bank sharing one sample pool for several".

Reading such a file merged **all** samples of the file into one single multi-sample and applied the shaping of its **first** tone to it. Every preset but the first was silently lost, so a bank written by ConvertWithMoss could not be read back by ConvertWithMoss.

## The fix

`PATa` is now read as the list of tones it is and `MSPa` as the list of multi-samples. Each tone becomes a multi-sample of its own, built from the multi-samples which its enabled partials reference through their wave number - which is the position in the `MSPa` section plus one, the numbering `buildTone` writes.

A file with a single tone keeps its previous behaviour exactly, including being named after the file; only a file with several tones names its multi-samples after the tones.

## Verification

A bank of 7 instruments written with the preset library destination, then read back:

```
BEFORE  presets detected: 1
AFTER   presets detected: 7
        Reading ZEN-Core user samples 'AR2 Strings' (32 zones).
        Reading ZEN-Core user samples 'DC Korg Strings' (84 zones).
        Reading ZEN-Core user samples 'MG1 Flute' (22 zones).
        Reading ZEN-Core user samples 'Mrs Mills' (32 zones).
        Reading ZEN-Core user samples 'OBX Strings Of L' (44 zones).
        Reading ZEN-Core user samples 'SH Morning Dew' (22 zones).
        Reading ZEN-Core user samples 'SH PolyKey 7' (22 zones).
```

Each tone comes back with its own name, zones and shaping. A single-tone SVZ still converts to one multi-sample named after the file.

Independent of #238 and #241, but worth noting: with this in, ZEN-Core becomes a format where one file holds several presets, so it then qualifies for the contents selection of #241.