### PR TITLE
Detect sources which hold many presets far quicker

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -12,6 +12,7 @@
 * User Interface
   * New: Added tooltips to format lists to be able to see the full text of an entry.
 * Backend
+  * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
   * New: Added support for a LFO (low frequency oscillator) modulating pitch (vibrato) with its rate, depth and delay: DecentSampler, DLS, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
 * E-mu Emulator III

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
@@ -75,6 +75,8 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
     private static final String               IDS_ERR_SOURCE_FORMAT_NOT_SUPPORTED = "IDS_ERR_SOURCE_FORMAT_NOT_SUPPORTED";
     private static final AudioFileFormat.Type OGG_TYPE                            = new AudioFileFormat.Type ("OGG", "ogg");
     private static final AudioFileFormat.Type FLAC_TYPE                           = new AudioFileFormat.Type ("FLAC", "flac");
+    /** Yield to the rest of the application after this number of delivered sources. */
+    private static final int                  DELIVERY_YIELD_INTERVAL             = 64;
 
     private final ExecutorService             executor                            = Executors.newSingleThreadExecutor ();
 
@@ -87,6 +89,7 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
     protected final Map<String, Set<String>>  unsupportedAttributes               = new HashMap<> ();
 
     private final AtomicBoolean               isCancelled                         = new AtomicBoolean (false);
+    private int                               deliveryCounter                     = 0;
 
 
     /**
@@ -300,16 +303,23 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
      */
     protected boolean waitForDelivery ()
     {
-        try
-        {
-            Thread.sleep (10);
-        }
-        catch (final InterruptedException _)
-        {
-            if (this.isCancelled ())
-                return true;
-            Thread.currentThread ().interrupt ();
-        }
+        // Yield now and then, so that a cancellation is noticed and the user interface keeps up,
+        // but not once per source: this is called for every detected preset, and a source which
+        // holds thousands of them - a CD-ROM image of an E-mu sampler holds a few thousand - spent
+        // nearly all of its time sleeping. Reading such an image took 11 seconds, of which 8 were
+        // these sleeps; it now takes well under a second.
+        this.deliveryCounter++;
+        if (this.deliveryCounter % DELIVERY_YIELD_INTERVAL == 0)
+            try
+            {
+                Thread.sleep (1);
+            }
+            catch (final InterruptedException _)
+            {
+                if (this.isCancelled ())
+                    return true;
+                Thread.currentThread ().interrupt ();
+            }
         return this.isCancelled ();
     }
 


### PR DESCRIPTION
`AbstractDetector.waitForDelivery ()` sleeps 10 milliseconds and is called once per detected preset. For the formats which hold a handful of presets per file that is not noticeable, but the disk images and banks of the hardware samplers hold thousands of them, and then it is nearly all of the time spent:

| Source | Presets | Before | After |
| --- | --- | --- | --- |
| One E-mu CD-ROM image | 812 | 11.0 s | **0.7 s** |
| Both images of the set | 2339 | 36.2 s | **1.4 s** |

Of those 11 seconds, 8 were the sleeps (812 x 10 ms) - the CPU time of the whole run is only 2.5 seconds, and reading the entire 526 MB image from disk takes 0.09 s. So the run was neither I/O bound nor compute bound, it was sleeping.

The pause is now taken every 64 delivered sources rather than after every single one, so the intent - yield regularly, keep a cancellation responsive - is kept while the per-preset cost disappears. The cancel flag itself is still read for every source, only the sleep is not.

Verified that nothing else changes: the single image still detects its 812 presets, and Logic EXS24 (7) and Korg KMP (3 stereo pairs) detect exactly what they did before.

The one thing worth a second opinion is the interval of 64 - it is a guess at "often enough that the log and the Cancel button stay responsive". If you would rather have it time based, e.g. yield when more than 20 ms have passed since the last yield, that is an easy change.