### PR TITLE
Akai MPC: write MPC 3 track files (*.xty) as an alternative output format

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,6 +16,11 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
+* Akai MPC
+  * New: The destination can now write MPC 3 track files (*.xty) with their '_[TrackData]' sample folder as an alternative to MPC 2 keygroup folders (new 'Output Format' option, issue #117). The files replicate the complete track structure of MPC firmware 3.7 from a template - the firmware's own reader is strict about its serialized object tree - and only the multi-sample fields are patched in. Not verified in the MPC 3 software itself yet.
+  * Fixed: The pitch bend range of a MPC 3 track or project was read as cents but the file stores semitones, so the default of 2 semitones became 2 cents. The fraction of an octave stored next to it confirms the unit.
+  * Fixed: The tuning of a MPC 3 layer was read from the coarse and fine tune of its instrument, which the caller had already applied - the instrument tuning was doubled and the layer's own tuning was lost.
+  * New: The volume of a MPC 3 layer (an object holding the linear gain coefficient) is now read.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,11 +16,6 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
-* Akai MPC
-  * New: The destination can now write MPC 3 track files (*.xty) with their '_[TrackData]' sample folder as an alternative to MPC 2 keygroup folders (new 'Output Format' option, issue #117). The files replicate the complete track structure of MPC firmware 3.7 from a template - the firmware's own reader is strict about its serialized object tree - and only the multi-sample fields are patched in. Not verified in the MPC 3 software itself yet.
-  * Fixed: The pitch bend range of a MPC 3 track or project was read as cents but the file stores semitones, so the default of 2 semitones became 2 cents. The fraction of an octave stored next to it confirms the unit.
-  * Fixed: The tuning of a MPC 3 layer was read from the coarse and fine tune of its instrument, which the caller had already applied - the instrument tuning was doubled and the layer's own tuning was lost.
-  * New: The volume of a MPC 3 layer (an object holding the linear gain coefficient) is now read.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -173,7 +173,7 @@ The Akai MESA S3P format is a computer-side representation of Akai S-series prog
 
 A MPC Keygroup or MPC Drum setup is stored in a folder. It contains a description file (.xpm) and the sample files (.WAV). Both keygroup and drum types are supported.
 
-### Akai MPC Project/Track - read only
+### Akai MPC Project/Track
 
 A track file (*.xty) is a MPC v3 specific file that saves all settings, samples, macros, FX and MIDI data associated with a track. A track consists of two elements; the track file itself and a trackData folder containing the samples used within the track (ending with '_\[TrackData\]'). If the track contains a keygroup it is extracted as a multi-sample source.
 A project file (*.xpj) contains all track and project settings. All tracks which contain a keygroup are extracted as a multi-sample source.
@@ -184,6 +184,7 @@ A project file (*.xpj) contains all track and project settings. All tracks which
 
 ### Destination Options
 
+* Output Format: Writes either a MPC 2 keygroup - a folder with the description file (.xpm) and the samples - or a MPC 3 track file (.xty) with its sample folder (ending with '_\[TrackData\]'). The track files replicate the complete 'SerialisableTrackData' structure of files written by MPC firmware 3.7 - all 128 instrument slots with their layers, the key-group performance controls and the sample list - but have not been verified in the MPC 3 software itself yet; reports welcome.
 * Limit layers to: MPC Firmware 3.4 increased the number of possible layers in a keygroup to 8. This option allows you to choose between 4 (for older firmware revisions) or 8.
 
 ### Destination Restrictions

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPC3TrackFile.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPC3TrackFile.java
@@ -1,0 +1,375 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.akai.mpc;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.algorithm.MathUtils;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelopeModulator;
+import de.mossgrabers.convertwithmoss.core.model.IFilter;
+import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.tools.ui.Functions;
+
+
+/**
+ * Builds the JSON document of a MPC 3 track file (*.xty) from a template which carries the full
+ * 'SerialisableTrackData' structure of a real key-group track written by MPC firmware 3.7. The
+ * firmware serializes its complete C++ object tree - the track, the program with its mixer and
+ * macro assignments, the key-group performance controls and all 128 instrument slots with their
+ * eight layers - and its reader is strict about the shape, so the writer keeps every field of the
+ * template and only patches the ones which carry the multi-sample: the names, the key-group count
+ * and pitch bend ranges, the used instrument slots (key range, envelopes, filter, layers) and the
+ * sample list. Unused slots are clones of the template's neutral instrument.
+ * <p>
+ * The encodings mirror the real files: envelope parameters are wrapped in 'value0' objects with
+ * times normalized logarithmically between 1 millisecond and 100 seconds, curves and the panorama
+ * are stored in the range of [0..1], layer volumes are objects holding the gain coefficient, the
+ * key-group pitch bend range is stored both as a fraction of an octave and as semitone integers,
+ * and the root note of a sample lives in the metadata of its sample list entry.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class MPC3TrackFile
+{
+    /** The format identifier in the first line of the file header. */
+    public static final String  HEADER_MAGIC      = "ACVS";
+    /** The data type identifier in the third line of the file header. */
+    public static final String  HEADER_DATA_TYPE  = "SerialisableTrackData";
+    /** The encoding identifier in the fourth line of the file header. */
+    public static final String  HEADER_ENCODING   = "json";
+    /** The suffix of the folder which holds the samples of a track. */
+    public static final String  TRACK_DATA_SUFFIX = "_[TrackData]";
+
+    private static final String TEMPLATE          = "de/mossgrabers/convertwithmoss/templates/mpc/keygroup-track-template.json";
+    private static final String VALUE0            = "value0";
+    /** A track file always carries 128 instrument slots. */
+    private static final int    NUM_INSTRUMENTS   = 128;
+
+    private final ObjectMapper  mapper            = new ObjectMapper ();
+    private final int           layerLimit;
+
+
+    /**
+     * Constructor.
+     *
+     * @param layerLimit The maximum number of layers of one key-group (4, or 8 from firmware 3.4)
+     */
+    public MPC3TrackFile (final int layerLimit)
+    {
+        this.layerLimit = layerLimit;
+    }
+
+
+    /**
+     * Create the JSON document of the track.
+     *
+     * @param multisampleSource The multi-sample to store
+     * @param sampleName The name of the multi-sample, which prefixes the sample files
+     * @return The JSON document and the number of created key-groups
+     * @throws IOException Could not load or parse the template
+     */
+    public TrackDocument create (final IMultisampleSource multisampleSource, final String sampleName) throws IOException
+    {
+        final ObjectNode root = (ObjectNode) this.mapper.readTree (Functions.textFileFor (TEMPLATE));
+        final ObjectNode dataNode = (ObjectNode) root.get ("data");
+        final String name = multisampleSource.getName ();
+        dataNode.put ("name", name);
+        final ObjectNode programNode = (ObjectNode) dataNode.get ("program");
+        programNode.put ("name", name);
+
+        // The prototypes for the instrument slots and the sample list entries
+        final ObjectNode drumNode = (ObjectNode) programNode.get ("drum");
+        final ArrayNode instrumentsNode = (ArrayNode) drumNode.get ("instruments");
+        final ObjectNode instrumentPrototype = instrumentsNode.get (0).deepCopy ();
+        instrumentsNode.removeAll ();
+        final ArrayNode samplesNode = (ArrayNode) dataNode.get ("samples");
+        final ObjectNode samplePrototype = samplesNode.get (0).deepCopy ();
+        samplesNode.removeAll ();
+
+        // Stack the zones of all groups into key-groups by their key range
+        final Map<String, List<List<ISampleZone>>> keygroupsMap = new LinkedHashMap<> ();
+        final List<List<ISampleZone>> keygroups = new ArrayList<> ();
+        final List<ISampleZone> allZones = new ArrayList<> ();
+        for (final IGroup group: multisampleSource.getNonEmptyGroups (false))
+            for (final ISampleZone zone: group.getSampleZones ())
+            {
+                // Add the name of the multi-sample to the wave file to make it 'more unique' if
+                // necessary
+                String zoneName = zone.getName ();
+                if (!zoneName.startsWith (sampleName))
+                {
+                    zoneName = sampleName + "_" + zoneName;
+                    zone.setName (zoneName);
+                }
+                allZones.add (zone);
+
+                final String rangeKey = limitToDefault (zone.getKeyLow (), 0) + "-" + limitToDefault (zone.getKeyHigh (), 127);
+                final List<List<ISampleZone>> stacks = keygroupsMap.computeIfAbsent (rangeKey, _ -> new ArrayList<> ());
+                List<ISampleZone> stack = stacks.isEmpty () ? null : stacks.get (stacks.size () - 1);
+                if (stack == null || stack.size () >= this.layerLimit)
+                {
+                    stack = new ArrayList<> ();
+                    stacks.add (stack);
+                    keygroups.add (stack);
+                }
+                stack.add (zone);
+            }
+        final int numKeygroups = Math.min (keygroups.size (), NUM_INSTRUMENTS);
+
+        // The key-group node holds the zone count and the pitch bend range; the range is stored
+        // both as a fraction of an octave and as semitone integers
+        final ObjectNode keygroupNode = (ObjectNode) programNode.get ("keygroup");
+        keygroupNode.put ("numKeygroups", Math.max (1, numKeygroups));
+        int bendUpCents = 200;
+        int bendDownCents = 200;
+        if (!allZones.isEmpty ())
+        {
+            final ISampleZone firstZone = allZones.get (0);
+            if (firstZone.getBendUp () != 0)
+                bendUpCents = Math.abs (firstZone.getBendUp ());
+            if (firstZone.getBendDown () != 0)
+                bendDownCents = Math.abs (firstZone.getBendDown ());
+        }
+        final int bendUpSemitones = Math.max (1, Math.round (bendUpCents / 100f));
+        final int bendDownSemitones = Math.max (1, Math.round (bendDownCents / 100f));
+        keygroupNode.put ("pitchBendRange", bendUpSemitones / 12.0);
+        keygroupNode.put ("pitchBendPositiveRange", bendUpSemitones);
+        keygroupNode.put ("pitchBendNegativeRange", bendDownSemitones);
+
+        // The used instrument slots carry the key-groups, the rest stays at the neutral prototype
+        for (int i = 0; i < NUM_INSTRUMENTS; i++)
+        {
+            final ObjectNode instrumentNode = instrumentPrototype.deepCopy ();
+            if (i < numKeygroups)
+                this.patchInstrument (instrumentNode, keygroups.get (i));
+            instrumentsNode.add (instrumentNode);
+        }
+
+        // The sample list with the metadata which the MPC keeps for each sample. Zones of
+        // different velocity layers may share one sample; the first zone provides the metadata
+        final Map<String, ObjectNode> sampleEntries = new LinkedHashMap<> ();
+        for (final ISampleZone zone: allZones)
+            sampleEntries.computeIfAbsent (zone.getName (), zoneName -> {
+                final ObjectNode sampleNode = samplePrototype.deepCopy ();
+                sampleNode.put ("name", zoneName);
+                sampleNode.put ("path", zoneName + ".WAV");
+                final ObjectNode metadataNode = (ObjectNode) sampleNode.get ("metadata");
+                metadataNode.put ("rootNote", limitToDefault (zone.getKeyRoot (), limitToDefault (zone.getKeyLow (), 0)));
+                metadataNode.put ("tune", 0.0);
+                samplesNode.add (sampleNode);
+                return sampleNode;
+            });
+
+        return new TrackDocument (root.toPrettyString (), numKeygroups);
+    }
+
+
+    /**
+     * Patch one instrument slot with the zones of one key-group.
+     *
+     * @param instrumentNode The instrument node to patch
+     * @param zones The zones which are stacked as the layers of the key-group
+     */
+    private void patchInstrument (final ObjectNode instrumentNode, final List<ISampleZone> zones)
+    {
+        final ISampleZone firstZone = zones.get (0);
+        instrumentNode.put ("lowNote", limitToDefault (firstZone.getKeyLow (), 0));
+        instrumentNode.put ("highNote", limitToDefault (firstZone.getKeyHigh (), 127));
+        instrumentNode.put ("ignoreBaseNote", firstZone.getKeyTracking () == 0);
+        // 0 is one-shot, 1 is note-off and 2 is note-on
+        instrumentNode.put ("triggerMode", firstZone.isOneShot () ? 0 : 2);
+
+        this.patchSynthSection ((ObjectNode) instrumentNode.get ("synthSection"), firstZone);
+
+        final ArrayNode layersNode = (ArrayNode) instrumentNode.get ("layersv");
+        for (int i = 0; i < zones.size () && i < layersNode.size (); i++)
+            this.patchLayer ((ObjectNode) layersNode.get (i), zones.get (i));
+    }
+
+
+    /**
+     * Patch one layer with the values of a sample zone.
+     *
+     * @param layerNode The layer node to patch
+     * @param zone The sample zone
+     */
+    private void patchLayer (final ObjectNode layerNode, final ISampleZone zone)
+    {
+        layerNode.put ("active", true);
+        layerNode.put ("sampleName", zone.getName ());
+        layerNode.put ("sampleFile", zone.getName () + ".WAV");
+
+        // The volume of a layer is an object; the gain coefficient is the linear amplitude
+        final double gainCoefficient = Math.pow (10, Math.min (zone.getGain (), 6) / 20.0);
+        final ObjectNode volumeNode = (ObjectNode) layerNode.get ("volume");
+        volumeNode.put ("gainCoefficient", gainCoefficient);
+        volumeNode.put ("controlValue", gainCoefficient);
+
+        layerNode.put ("pan", (Math.clamp (zone.getPanning (), -1.0d, 1.0d) + 1.0d) / 2.0d);
+
+        final double tuneSemitones = zone.getTuning ();
+        final int coarseTune = (int) Math.round (tuneSemitones);
+        layerNode.put ("pitch", tuneSemitones);
+        layerNode.put ("coarseTune", coarseTune);
+        layerNode.put ("fineTune", (int) Math.round ((tuneSemitones - coarseTune) * 100.0));
+
+        layerNode.put ("velocityStart", limitToDefault (zone.getVelocityLow (), 1));
+        layerNode.put ("velocityEnd", limitToDefault (zone.getVelocityHigh (), 127));
+        layerNode.put ("sampleStart", zone.getStart ());
+        layerNode.put ("sampleEnd", zone.getStop ());
+        layerNode.put ("direction", zone.isReversed () ? 1 : 0);
+        layerNode.put ("keyTrackEnable", zone.getKeyTracking () != 0);
+
+        final List<ISampleLoop> loops = zone.getLoops ();
+        final ObjectNode sliceInfoNode = (ObjectNode) layerNode.get ("sliceInfo");
+        sliceInfoNode.put ("Start", zone.getStart ());
+        sliceInfoNode.put ("End", zone.getStop ());
+        if (loops.isEmpty ())
+            return;
+
+        // The format can store only 1 loop; the layer settings override the (unused) slice
+        final ISampleLoop loop = loops.get (0);
+        final int loopCrossfade = (int) Math.floor (loop.getCrossfade () * loop.getLength ());
+        layerNode.put ("loop", true);
+        layerNode.put ("layerLoopModeOverridesSliceLoopMode", true);
+        layerNode.put ("loopMode", 1);
+        layerNode.put ("loopStart", loop.getStart ());
+        layerNode.put ("loopEnd", loop.getEnd ());
+        layerNode.put ("loopCrossfadeLength", loopCrossfade);
+        sliceInfoNode.put ("LoopMode", 1);
+        sliceInfoNode.put ("LoopStart", loop.getStart ());
+        sliceInfoNode.put ("LoopCrossfadeLength", loopCrossfade);
+    }
+
+
+    /**
+     * Patch the synthesizer section of an instrument slot with the envelopes and the filter of a
+     * zone.
+     *
+     * @param synthNode The synthesizer section node to patch
+     * @param zone The sample zone
+     */
+    private void patchSynthSection (final ObjectNode synthNode, final ISampleZone zone)
+    {
+        patchEnvelope ((ObjectNode) synthNode.get ("ampEnvelope"), zone.getAmplitudeEnvelopeModulator ().getSource ());
+
+        final IEnvelopeModulator pitchModulator = zone.getPitchEnvelopeModulator ();
+        final double pitchDepth = pitchModulator.getDepth ();
+        if (pitchDepth != 0)
+        {
+            patchEnvelope ((ObjectNode) synthNode.get ("pitchEnvelope"), pitchModulator.getSource ());
+            synthNode.put ("pitchEnvelopeAmount", Math.clamp (pitchDepth / 2.0 + 0.5, 0, 1));
+        }
+
+        final Optional<IFilter> optFilter = zone.getFilter ();
+        if (optFilter.isEmpty ())
+            return;
+        final IFilter filter = optFilter.get ();
+        final ObjectNode filterValueNode = (ObjectNode) synthNode.get ("filterData").get (VALUE0);
+        filterValueNode.put ("filterType", MPCFilter.getFilterIndex (filter));
+        filterValueNode.put ("filterCutoff", MathUtils.normalizeFrequency (filter.getCutoff (), IFilter.MAX_FREQUENCY));
+        filterValueNode.put ("filterResonance", filter.getResonance ());
+        filterValueNode.put ("filterKeytrack", filter.getCutoffKeyTracking ());
+        final double filterCutoffVelocityAmount = filter.getCutoffVelocityModulator ().getDepth ();
+        if (filterCutoffVelocityAmount > 0)
+            filterValueNode.put ("filterVelocity", filterCutoffVelocityAmount);
+
+        final IEnvelopeModulator cutoffModulator = filter.getCutoffEnvelopeModulator ();
+        final double envelopeDepth = cutoffModulator.getDepth ();
+        // Only positive modulation values are supported with MPC
+        if (envelopeDepth > 0)
+        {
+            filterValueNode.put ("filterEnvelopeAmount", envelopeDepth);
+            patchEnvelope ((ObjectNode) synthNode.get ("filterEnvelope"), cutoffModulator.getSource ());
+        }
+    }
+
+
+    /**
+     * Patch an envelope node. Only the parameters which the model carries are overwritten, the
+     * rest keeps the values of the template. All parameters are wrapped in 'value0' objects, the
+     * times are normalized logarithmically.
+     *
+     * @param envelopeNode The envelope node to patch
+     * @param envelope The envelope values to set
+     */
+    private static void patchEnvelope (final ObjectNode envelopeNode, final IEnvelope envelope)
+    {
+        setWrappedValue (envelopeNode, "AD", false);
+        setWrappedValue (envelopeNode, "OneShot", false);
+        setWrappedTime (envelopeNode, "Delay", envelope.getDelayTime (), 0);
+        setWrappedTime (envelopeNode, "Attack", envelope.getAttackTime (), MPCKeygroupConstants.DEFAULT_ATTACK_TIME);
+        setWrappedTime (envelopeNode, "Hold", envelope.getHoldTime (), MPCKeygroupConstants.DEFAULT_HOLD_TIME);
+        setWrappedTime (envelopeNode, "Decay", envelope.getDecayTime (), MPCKeygroupConstants.DEFAULT_DECAY_TIME);
+        setWrappedValue (envelopeNode, "Sustain", Math.clamp (envelope.getSustainLevel () < 0 ? 1 : envelope.getSustainLevel (), 0, 1));
+        setWrappedTime (envelopeNode, "Release", envelope.getReleaseTime (), MPCKeygroupConstants.DEFAULT_RELEASE_TIME);
+        setWrappedValue (envelopeNode, "AttackCurve", Math.clamp ((envelope.getAttackSlope () + 1.0) / 2.0, 0, 1));
+        setWrappedValue (envelopeNode, "DecayCurve", Math.clamp ((envelope.getDecaySlope () + 1.0) / 2.0, 0, 1));
+        setWrappedValue (envelopeNode, "ReleaseCurve", Math.clamp ((envelope.getReleaseSlope () + 1.0) / 2.0, 0, 1));
+    }
+
+
+    private static void setWrappedTime (final ObjectNode node, final String name, final double time, final double normalizedDefault)
+    {
+        setWrappedValue (node, name, time < 0 ? normalizedDefault : normalizeLogarithmicEnvTimeValue (time, MPCKeygroupConstants.MIN_ENV_TIME_SECONDS, MPCKeygroupConstants.MAX_ENV_TIME_SECONDS));
+    }
+
+
+    private static void setWrappedValue (final ObjectNode node, final String name, final double value)
+    {
+        final JsonNode wrapper = node.get (name);
+        if (wrapper instanceof final ObjectNode wrapperObject)
+            wrapperObject.put (VALUE0, value);
+    }
+
+
+    private static void setWrappedValue (final ObjectNode node, final String name, final boolean value)
+    {
+        final JsonNode wrapper = node.get (name);
+        if (wrapper instanceof final ObjectNode wrapperObject)
+            wrapperObject.put (VALUE0, value);
+    }
+
+
+    /**
+     * Computes a normalized logarithmic value between 0 and 1 from a value and a given range.
+     *
+     * @param value The value (e.g. duration)
+     * @param minimum The minimum value (must be greater than zero)
+     * @param maximum The maximum value
+     * @return The normalized logarithmic value
+     */
+    private static double normalizeLogarithmicEnvTimeValue (final double value, final double minimum, final double maximum)
+    {
+        return Math.log (Math.clamp (value, minimum, maximum) / minimum) / Math.log (maximum / minimum);
+    }
+
+
+    private static int limitToDefault (final int value, final int defaultValue)
+    {
+        return value < 0 ? defaultValue : value;
+    }
+
+
+    /** The created JSON document and the number of key-groups it holds. */
+    public record TrackDocument (String json, int numKeygroups)
+    {
+        // Intentionally empty
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCKeygroupConstants.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCKeygroupConstants.java
@@ -17,6 +17,10 @@ public class MPCKeygroupConstants
     public static final String FILE_VERSION         = "2.1";
     /** Application version. */
     public static final String APP_VERSION          = "v2.11.6.6";
+    /** The version line of a created MPC 3 track file, the firmware whose structure is written. */
+    public static final String TRACK_FILE_VERSION   = "3.7.0.38";
+    /** The platform line of a created MPC 3 track file. */
+    public static final String TRACK_FILE_PLATFORM  = "Linux";
 
     /** Value for -12dB. */
     public static final double MINUS_12_DB          = 0.353000;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCKeygroupCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCKeygroupCreator.java
@@ -5,8 +5,11 @@
 package de.mossgrabers.convertwithmoss.format.akai.mpc;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.zip.GZIPOutputStream;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -65,6 +69,12 @@ public class MPCKeygroupCreator extends AbstractWavCreator<MPCKeygroupCreatorUI>
     @Override
     public void createPreset (final File destinationFolder, final IMultisampleSource multisampleSource) throws IOException
     {
+        if (this.settingsConfiguration.isWriteTrackFile ())
+        {
+            this.createTrackPreset (destinationFolder, multisampleSource);
+            return;
+        }
+
         final String sampleName = createSafeFilename (multisampleSource.getName ());
 
         // Store all samples and metadata file in one folder
@@ -85,6 +95,48 @@ public class MPCKeygroupCreator extends AbstractWavCreator<MPCKeygroupCreatorUI>
 
         // Store all samples - WAV ending needs to be upper case!
         this.writeSamples (sampleFolder, multisampleSource, ".WAV");
+
+        this.progress.notifyDone ();
+    }
+
+
+    /**
+     * Create a MPC 3 track file (*.xty) with its sample folder.
+     *
+     * @param destinationFolder Where to store the track file
+     * @param multisampleSource The multi-sample to store
+     * @throws IOException Could not store the file
+     */
+    private void createTrackPreset (final File destinationFolder, final IMultisampleSource multisampleSource) throws IOException
+    {
+        final String sampleName = createSafeFilename (multisampleSource.getName ());
+        final File multiFile = this.createUniqueFilename (destinationFolder, sampleName, "xty");
+
+        final MPC3TrackFile.TrackDocument document = new MPC3TrackFile (this.settingsConfiguration.getLayerLimit ()).create (multisampleSource, sampleName);
+        if (document.numKeygroups () > 128)
+            this.notifier.logError ("IDS_MPC_MORE_THAN_128_KEYGROUPS", Integer.toString (document.numKeygroups ()));
+
+        this.notifier.log ("IDS_NOTIFY_STORING", multiFile.getAbsolutePath ());
+        try (final Writer writer = new OutputStreamWriter (new GZIPOutputStream (new FileOutputStream (multiFile)), StandardCharsets.UTF_8))
+        {
+            writer.write (MPC3TrackFile.HEADER_MAGIC);
+            writer.write ('\n');
+            writer.write (MPCKeygroupConstants.TRACK_FILE_VERSION);
+            writer.write ('\n');
+            writer.write (MPC3TrackFile.HEADER_DATA_TYPE);
+            writer.write ('\n');
+            writer.write (MPC3TrackFile.HEADER_ENCODING);
+            writer.write ('\n');
+            writer.write (MPCKeygroupConstants.TRACK_FILE_PLATFORM);
+            writer.write ('\n');
+            writer.write (document.json ());
+        }
+
+        // The samples live in a folder next to the track file - WAV ending needs to be upper case!
+        final String trackFileName = multiFile.getName ();
+        final File trackDataFolder = new File (destinationFolder, trackFileName.substring (0, trackFileName.length () - ".xty".length ()) + MPC3TrackFile.TRACK_DATA_SUFFIX);
+        safeCreateDirectory (trackDataFolder);
+        this.writeSamples (trackDataFolder, multisampleSource, ".WAV");
 
         this.progress.notifyDone ();
     }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCKeygroupCreatorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCKeygroupCreatorUI.java
@@ -29,9 +29,14 @@ import javafx.scene.layout.Pane;
 public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
 {
     private static final String MPC_LAYER_LIMIT_USE_8 = "MPCLayerLimitUse8";
+    private static final String MPC_OUTPUT_FORMAT     = "MPCOutputFormat";
+    private static final String FORMAT_XPM            = "XPM";
+    private static final String FORMAT_XTY            = "XTY";
 
+    private ToggleGroup         outputFormatGroup;
     private ToggleGroup         layerLimitGroup;
     private int                 layerLimit;
+    private boolean             writeTrackFile;
 
 
     /**
@@ -50,6 +55,16 @@ public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
     public Pane getEditPane ()
     {
         final BoxPanel panel = new BoxPanel (Orientation.VERTICAL);
+
+        panel.createSeparator ("@IDS_MPC_OUTPUT_FORMAT");
+
+        this.outputFormatGroup = new ToggleGroup ();
+        final RadioButton formatXpm = panel.createRadioButton ("@IDS_MPC_OUTPUT_FORMAT_XPM");
+        formatXpm.setAccessibleHelp (Functions.getMessage ("IDS_MPC_OUTPUT_FORMAT"));
+        formatXpm.setToggleGroup (this.outputFormatGroup);
+        final RadioButton formatXty = panel.createRadioButton ("@IDS_MPC_OUTPUT_FORMAT_XTY");
+        formatXty.setAccessibleHelp (Functions.getMessage ("IDS_MPC_OUTPUT_FORMAT"));
+        formatXty.setToggleGroup (this.outputFormatGroup);
 
         panel.createSeparator ("@IDS_MPC_LAYER_LIMIT");
 
@@ -72,6 +87,9 @@ public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
     @Override
     public void loadSettings (final BasicConfig config)
     {
+        final boolean isTrackFile = FORMAT_XTY.equals (config.getProperty (MPC_OUTPUT_FORMAT, FORMAT_XPM));
+        this.outputFormatGroup.selectToggle (this.outputFormatGroup.getToggles ().get (isTrackFile ? 1 : 0));
+
         final boolean use8Layers = config.getBoolean (MPC_LAYER_LIMIT_USE_8, true);
         this.layerLimitGroup.selectToggle (this.layerLimitGroup.getToggles ().get (use8Layers ? 1 : 0));
 
@@ -83,6 +101,7 @@ public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
     @Override
     public void saveSettings (final BasicConfig config)
     {
+        config.setProperty (MPC_OUTPUT_FORMAT, this.writeTrackFile ? FORMAT_XTY : FORMAT_XPM);
         config.setBoolean (MPC_LAYER_LIMIT_USE_8, this.getLayerLimit () == 8);
 
         super.saveSettings (config);
@@ -96,6 +115,7 @@ public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
         if (!super.checkSettingsUI (notifier))
             return false;
 
+        this.writeTrackFile = this.outputFormatGroup.getToggles ().get (1).isSelected ();
         this.layerLimit = this.layerLimitGroup.getToggles ().get (1).isSelected () ? 8 : 4;
         return true;
     }
@@ -107,6 +127,17 @@ public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
     {
         if (!super.checkSettingsCLI (notifier, parameters))
             return false;
+
+        final String formatValue = parameters.remove (MPC_OUTPUT_FORMAT);
+        if (formatValue == null || formatValue.isBlank () || FORMAT_XPM.equalsIgnoreCase (formatValue))
+            this.writeTrackFile = false;
+        else if (FORMAT_XTY.equalsIgnoreCase (formatValue))
+            this.writeTrackFile = true;
+        else
+        {
+            notifier.logError ("IDS_CLI_UNKNOWN_OUTPUT_FORMAT", formatValue);
+            return false;
+        }
 
         try
         {
@@ -138,6 +169,7 @@ public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
     public String [] getCLIParameterNames ()
     {
         final List<String> parameterNames = new ArrayList<> (Arrays.asList (super.getCLIParameterNames ()));
+        parameterNames.add (MPC_OUTPUT_FORMAT);
         parameterNames.add (MPC_LAYER_LIMIT_USE_8);
         return parameterNames.toArray (new String [parameterNames.size ()]);
     }
@@ -151,5 +183,16 @@ public class MPCKeygroupCreatorUI extends WavChunkSettingsUI
     public int getLayerLimit ()
     {
         return this.layerLimit;
+    }
+
+
+    /**
+     * Should a MPC 3 track file (*.xty) be written instead of a key-group folder (*.xpm)?
+     *
+     * @return True to write a track file
+     */
+    public boolean isWriteTrackFile ()
+    {
+        return this.writeTrackFile;
     }
 }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCModernDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc/MPCModernDetector.java
@@ -796,8 +796,10 @@ public class MPCModernDetector extends AbstractDetector<MPCKeygroupDetectorUI>
             if (keygroupNode != null)
             {
                 keygroupTranspose = programTranspose + keygroupNode.get ("transpose").asDouble ();
-                pitchBendUp = keygroupNode.get ("pitchBendPositiveRange").asInt ();
-                pitchBendDown = keygroupNode.get ("pitchBendNegativeRange").asInt ();
+                // The ranges are semitones, e.g. the default of 2 (the fraction of an octave
+                // in 'pitchBendRange' confirms it)
+                pitchBendUp = keygroupNode.get ("pitchBendPositiveRange").asInt () * 100;
+                pitchBendDown = keygroupNode.get ("pitchBendNegativeRange").asInt () * 100;
                 final JsonNode synthSectionNode = keygroupNode.get ("synthSection");
                 globalEnvelopesAndFilter = new MPCEnvelopesAndFilter (synthSectionNode, true);
             }
@@ -893,10 +895,20 @@ public class MPCModernDetector extends AbstractDetector<MPCKeygroupDetectorUI>
         else if (sampleInfo != null)
             sampleZone.setKeyRoot (sampleInfo.rootNote);
 
-        final int layerCoarseTune = instrumentNode.get ("coarseTune").asInt ();
-        final int layerFineTune = instrumentNode.get ("fineTune").asInt ();
+        // The instrument tuning is already part of the tuning parameter, the layer adds its own
+        final int layerCoarseTune = layerNode.path ("coarseTune").asInt ();
+        final int layerFineTune = layerNode.path ("fineTune").asInt ();
         final double layerTuning = layerCoarseTune + layerFineTune / 100.0;
         sampleZone.setTuning (layerTuning + tuning + (sampleInfo != null ? sampleInfo.tuning : 0));
+
+        // The volume of a layer is an object; the gain coefficient is the linear amplitude
+        final JsonNode volumeNode = layerNode.get ("volume");
+        if (volumeNode != null)
+        {
+            final double gainCoefficient = volumeNode.path ("gainCoefficient").asDouble (1);
+            if (gainCoefficient > 0)
+                sampleZone.setGain (20.0 * Math.log10 (gainCoefficient));
+        }
 
         sampleZone.setPanning (layerNode.get ("pan").asDouble () * 2.0 - 1.0);
         sampleZone.setKeyLow (lowNote);

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -41,6 +41,7 @@ module de.mossgrabers.convertwithmoss
     opens de.mossgrabers.convertwithmoss.templates.adv;
     opens de.mossgrabers.convertwithmoss.templates.dspreset;
     opens de.mossgrabers.convertwithmoss.templates.maschine;
+    opens de.mossgrabers.convertwithmoss.templates.mpc;
     opens de.mossgrabers.convertwithmoss.templates.prt_omn;
     opens de.mossgrabers.convertwithmoss.templates.ysfc;
     opens de.mossgrabers.convertwithmoss.templates.tonverk;

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -699,6 +699,9 @@ IDS_KMP_GAIN_12DB=Enable the +12dB option
 IDS_KMP_MAXIMIZE_VOLUME=Set sample volume to +99
 IDS_KMP_MAXIMIZE_VOLUME_TOOLTIP=Sets all sample volumes to +99. Use for low volume samples.
 
+IDS_MPC_OUTPUT_FORMAT=Output Format
+IDS_MPC_OUTPUT_FORMAT_XPM=MPC 2 Keygroup (XPM)
+IDS_MPC_OUTPUT_FORMAT_XTY=MPC 3 Track (XTY) - experimental, not yet verified in the MPC 3 software
 IDS_MPC_LAYER_LIMIT=Limit layers to
 IDS_MPC_LAYER_LIMIT_4=4
 IDS_MPC_LAYER_LIMIT_8=8 (requires MPC Firmware 3.4 or later)

--- a/src/main/resources/de/mossgrabers/convertwithmoss/templates/mpc/keygroup-track-template.json
+++ b/src/main/resources/de/mossgrabers/convertwithmoss/templates/mpc/keygroup-track-template.json
@@ -1,0 +1,3512 @@
+{
+ "data": {
+  "version": 5,
+  "name": "",
+  "volume": 1.0,
+  "volumeKnown": true,
+  "pan": 0.5039370059967041,
+  "panKnown": true,
+  "mute": false,
+  "cvPort": 0,
+  "gatePort": 1,
+  "velocityScale": 1.0,
+  "muteGroup": 0,
+  "transposition": 0,
+  "colour": 8355711,
+  "padsFollowTrackColour": false,
+  "skipFromRowLaunch": false,
+  "samples": [
+   {
+    "version": 1,
+    "name": "",
+    "path": "",
+    "loadImpl": 0,
+    "metadata": {
+     "tempo": 0.0,
+     "rootNote": 60,
+     "tune": 0.0,
+     "key": ""
+    }
+   }
+  ],
+  "program": {
+   "version": 4,
+   "name": "",
+   "type": 1,
+   "programPads": {
+    "Universal": {
+     "value0": true
+    },
+    "Type": {
+     "value0": 2
+    },
+    "universalPad": 8355711,
+    "pads": {
+     "value0": 0,
+     "value1": 0,
+     "value2": 0,
+     "value3": 0,
+     "value4": 0,
+     "value5": 0,
+     "value6": 0,
+     "value7": 0,
+     "value8": 0,
+     "value9": 0,
+     "value10": 0,
+     "value11": 0,
+     "value12": 0,
+     "value13": 0,
+     "value14": 0,
+     "value15": 0,
+     "value16": 0,
+     "value17": 0,
+     "value18": 0,
+     "value19": 0,
+     "value20": 0,
+     "value21": 0,
+     "value22": 0,
+     "value23": 0,
+     "value24": 0,
+     "value25": 0,
+     "value26": 0,
+     "value27": 0,
+     "value28": 0,
+     "value29": 0,
+     "value30": 0,
+     "value31": 0,
+     "value32": 0,
+     "value33": 0,
+     "value34": 0,
+     "value35": 0,
+     "value36": 0,
+     "value37": 0,
+     "value38": 0,
+     "value39": 0,
+     "value40": 0,
+     "value41": 0,
+     "value42": 0,
+     "value43": 0,
+     "value44": 0,
+     "value45": 0,
+     "value46": 0,
+     "value47": 0,
+     "value48": 0,
+     "value49": 0,
+     "value50": 0,
+     "value51": 0,
+     "value52": 0,
+     "value53": 0,
+     "value54": 0,
+     "value55": 0,
+     "value56": 0,
+     "value57": 0,
+     "value58": 0,
+     "value59": 0,
+     "value60": 0,
+     "value61": 0,
+     "value62": 0,
+     "value63": 0,
+     "value64": 0,
+     "value65": 0,
+     "value66": 0,
+     "value67": 0,
+     "value68": 0,
+     "value69": 0,
+     "value70": 0,
+     "value71": 0,
+     "value72": 0,
+     "value73": 0,
+     "value74": 0,
+     "value75": 0,
+     "value76": 0,
+     "value77": 0,
+     "value78": 0,
+     "value79": 0,
+     "value80": 0,
+     "value81": 0,
+     "value82": 0,
+     "value83": 0,
+     "value84": 0,
+     "value85": 0,
+     "value86": 0,
+     "value87": 0,
+     "value88": 0,
+     "value89": 0,
+     "value90": 0,
+     "value91": 0,
+     "value92": 0,
+     "value93": 0,
+     "value94": 0,
+     "value95": 0,
+     "value96": 0,
+     "value97": 0,
+     "value98": 0,
+     "value99": 0,
+     "value100": 0,
+     "value101": 0,
+     "value102": 0,
+     "value103": 0,
+     "value104": 0,
+     "value105": 0,
+     "value106": 0,
+     "value107": 0,
+     "value108": 0,
+     "value109": 0,
+     "value110": 0,
+     "value111": 0,
+     "value112": 0,
+     "value113": 0,
+     "value114": 0,
+     "value115": 0,
+     "value116": 0,
+     "value117": 0,
+     "value118": 0,
+     "value119": 0,
+     "value120": 0,
+     "value121": 0,
+     "value122": 0,
+     "value123": 0,
+     "value124": 0,
+     "value125": 0,
+     "value126": 0,
+     "value127": 0
+    },
+    "UnusedPads": {
+     "value0": 1
+    },
+    "PadsFollowTrackColour": {
+     "value0": false
+    }
+   },
+   "customQLinks": [
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    },
+    {
+     "name": "",
+     "controlType": 0,
+     "targetData": [
+      {
+       "version": 1,
+       "parameter": 2147483647,
+       "track": "String-X Strings",
+       "insertParamIndex": {
+        "initialized": true,
+        "none": true
+       },
+       "instrumentIndex": 2147483647,
+       "paramType": 0,
+       "controlInputRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "parameterRange": {
+        "min": 0.0,
+        "max": 1.0,
+        "stride": 0.0,
+        "deadspot": 2.0,
+        "skew": 1.0
+       },
+       "behaviour": 0
+      }
+     ],
+     "momentary": 0,
+     "controlValue": 0.0
+    }
+   ],
+   "transpose": 0,
+   "midiKillGroup": -1,
+   "chainID": 0,
+   "midiEventsFilter": {
+    "channelFilterData": {
+     "channel": 255
+    },
+    "velocityFilterData": {
+     "min": 0.0,
+     "max": 1.0
+    },
+    "noteFilterData": {
+     "noteRange": {
+      "type": 2,
+      "data": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+     }
+    },
+    "automationFilterData": {
+     "filteredParams": "00000000000000000"
+    }
+   },
+   "mixable": {
+    "version": 1,
+    "audioRoute": {
+     "destination": 2,
+     "audioRouteSubIndex": 0,
+     "channelBitmap": {
+      "type": 0,
+      "data": 3
+     }
+    },
+    "volume": 0.40039101243019104,
+    "mute": false,
+    "solo": false,
+    "pan": 0.6322810053825378,
+    "automationFilter": 1,
+    "sends": [
+     0.0,
+     0.0,
+     0.0,
+     0.0
+    ],
+    "inserts": {
+     "insertsEnabled": true,
+     "effects": [
+      {
+       "index": 0,
+       "plugin": {
+        "version": 2,
+        "is64Bits": true,
+        "description": {
+         "version": 1,
+         "name": "Reverb Large",
+         "descriptiveName": "Reverb Large",
+         "pluginFormatName": "MPC",
+         "category": "",
+         "manufacturerName": "Akai Professional",
+         "fileOrIdentifier": "Reverb Large",
+         "uid": 1094932090,
+         "isInstrument": false,
+         "numInputChannels": 2,
+         "numOutputChannels": 2
+        },
+        "state": "190.AMjUSA....P.I.........................PA.........PTYiEVd...P+X..........DklYlU2b....+X..........D41boQWd....+X..........DIWdWUFcOJb88T..........EElbrkG...vOF..........RoAxP0QWyLybOF..........SuAxP0QWyLybOF..........TxUFQkwVAp0uOI4VZzA.TRUzTEQkSA0TQE.....",
+        "programNumber": 0,
+        "presetName": "Init",
+        "presetEdited": false
+       },
+       "enable": true
+      }
+     ]
+    }
+   },
+   "customisable": {
+    "mapping": []
+   },
+   "renderable": {
+    "sendToCueBus": false
+   },
+   "xfaderRoute": 0,
+   "padNoteMap": {
+    "noteForPad": {
+     "value0": 0,
+     "value1": 1,
+     "value2": 2,
+     "value3": 3,
+     "value4": 4,
+     "value5": 5,
+     "value6": 6,
+     "value7": 7,
+     "value8": 8,
+     "value9": 9,
+     "value10": 10,
+     "value11": 11,
+     "value12": 12,
+     "value13": 13,
+     "value14": 14,
+     "value15": 15,
+     "value16": 16,
+     "value17": 17,
+     "value18": 18,
+     "value19": 19,
+     "value20": 20,
+     "value21": 21,
+     "value22": 22,
+     "value23": 23,
+     "value24": 24,
+     "value25": 25,
+     "value26": 26,
+     "value27": 27,
+     "value28": 28,
+     "value29": 29,
+     "value30": 30,
+     "value31": 31,
+     "value32": 32,
+     "value33": 33,
+     "value34": 34,
+     "value35": 35,
+     "value36": 36,
+     "value37": 37,
+     "value38": 38,
+     "value39": 39,
+     "value40": 40,
+     "value41": 41,
+     "value42": 42,
+     "value43": 43,
+     "value44": 44,
+     "value45": 45,
+     "value46": 46,
+     "value47": 47,
+     "value48": 48,
+     "value49": 49,
+     "value50": 50,
+     "value51": 51,
+     "value52": 52,
+     "value53": 53,
+     "value54": 54,
+     "value55": 55,
+     "value56": 56,
+     "value57": 57,
+     "value58": 58,
+     "value59": 59,
+     "value60": 60,
+     "value61": 61,
+     "value62": 62,
+     "value63": 63,
+     "value64": 64,
+     "value65": 65,
+     "value66": 66,
+     "value67": 67,
+     "value68": 68,
+     "value69": 69,
+     "value70": 70,
+     "value71": 71,
+     "value72": 72,
+     "value73": 73,
+     "value74": 74,
+     "value75": 75,
+     "value76": 76,
+     "value77": 77,
+     "value78": 78,
+     "value79": 79,
+     "value80": 80,
+     "value81": 81,
+     "value82": 82,
+     "value83": 83,
+     "value84": 84,
+     "value85": 85,
+     "value86": 86,
+     "value87": 87,
+     "value88": 88,
+     "value89": 89,
+     "value90": 90,
+     "value91": 91,
+     "value92": 92,
+     "value93": 93,
+     "value94": 94,
+     "value95": 95,
+     "value96": 96,
+     "value97": 97,
+     "value98": 98,
+     "value99": 99,
+     "value100": 100,
+     "value101": 101,
+     "value102": 102,
+     "value103": 103,
+     "value104": 104,
+     "value105": 105,
+     "value106": 106,
+     "value107": 107,
+     "value108": 108,
+     "value109": 109,
+     "value110": 110,
+     "value111": 111,
+     "value112": 112,
+     "value113": 113,
+     "value114": 114,
+     "value115": 115,
+     "value116": 116,
+     "value117": 117,
+     "value118": 118,
+     "value119": 119,
+     "value120": 120,
+     "value121": 121,
+     "value122": 122,
+     "value123": 123,
+     "value124": 124,
+     "value125": 125,
+     "value126": 126,
+     "value127": 127
+    }
+   },
+   "drum": {
+    "version": 8,
+    "pitch": 0.0,
+    "coarseTune": 0,
+    "fineTune": 0,
+    "monophonic": false,
+    "poliphony": 12,
+    "portamentoTime": 0.0,
+    "portamentoLegato": false,
+    "padGroup": {
+     "value0": 0,
+     "value1": 0,
+     "value2": 0,
+     "value3": 0,
+     "value4": 0,
+     "value5": 0,
+     "value6": 0,
+     "value7": 0,
+     "value8": 0,
+     "value9": 0,
+     "value10": 0,
+     "value11": 0,
+     "value12": 0,
+     "value13": 0,
+     "value14": 0,
+     "value15": 0,
+     "value16": 0,
+     "value17": 0,
+     "value18": 0,
+     "value19": 0,
+     "value20": 0,
+     "value21": 0,
+     "value22": 0,
+     "value23": 0,
+     "value24": 0,
+     "value25": 0,
+     "value26": 0,
+     "value27": 0,
+     "value28": 0,
+     "value29": 0,
+     "value30": 0,
+     "value31": 0,
+     "value32": 0,
+     "value33": 0,
+     "value34": 0,
+     "value35": 0,
+     "value36": 0,
+     "value37": 0,
+     "value38": 0,
+     "value39": 0,
+     "value40": 0,
+     "value41": 0,
+     "value42": 0,
+     "value43": 0,
+     "value44": 0,
+     "value45": 0,
+     "value46": 0,
+     "value47": 0,
+     "value48": 0,
+     "value49": 0,
+     "value50": 0,
+     "value51": 0,
+     "value52": 0,
+     "value53": 0,
+     "value54": 0,
+     "value55": 0,
+     "value56": 0,
+     "value57": 0,
+     "value58": 0,
+     "value59": 0,
+     "value60": 0,
+     "value61": 0,
+     "value62": 0,
+     "value63": 0,
+     "value64": 0,
+     "value65": 0,
+     "value66": 0,
+     "value67": 0,
+     "value68": 0,
+     "value69": 0,
+     "value70": 0,
+     "value71": 0,
+     "value72": 0,
+     "value73": 0,
+     "value74": 0,
+     "value75": 0,
+     "value76": 0,
+     "value77": 0,
+     "value78": 0,
+     "value79": 0,
+     "value80": 0,
+     "value81": 0,
+     "value82": 0,
+     "value83": 0,
+     "value84": 0,
+     "value85": 0,
+     "value86": 0,
+     "value87": 0,
+     "value88": 0,
+     "value89": 0,
+     "value90": 0,
+     "value91": 0,
+     "value92": 0,
+     "value93": 0,
+     "value94": 0,
+     "value95": 0,
+     "value96": 0,
+     "value97": 0,
+     "value98": 0,
+     "value99": 0,
+     "value100": 0,
+     "value101": 0,
+     "value102": 0,
+     "value103": 0,
+     "value104": 0,
+     "value105": 0,
+     "value106": 0,
+     "value107": 0,
+     "value108": 0,
+     "value109": 0,
+     "value110": 0,
+     "value111": 0,
+     "value112": 0,
+     "value113": 0,
+     "value114": 0,
+     "value115": 0,
+     "value116": 0,
+     "value117": 0,
+     "value118": 0,
+     "value119": 0,
+     "value120": 0,
+     "value121": 0,
+     "value122": 0,
+     "value123": 0,
+     "value124": 0,
+     "value125": 0,
+     "value126": 0,
+     "value127": 0
+    },
+    "instruments": [
+     {
+      "version": 27,
+      "coarseTune": 0,
+      "fineTune": 0,
+      "monophonic": false,
+      "polyphony": 0,
+      "lowNote": 0,
+      "highNote": 127,
+      "ignoreBaseNote": false,
+      "zonePlayTime": 1,
+      "whichMuteGroup": 0,
+      "muteTargets": {
+       "value0": 0,
+       "value1": 0,
+       "value2": 0,
+       "value3": 0
+      },
+      "simultPlayTargets": {
+       "value0": 0,
+       "value1": 0,
+       "value2": 0,
+       "value3": 0
+      },
+      "synthSection": {
+       "version": 27,
+       "filterData": {
+        "value0": {
+         "version": 27,
+         "filterKeytrack": 0.2578119933605194,
+         "filterType": 5,
+         "filterCutoff": 1.0,
+         "filterResonance": 0.0,
+         "filterEnvelopeAmount": 0.0,
+         "afterTouchToFilter": 0.0,
+         "filterVelocity": 0.65625,
+         "filterEnvelopeVelocity": 0.2265619933605194,
+         "cutoffRandom": 0.0,
+         "resonanceRandom": 0.0,
+         "outputLevel": 1.0,
+         "pressureToFilter": 0.0
+        },
+        "value1": {
+         "version": 27,
+         "filterKeytrack": 0.0,
+         "filterType": 0,
+         "filterCutoff": 1.0,
+         "filterResonance": 0.0,
+         "filterEnvelopeAmount": 0.0,
+         "afterTouchToFilter": 0.0,
+         "filterVelocity": 0.0,
+         "filterEnvelopeVelocity": 0.0,
+         "cutoffRandom": 0.0,
+         "resonanceRandom": 0.0,
+         "outputLevel": 1.0,
+         "pressureToFilter": 0.0
+        }
+       },
+       "filterSerialRouting": false,
+       "filterBlend": 0.5,
+       "lfoData": {
+        "value0": {
+         "version": 27,
+         "lfoPitch": 0.1328119933605194,
+         "lfoAmpLevel": 0.0,
+         "lfoPan": 0.0,
+         "lfoFilterCutOff": {
+          "value0": 0.4921880066394806,
+          "value1": 0.0
+         },
+         "lfoDelay": 0.0,
+         "lfoLevel": 1.0,
+         "lfoFadein": 0.0,
+         "lfoWaveformType": 1,
+         "lfoRate": 0.6299999952316284,
+         "lfoSync": 0,
+         "lfoFreeRunning": false,
+         "lfoDelaySync": 0,
+         "lfoFadeinSync": 0,
+         "lfoReset": false
+        },
+        "value1": {
+         "version": 27,
+         "lfoPitch": 0.0,
+         "lfoAmpLevel": 0.0,
+         "lfoPan": 0.0,
+         "lfoFilterCutOff": {
+          "value0": 0.0,
+          "value1": 0.0
+         },
+         "lfoDelay": 0.0,
+         "lfoLevel": 1.0,
+         "lfoFadein": 0.0,
+         "lfoWaveformType": 0,
+         "lfoRate": 0.5,
+         "lfoSync": 0,
+         "lfoFreeRunning": false,
+         "lfoDelaySync": 0,
+         "lfoFadeinSync": 0,
+         "lfoReset": true
+        }
+       },
+       "velocityToStart": 0.0,
+       "filterEnvelope": {
+        "version": 2,
+        "Attack": {
+         "value0": 0.140625
+        },
+        "VelocityToAttack": {
+         "value0": 0.203125
+        },
+        "Decay": {
+         "value0": 1.0
+        },
+        "Sustain": {
+         "value0": 0.1875
+        },
+        "Release": {
+         "value0": 0.609375
+        },
+        "Hold": {
+         "value0": 0.0
+        },
+        "DecayFromEnd": {
+         "value0": true
+        },
+        "AD": {
+         "value0": true
+        },
+        "OneShot": {
+         "value0": false
+        },
+        "AttackPhase": {
+         "value0": 0.0
+        },
+        "DecayPhase": {
+         "value0": 0.0
+        },
+        "DecayStart": {
+         "value0": 0
+        },
+        "Type": 0,
+        "Delay": {
+         "value0": 0.0
+        },
+        "AttackCurve": {
+         "value0": 0.375
+        },
+        "DecayCurve": {
+         "value0": 0.375
+        },
+        "ReleaseCurve": {
+         "value0": 0.375
+        },
+        "tempoSync": {
+         "value0": "None"
+        },
+        "Looped": {
+         "value0": false
+        },
+        "TimeScaling": {
+         "value0": 0.5
+        }
+       },
+       "ampEnvelope": {
+        "version": 2,
+        "Attack": {
+         "value0": 0.0
+        },
+        "VelocityToAttack": {
+         "value0": 0.0
+        },
+        "Decay": {
+         "value0": 0.2109380066394806
+        },
+        "Sustain": {
+         "value0": 1.0
+        },
+        "Release": {
+         "value0": 0.6796879768371582
+        },
+        "Hold": {
+         "value0": 0.0
+        },
+        "DecayFromEnd": {
+         "value0": true
+        },
+        "AD": {
+         "value0": true
+        },
+        "OneShot": {
+         "value0": false
+        },
+        "AttackPhase": {
+         "value0": 0.0
+        },
+        "DecayPhase": {
+         "value0": 0.0
+        },
+        "DecayStart": {
+         "value0": 0
+        },
+        "Type": 0,
+        "Delay": {
+         "value0": 0.0
+        },
+        "AttackCurve": {
+         "value0": 0.375
+        },
+        "DecayCurve": {
+         "value0": 0.375
+        },
+        "ReleaseCurve": {
+         "value0": 0.375
+        },
+        "tempoSync": {
+         "value0": "None"
+        },
+        "Looped": {
+         "value0": false
+        },
+        "TimeScaling": {
+         "value0": 0.5
+        }
+       },
+       "pitchEnvelope": {
+        "version": 2,
+        "Attack": {
+         "value0": 0.0
+        },
+        "VelocityToAttack": {
+         "value0": 0.0
+        },
+        "Decay": {
+         "value0": 0.04724400117993355
+        },
+        "Sustain": {
+         "value0": 1.0
+        },
+        "Release": {
+         "value0": 0.0
+        },
+        "Hold": {
+         "value0": 0.0
+        },
+        "DecayFromEnd": {
+         "value0": true
+        },
+        "AD": {
+         "value0": true
+        },
+        "OneShot": {
+         "value0": false
+        },
+        "AttackPhase": {
+         "value0": 0.0
+        },
+        "DecayPhase": {
+         "value0": 0.0
+        },
+        "DecayStart": {
+         "value0": 0
+        },
+        "Type": 0,
+        "Delay": {
+         "value0": 0.0
+        },
+        "AttackCurve": {
+         "value0": 0.375
+        },
+        "DecayCurve": {
+         "value0": 0.375
+        },
+        "ReleaseCurve": {
+         "value0": 0.375
+        },
+        "tempoSync": {
+         "value0": "None"
+        },
+        "Looped": {
+         "value0": false
+        },
+        "TimeScaling": {
+         "value0": 0.5
+        }
+       },
+       "pitchEnvelopeAmount": 0.5,
+       "randomisationScale": 1.0,
+       "attackRandom": 0.0,
+       "decayRandom": 0.0,
+       "auxEnvelope": {
+        "version": 2,
+        "Attack": {
+         "value0": 0.0
+        },
+        "VelocityToAttack": {
+         "value0": 0.0
+        },
+        "Decay": {
+         "value0": 0.04724409431219101
+        },
+        "Sustain": {
+         "value0": 1.0
+        },
+        "Release": {
+         "value0": 0.0
+        },
+        "Hold": {
+         "value0": 0.0
+        },
+        "DecayFromEnd": {
+         "value0": true
+        },
+        "AD": {
+         "value0": true
+        },
+        "OneShot": {
+         "value0": false
+        },
+        "AttackPhase": {
+         "value0": 0.0
+        },
+        "DecayPhase": {
+         "value0": 0.0
+        },
+        "DecayStart": {
+         "value0": 0
+        },
+        "Type": 0,
+        "Delay": {
+         "value0": 0.0
+        },
+        "AttackCurve": {
+         "value0": 0.375
+        },
+        "DecayCurve": {
+         "value0": 0.375
+        },
+        "ReleaseCurve": {
+         "value0": 0.375
+        },
+        "tempoSync": {
+         "value0": "None"
+        },
+        "Looped": {
+         "value0": false
+        },
+        "TimeScaling": {
+         "value0": 0.5
+        }
+       },
+       "auxEnvelopeAmount": 0.0,
+       "rampData": {
+        "value0": 0.0,
+        "value1": 0.0
+       },
+       "driftSpeed": 0.0,
+       "velocityToPitch": 0.0,
+       "velocitySensitivity": 1.0,
+       "velocityToPan": 0.0
+      },
+      "triggerMode": 2,
+      "tempo": 120.0,
+      "bpmLock": true,
+      "warpEnable": false,
+      "stretchPercentage": 100,
+      "layersv": [
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 128,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 128,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       },
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 128,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 128,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       },
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 128,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 128,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       },
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 128,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 128,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       },
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 129,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 1,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       },
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 129,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 1,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       },
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 129,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 1,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       },
+       {
+        "active": true,
+        "volume": {
+         "gainCoefficient": 1.0,
+         "controlValue": 1.0,
+         "law": 1
+        },
+        "pan": 0.5,
+        "pitch": 0.0,
+        "coarseTune": 0,
+        "fineTune": 0,
+        "velocityStart": 0,
+        "velocityEnd": 127,
+        "sampleStart": 0,
+        "sampleEnd": 0,
+        "loop": false,
+        "loopStart": 0,
+        "loopEnd": 0,
+        "loopCrossfadeLength": 0,
+        "loopFineTune": 0,
+        "mute": false,
+        "rootNote": 0,
+        "keyTrackEnable": false,
+        "sampleName": "",
+        "sampleFile": "",
+        "sliceIndex": 129,
+        "direction": 0,
+        "offset": 0,
+        "sliceInfo": {
+         "Start": 0,
+         "End": 0,
+         "LoopStart": 0,
+         "LoopMode": 0,
+         "PulsePosition": 0,
+         "LoopCrossfadeLength": 0,
+         "LoopCrossfadeType": 0,
+         "TailLength": 0.0,
+         "TailLoopPosition": 0.5,
+         "NumLoopRepeats": 0
+        },
+        "version": 11,
+        "pitchRandom": 0.0,
+        "VolumeRandom": 0.0,
+        "PanRandom": 0.0,
+        "OffsetRandom": 0.0,
+        "sliceIncrement": 0,
+        "sliceCycleLength": 1,
+        "sliceIncrementRngSeed": 0,
+        "playbackOffset": 0.0,
+        "layerLoopModeOverridesSliceLoopMode": false,
+        "loopMode": 0,
+        "quadrantEnabled": {
+         "value0": true,
+         "value1": true,
+         "value2": true,
+         "value3": true
+        }
+       }
+      ],
+      "editAllLayers": false,
+      "articulationUseXY": false,
+      "articulations": {
+       "value0": {
+        "version": 27,
+        "articulationType": 0,
+        "articulationSpeed": 0.5,
+        "articulationDynamics": 0.5,
+        "articulationStereo": 1.0,
+        "articulationSpeedScaling": 1
+       },
+       "value1": {
+        "version": 27,
+        "articulationType": 0,
+        "articulationSpeed": 0.5,
+        "articulationDynamics": 0.5,
+        "articulationStereo": 1.0,
+        "articulationSpeedScaling": 1
+       },
+       "value2": {
+        "version": 27,
+        "articulationType": 0,
+        "articulationSpeed": 0.5,
+        "articulationDynamics": 0.5,
+        "articulationStereo": 1.0,
+        "articulationSpeedScaling": 1
+       },
+       "value3": {
+        "version": 27,
+        "articulationType": 0,
+        "articulationSpeed": 0.5,
+        "articulationDynamics": 0.5,
+        "articulationStereo": 1.0,
+        "articulationSpeedScaling": 1
+       }
+      },
+      "userSelectableWarpPoolIndex": 0,
+      "velocityScale": 1.0,
+      "chopProperties": {
+       "version": 1,
+       "chopMode": 0,
+       "chopThreshold": 65,
+       "chopMinSliceTime": 100,
+       "chopRegions": 16,
+       "chopBars": 1,
+       "chopBeats": 4,
+       "chopTimeSignature": 2
+      },
+      "layerCrossfade": 0,
+      "layerCrossfadeX": 0.0,
+      "layerCrossfadeY": 0.0,
+      "mixable": {
+       "version": 1,
+       "audioRoute": {
+        "destination": 0,
+        "audioRouteSubIndex": 0,
+        "channelBitmap": {
+         "type": 0,
+         "data": 3
+        }
+       },
+       "volume": 0.7079460024833679,
+       "mute": false,
+       "solo": false,
+       "pan": 0.5,
+       "automationFilter": 1,
+       "sends": [
+        0.0,
+        0.0,
+        0.0,
+        0.0
+       ],
+       "inserts": {
+        "insertsEnabled": true,
+        "effects": []
+       }
+      },
+      "padEffects": {
+       "padEffectsData": {
+        "value0": {
+         "fxType": 0,
+         "fxValue": 0.0
+        },
+        "value1": {
+         "fxType": 9,
+         "fxValue": 0.0
+        },
+        "value2": {
+         "fxType": 1,
+         "fxValue": 0.0
+        },
+        "value3": {
+         "fxType": 2,
+         "fxValue": 0.0
+        },
+        "value4": {
+         "fxType": 3,
+         "fxValue": 0.0
+        },
+        "value5": {
+         "fxType": 7,
+         "fxValue": 0.0
+        },
+        "value6": {
+         "fxType": 4,
+         "fxValue": 0.0
+        },
+        "value7": {
+         "fxType": 13,
+         "fxValue": 0.0
+        }
+       }
+      },
+      "noteCounters": {
+       "value0": 2,
+       "value1": 2
+      },
+      "modLinks": [],
+      "randomPlaySeed": 0,
+      "midiOutChannel": 0,
+      "midiOutNote": 0,
+      "midiOutBehaviour": 1,
+      "partialPresetName": "<none>"
+     }
+    ],
+    "driftSpeed": 0.0,
+    "portamentoQuantised": false,
+    "monoRetrigger": false,
+    "freeRunningLfoData": {
+     "value0": {
+      "version": 27,
+      "lfoLevel": 1.0,
+      "lfoWaveformType": 0,
+      "lfoRate": 0.5,
+      "lfoSync": 0
+     },
+     "value1": {
+      "version": 27,
+      "lfoLevel": 1.0,
+      "lfoWaveformType": 0,
+      "lfoRate": 0.5,
+      "lfoSync": 0
+     }
+    }
+   },
+   "keygroup": {
+    "transpose": 0,
+    "numKeygroups": 1,
+    "pitchBendRange": 0.17000000178813934,
+    "keygroupVersion": 9,
+    "version": 8,
+    "wheelToLfo": {
+     "value0": 1.0,
+     "value1": 1.0
+    },
+    "afterTouchToFilter": {
+     "value0": 0.0,
+     "value1": 0.0
+    },
+    "modlinksData": {
+     "value0": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value1": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value2": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value3": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value4": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value5": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value6": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value7": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value8": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value9": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value10": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value11": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value12": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value13": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value14": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value15": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value16": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value17": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value18": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value19": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value20": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value21": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value22": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value23": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value24": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value25": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value26": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value27": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value28": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value29": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value30": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     },
+     "value31": {
+      "link.source": 0,
+      "link.target": 0,
+      "link.min": 0.0,
+      "link.max": 1.0,
+      "link.amount": 1.0,
+      "link.viaSource": 0,
+      "link.viaAmount": 1.0,
+      "link.shaper": 0,
+      "link.shaperAmount": 1.0,
+      "version": 1,
+      "link.bipolar": false
+     }
+    },
+    "noteCounters": {
+     "value0": 2,
+     "value1": 2
+    },
+    "legacyMode": true,
+    "timbreShift": 0,
+    "pitchBendPositiveRange": 2,
+    "pitchBendNegativeRange": 2,
+    "synthSection": {
+     "version": 27,
+     "filterData": {
+      "value0": {
+       "version": 27,
+       "filterKeytrack": 0.0,
+       "filterType": 0,
+       "filterCutoff": 1.0,
+       "filterResonance": 0.0,
+       "filterEnvelopeAmount": 0.0,
+       "afterTouchToFilter": 0.0,
+       "filterVelocity": 0.0,
+       "filterEnvelopeVelocity": 0.0,
+       "cutoffRandom": 0.0,
+       "resonanceRandom": 0.0,
+       "outputLevel": 1.0,
+       "pressureToFilter": 0.0
+      },
+      "value1": {
+       "version": 27,
+       "filterKeytrack": 0.0,
+       "filterType": 0,
+       "filterCutoff": 1.0,
+       "filterResonance": 0.0,
+       "filterEnvelopeAmount": 0.0,
+       "afterTouchToFilter": 0.0,
+       "filterVelocity": 0.0,
+       "filterEnvelopeVelocity": 0.0,
+       "cutoffRandom": 0.0,
+       "resonanceRandom": 0.0,
+       "outputLevel": 1.0,
+       "pressureToFilter": 0.0
+      }
+     },
+     "filterSerialRouting": false,
+     "filterBlend": 0.5,
+     "lfoData": {
+      "value0": {
+       "version": 27,
+       "lfoPitch": 0.0,
+       "lfoAmpLevel": 0.0,
+       "lfoPan": 0.0,
+       "lfoFilterCutOff": {
+        "value0": 0.0,
+        "value1": 0.0
+       },
+       "lfoDelay": 0.0,
+       "lfoLevel": 1.0,
+       "lfoFadein": 0.0,
+       "lfoWaveformType": 0,
+       "lfoRate": 0.5,
+       "lfoSync": 0,
+       "lfoFreeRunning": false,
+       "lfoDelaySync": 0,
+       "lfoFadeinSync": 0,
+       "lfoReset": true
+      },
+      "value1": {
+       "version": 27,
+       "lfoPitch": 0.0,
+       "lfoAmpLevel": 0.0,
+       "lfoPan": 0.0,
+       "lfoFilterCutOff": {
+        "value0": 0.0,
+        "value1": 0.0
+       },
+       "lfoDelay": 0.0,
+       "lfoLevel": 1.0,
+       "lfoFadein": 0.0,
+       "lfoWaveformType": 0,
+       "lfoRate": 0.5,
+       "lfoSync": 0,
+       "lfoFreeRunning": false,
+       "lfoDelaySync": 0,
+       "lfoFadeinSync": 0,
+       "lfoReset": true
+      }
+     },
+     "velocityToStart": 0.0,
+     "filterEnvelope": {
+      "version": 2,
+      "Attack": {
+       "value0": 0.0
+      },
+      "VelocityToAttack": {
+       "value0": 0.0
+      },
+      "Decay": {
+       "value0": 0.04724409431219101
+      },
+      "Sustain": {
+       "value0": 1.0
+      },
+      "Release": {
+       "value0": 0.0
+      },
+      "Hold": {
+       "value0": 0.0
+      },
+      "DecayFromEnd": {
+       "value0": true
+      },
+      "AD": {
+       "value0": true
+      },
+      "OneShot": {
+       "value0": true
+      },
+      "AttackPhase": {
+       "value0": 0.0
+      },
+      "DecayPhase": {
+       "value0": 0.0
+      },
+      "DecayStart": {
+       "value0": 0
+      },
+      "Type": 0,
+      "Delay": {
+       "value0": 0.0
+      },
+      "AttackCurve": {
+       "value0": 0.375
+      },
+      "DecayCurve": {
+       "value0": 0.375
+      },
+      "ReleaseCurve": {
+       "value0": 0.375
+      },
+      "tempoSync": {
+       "value0": "None"
+      },
+      "Looped": {
+       "value0": false
+      },
+      "TimeScaling": {
+       "value0": 0.5
+      }
+     },
+     "ampEnvelope": {
+      "version": 2,
+      "Attack": {
+       "value0": 0.0
+      },
+      "VelocityToAttack": {
+       "value0": 0.0
+      },
+      "Decay": {
+       "value0": 0.04724409431219101
+      },
+      "Sustain": {
+       "value0": 1.0
+      },
+      "Release": {
+       "value0": 0.0
+      },
+      "Hold": {
+       "value0": 0.0
+      },
+      "DecayFromEnd": {
+       "value0": true
+      },
+      "AD": {
+       "value0": true
+      },
+      "OneShot": {
+       "value0": true
+      },
+      "AttackPhase": {
+       "value0": 0.0
+      },
+      "DecayPhase": {
+       "value0": 0.0
+      },
+      "DecayStart": {
+       "value0": 0
+      },
+      "Type": 0,
+      "Delay": {
+       "value0": 0.0
+      },
+      "AttackCurve": {
+       "value0": 0.375
+      },
+      "DecayCurve": {
+       "value0": 0.375
+      },
+      "ReleaseCurve": {
+       "value0": 0.375
+      },
+      "tempoSync": {
+       "value0": "None"
+      },
+      "Looped": {
+       "value0": false
+      },
+      "TimeScaling": {
+       "value0": 0.5
+      }
+     },
+     "pitchEnvelope": {
+      "version": 2,
+      "Attack": {
+       "value0": 0.0
+      },
+      "VelocityToAttack": {
+       "value0": 0.0
+      },
+      "Decay": {
+       "value0": 0.04724409431219101
+      },
+      "Sustain": {
+       "value0": 1.0
+      },
+      "Release": {
+       "value0": 0.0
+      },
+      "Hold": {
+       "value0": 0.0
+      },
+      "DecayFromEnd": {
+       "value0": true
+      },
+      "AD": {
+       "value0": true
+      },
+      "OneShot": {
+       "value0": true
+      },
+      "AttackPhase": {
+       "value0": 0.0
+      },
+      "DecayPhase": {
+       "value0": 0.0
+      },
+      "DecayStart": {
+       "value0": 0
+      },
+      "Type": 0,
+      "Delay": {
+       "value0": 0.0
+      },
+      "AttackCurve": {
+       "value0": 0.375
+      },
+      "DecayCurve": {
+       "value0": 0.375
+      },
+      "ReleaseCurve": {
+       "value0": 0.375
+      },
+      "tempoSync": {
+       "value0": "None"
+      },
+      "Looped": {
+       "value0": false
+      },
+      "TimeScaling": {
+       "value0": 0.5
+      }
+     },
+     "pitchEnvelopeAmount": 0.5,
+     "randomisationScale": 1.0,
+     "attackRandom": 0.0,
+     "decayRandom": 0.0,
+     "auxEnvelope": {
+      "version": 2,
+      "Attack": {
+       "value0": 0.0
+      },
+      "VelocityToAttack": {
+       "value0": 0.0
+      },
+      "Decay": {
+       "value0": 0.04724409431219101
+      },
+      "Sustain": {
+       "value0": 1.0
+      },
+      "Release": {
+       "value0": 0.0
+      },
+      "Hold": {
+       "value0": 0.0
+      },
+      "DecayFromEnd": {
+       "value0": true
+      },
+      "AD": {
+       "value0": true
+      },
+      "OneShot": {
+       "value0": true
+      },
+      "AttackPhase": {
+       "value0": 0.0
+      },
+      "DecayPhase": {
+       "value0": 0.0
+      },
+      "DecayStart": {
+       "value0": 0
+      },
+      "Type": 0,
+      "Delay": {
+       "value0": 0.0
+      },
+      "AttackCurve": {
+       "value0": 0.375
+      },
+      "DecayCurve": {
+       "value0": 0.375
+      },
+      "ReleaseCurve": {
+       "value0": 0.375
+      },
+      "tempoSync": {
+       "value0": "None"
+      },
+      "Looped": {
+       "value0": false
+      },
+      "TimeScaling": {
+       "value0": 0.5
+      }
+     },
+     "auxEnvelopeAmount": 0.0,
+     "rampData": {
+      "value0": 0.0,
+      "value1": 0.0
+     },
+     "driftSpeed": 0.0,
+     "velocityToPitch": 0.0,
+     "velocitySensitivity": 0.0,
+     "velocityToPan": 0.0
+    },
+    "filterEnvelopeGlobal": false,
+    "ampEnvelopeGlobal": false,
+    "pitchEnvelopeGlobal": false,
+    "auxEnvelopeGlobal": false,
+    "CurrentStackProcessor": 0,
+    "unisonProcessor": {
+     "mode": 0,
+     "voices": 0,
+     "detuneAmount": 0.0,
+     "stereoSpread": 0.0
+    },
+    "harmoniserProcessor": {
+     "version": 1,
+     "voicesData": {
+      "value0": {
+       "version": 1,
+       "voiceData.enabled": true,
+       "voiceData.shift": 0,
+       "voiceData.detune": 0.0,
+       "voiceData.pan": 0.0,
+       "voiceData.velScale": 1.0,
+       "voiceData.volume": 0.25,
+       "voiceData.delay": 0.0,
+       "voiceData.delaySync": 0
+      },
+      "value1": {
+       "version": 1,
+       "voiceData.enabled": true,
+       "voiceData.shift": 0,
+       "voiceData.detune": 0.0,
+       "voiceData.pan": 0.0,
+       "voiceData.velScale": 1.0,
+       "voiceData.volume": 0.25,
+       "voiceData.delay": 0.0,
+       "voiceData.delaySync": 0
+      },
+      "value2": {
+       "version": 1,
+       "voiceData.enabled": true,
+       "voiceData.shift": 0,
+       "voiceData.detune": 0.0,
+       "voiceData.pan": 0.0,
+       "voiceData.velScale": 1.0,
+       "voiceData.volume": 0.25,
+       "voiceData.delay": 0.0,
+       "voiceData.delaySync": 0
+      },
+      "value3": {
+       "version": 1,
+       "voiceData.enabled": true,
+       "voiceData.shift": 0,
+       "voiceData.detune": 0.0,
+       "voiceData.pan": 0.0,
+       "voiceData.velScale": 1.0,
+       "voiceData.volume": 0.25,
+       "voiceData.delay": 0.0,
+       "voiceData.delaySync": 0
+      }
+     },
+     "harmonizerMix": 0.5
+    },
+    "channelPressureToFilter": {
+     "value0": 0.0,
+     "value1": 0.0
+    }
+   },
+   "fxRackQLinks": [],
+   "customMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "fxRackMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customXFaders": [],
+   "base.customXFaderMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.fxRackXFaders": [],
+   "base.fxRackXFaderMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customXYPad1": [],
+   "base.customXYPad1MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.fxRackXYPad1": [],
+   "base.fxRackXYPad1MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customXYPad2": [],
+   "base.customXYPad2MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.fxRackXYPad2": [],
+   "base.fxRackXYPad2MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customXYPad3": [],
+   "base.customXYPad3MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.fxRackXYPad3": [],
+   "base.fxRackXYPad3MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customXYPad4": [],
+   "base.customXYPad4MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.fxRackXYPad4": [],
+   "base.fxRackXYPad4MacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customPadGrid": [],
+   "base.customPadGridMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.fxRackPadGrid": [],
+   "base.fxRackPadGridMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customEnvFollower": [],
+   "base.customEnvFollowerMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.fxRackEnvFollower": [],
+   "base.fxRackEnvFollowerMacroSceneData": {
+    "value0": {
+     "first": "",
+     "second": []
+    },
+    "value1": {
+     "first": "",
+     "second": []
+    },
+    "value2": {
+     "first": "",
+     "second": []
+    },
+    "value3": {
+     "first": "",
+     "second": []
+    },
+    "value4": {
+     "first": "",
+     "second": []
+    },
+    "value5": {
+     "first": "",
+     "second": []
+    },
+    "value6": {
+     "first": "",
+     "second": []
+    },
+    "value7": {
+     "first": "",
+     "second": []
+    }
+   },
+   "base.customPhysicalPadsAssignments": [],
+   "base.fxRackPhysicalPadsAssignments": []
+  },
+  "length": 0,
+  "lengthFollowsSequenceLength": true,
+  "midiEventsFilter": {
+   "channelFilterData": {
+    "channel": 255
+   },
+   "velocityFilterData": {
+    "min": 0.0,
+    "max": 1.0
+   },
+   "noteFilterData": {
+    "noteRange": {
+     "type": 2,
+     "data": "11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    }
+   },
+   "automationFilterData": {
+    "filteredParams": "00000000000000000"
+   }
+  },
+  "arrangementClipMap": [],
+  "sharedClipMap": [],
+  "recordArm": false,
+  "midiBankAndProgramNumber": {
+   "midiBankEnable": false,
+   "midiBankMsb": 0,
+   "midiBankLsb": 0,
+   "midiProgramNumberEnable": false,
+   "midiProgramNumber": 0
+  },
+  "midiInputRoute": {
+   "inputPort": {
+    "type": 0,
+    "deviceName": "All Ports",
+    "deviceId": "",
+    "os": "Linux"
+   },
+   "inputChannel": 0
+  },
+  "midiOutputRoute": {
+   "outputPort": {
+    "type": 1,
+    "deviceName": "<none>",
+    "deviceId": "",
+    "os": "Linux"
+   },
+   "outputChannel": 0
+  },
+  "midiMonitorable": {
+   "state": 2
+  }
+ }
+}


### PR DESCRIPTION
Implements the writing side of #117. The Akai MPC Modern destination gets an *Output Format* option: *MPC 2 Keygroup (XPM)* - the default, unchanged - or *MPC 3 Track (XTY)*, which writes the track file plus its `_[TrackData]` sample folder (CLI: `-p MPCOutputFormat=XTY`).

The MPC 3 firmware serializes its complete C++ object tree and its reader is strict about that shape, so a minimal document is not an option. The writer therefore replicates the complete `SerialisableTrackData` structure of a real key-group track written by MPC firmware 3.7 from a neutralized 73 KB template resource - all 128 instrument slots with their eight layers, the key-group performance controls, the mixer and macro blocks - and patches only the fields which carry the multi-sample: the names, the key-group count, the pitch bend range, the key ranges, the layers (sample, volume, panorama, tuning, velocity range, loop with crossfade, direction, key tracking), the envelopes, the filter and the sample list with its root-note metadata. The container follows the real files as well: the five ACVS header lines and the GZIP compression.

The encodings mirror what real 3.7 files contain: envelope parameters in `value0` wrappers with logarithmically normalized times, curves and panorama in [0..1], layer volumes as objects holding the linear gain coefficient, the pitch bend range stored both as a fraction of an octave and as semitone integers, per-layer coarse/fine tuning, and the root note of a sample in its sample-list metadata (the layer field stays 0, as in the real files). The structure and encodings were cross-checked against the community documentation of the format ([kurtjcu/MPC-project-file-definitions](https://github.com/kurtjcu/MPC-project-file-definitions), which includes a real key-group track of firmware 3.7) and against the container handling of tools in the wild ([crAZiAc/akai_mpc_tools](https://github.com/crAZiAc/akai_mpc_tools), which patches a real firmware template the same way).

Comparing the reader with the real 3.7 files surfaced three reading fixes which are included:

* The pitch bend range of a track/project is stored in semitones but was read as cents, so the default of 2 semitones became 2 cents. The fraction of an octave stored next to it (`pitchBendRange: 0.17` for 2 semitones) confirms the unit.
* A layer's tuning was read from the coarse/fine tune of its *instrument*, which the caller had already applied - the instrument tuning was doubled and the layer's own tuning fields were ignored.
* The layer volume object (linear gain coefficient) is now read.

Verification: a full-feature SFZ round trip (SFZ to XTY and back) preserves key and velocity ranges, root notes, loops with crossfade, panorama, per-layer tuning, pitch bend and envelopes; a real firmware-3.7 key-group track re-wrapped as an .xty parses correctly; the XPM output stays byte-identical to before.

Open point: a generated file has not been loaded in the MPC 3 software or on hardware yet, so the option is marked experimental in the UI and the documentation; I have asked in #117 for a test. One observation I left alone for a possible follow-up: the filter cutoff is written logarithmically (`MathUtils.normalizeFrequency`) but `MPCFilter` reads it linearly (`cutoff * MAX_FREQUENCY`) - that asymmetry exists for the XPM round trip today as well; if you tell me which law matches the device I will align reader and writer together.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Akai MPC
  * New: The destination can now write MPC 3 track files (*.xty) with their '_[TrackData]' sample folder as an alternative to MPC 2 keygroup folders (new 'Output Format' option, issue #117). The files replicate the complete track structure of MPC firmware 3.7 from a template - the firmware's own reader is strict about its serialized object tree - and only the multi-sample fields are patched in. Not verified in the MPC 3 software itself yet.
  * Fixed: The pitch bend range of a MPC 3 track or project was read as cents but the file stores semitones, so the default of 2 semitones became 2 cents. The fraction of an octave stored next to it confirms the unit.
  * Fixed: The tuning of a MPC 3 layer was read from the coarse and fine tune of its instrument, which the caller had already applied - the instrument tuning was doubled and the layer's own tuning was lost.
  * New: The volume of a MPC 3 layer (an object holding the linear gain coefficient) is now read.
```
