### PR TITLE
WAV: decode and encode the sample chunk's unity note in the right direction

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -33,9 +33,6 @@
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
-* WAV
-  * Fixed: The sample chunk stores a note with a negative fine tuning as the next higher unity note with the complementary positive fraction, but the correction was applied in the wrong direction on both sides: reading added 1 to the unity note where 1 must be subtracted and writing subtracted where it must add. The two errors cancelled between ConvertWithMoss' own reader and writer, which is why round trips never showed it - but any WAV from another tool whose pitch fraction is above 50 cents was read two semitones off, and every written WAV with a negative fine tuning carried a unity note two semitones below what conforming samplers expect.
-  * Fixed: A sample chunk whose pitch fraction is above 50 cents overwrote the root key which the preset format itself supplied (e.g. the root of a Bitwig multisample's XML), since the fine-tuning merge was not gated on the root being unset - combined with the direction error above, such a zone ended up more than two octaves off. The root key and fine tuning of the sample chunk are now only used when the format does not provide a root of its own.
 
 ## 19.1.0
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -33,6 +33,9 @@
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
+* WAV
+  * Fixed: The sample chunk stores a note with a negative fine tuning as the next higher unity note with the complementary positive fraction, but the correction was applied in the wrong direction on both sides: reading added 1 to the unity note where 1 must be subtracted and writing subtracted where it must add. The two errors cancelled between ConvertWithMoss' own reader and writer, which is why round trips never showed it - but any WAV from another tool whose pitch fraction is above 50 cents was read two semitones off, and every written WAV with a negative fine tuning carried a unity note two semitones below what conforming samplers expect.
+  * Fixed: A sample chunk whose pitch fraction is above 50 cents overwrote the root key which the preset format itself supplied (e.g. the root of a Bitwig multisample's XML), since the fine-tuning merge was not gated on the root being unset - combined with the direction error above, such a zone ended up more than two octaves off. The root key and fine tuning of the sample chunk are now only used when the format does not provide a root of its own.
 
 ## 19.1.0
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/file/wav/SampleChunk.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/file/wav/SampleChunk.java
@@ -141,14 +141,18 @@ public class SampleChunk extends AbstractSpecificRIFFChunk
     /**
      * The MIDI unity note value has the same meaning as the instrument chunk's MIDI Unshifted Note
      * field which specifies the musical note at which the sample will be played at it's original
-     * sample rate (the sample rate specified in the format chunk).
+     * sample rate (the sample rate specified in the format chunk). Since the pitch fraction can
+     * only tune upwards, a note with a negative fine tuning is stored as the next higher unity
+     * note with the complementary positive fraction (see {@link #getMIDIPitchFraction()}); this
+     * getter reverses that encoding, so together with
+     * {@link #getMIDIPitchFractionAsCents()} it returns the intended root key and fine tuning.
      *
      * @return The four bytes converted to an integer
      */
     public int getMIDIUnityNote ()
     {
         final int unityNote = this.rawRiffChunk.getFourBytesAsUnsignedInt (0x0C);
-        return this.getMIDIPitchFractionAsCents () < 0 ? unityNote + 1 : unityNote;
+        return this.getMIDIPitchFractionAsCents () < 0 ? unityNote - 1 : unityNote;
     }
 
 
@@ -205,13 +209,15 @@ public class SampleChunk extends AbstractSpecificRIFFChunk
      */
     public void setPitch (final int unityNote, final int cent)
     {
-        // Needs to be inverted since this is the play-back root!
+        // Whole semitones are folded into the unity note; the fraction tunes the play-back
+        // upwards, so a tuning of a semitone up is one unity note down
         int rootNote = unityNote - cent / 100;
         int pitchOffset = cent % 100;
-        // Pitch fraction can only be positive (0-99 cents)!
+        // The pitch fraction can only be positive (0-99 cents): a negative remainder is stored
+        // as the next higher unity note with the complementary positive fraction
         if (pitchOffset < 0)
         {
-            rootNote--;
+            rootNote++;
             pitchOffset += 100;
         }
         this.setMIDIUnityNote (rootNote);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/wav/WavFileSampleData.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/wav/WavFileSampleData.java
@@ -179,17 +179,14 @@ public class WavFileSampleData extends AbstractFileSampleData
         if (sampleChunk == null)
             return;
 
-        // Read the this.keyRoot if not set...
+        // Read the root key and its fine tuning if the format did not provide a root itself.
+        // The pitch fraction is relative to the unity note of the chunk, so it must never be
+        // combined with - or even overwrite - a root key which the format supplied
         if (addRootKey && zone.getKeyRoot () == -1)
-            zone.setKeyRoot (sampleChunk.getMIDIUnityNote ());
-
-        if (zone.getTuning () == 0)
         {
-            final double tune = Math.clamp (sampleChunk.getMIDIPitchFractionAsCents () / 100.0, -0.5, 0.5);
-            zone.setTuning (tune);
-            // Root note needs to be updated as well!
-            if (tune < 0)
-                zone.setKeyRoot (sampleChunk.getMIDIUnityNote ());
+            zone.setKeyRoot (sampleChunk.getMIDIUnityNote ());
+            if (zone.getTuning () == 0)
+                zone.setTuning (Math.clamp (sampleChunk.getMIDIPitchFractionAsCents () / 100.0, -0.5, 0.5));
         }
 
         if (addLoops)


### PR DESCRIPTION
The WAV sample chunk stores a note with a negative fine tuning as the next higher unity note with the complementary positive fraction, since the pitch fraction can only tune upwards (the convention is quoted in `SampleChunk`'s own javadoc: "you must add 1 to the root key ... and add 100 to the negative tuning value", reversed on import). Both sides of the code applied that correction in the wrong direction:

* `SampleChunk.getMIDIUnityNote` added 1 to the unity note when the fraction decodes negative - the reverse of the encoding requires subtracting 1.
* `SampleChunk.setPitch` decremented the unity note when wrapping a negative cent remainder - the encoding requires incrementing.

The two errors cancel between ConvertWithMoss' own reader and writer, so every internal round trip looked correct - which is exactly why this survived. Against the rest of the world it is off by two semitones in both directions: a WAV from another tool whose pitch fraction is above 50 cents (the standard encoding of a flat fine tuning) was read two semitones sharp of its intended root, and every WAV written with a negative fine tuning carries a unity note two semitones below what conforming samplers read. The instrument chunk handling and the identical root/tune fold in `AbletonCreator.createPitch` already follow the correct direction, which corroborates the convention.

A second, related defect in `WavFileSampleData.addZoneData`: the fine-tuning merge from the sample chunk was not gated on the zone's root being unset, and even overwrote a root key which the preset format itself had supplied. A Bitwig multisample zone with an explicit `root="36"` whose WAV carries a stale sample chunk (unity 61, fraction 75 cents) was converted with root 62 and a phantom -25 cent tuning - more than two octaves off, with the XML being authoritative. The chunk's root and fine tuning are now only used when the format does not provide a root of its own.

Verified with crafted sample chunks, before vs. after:

| Case | Before | After |
| --- | --- | --- |
| Read unity 61 / fraction 75 (= root 60, -25 cents) | root **62**, -25 ct | root **60**, -25 ct |
| Read unity 60 / fraction 25 | root 60, +25 ct | unchanged |
| Read unity 60 / fraction 0 | root 60 | unchanged |
| Write root 60, tune -25 ct | unity **59** / 75 ct | unity **61** / 75 ct |
| Bitwig multisample root 36, WAV chunk unity 61 / 75 ct | root **62**, -25 ct | root **36**, no tuning |

Zones with positive or zero fractions and all CWM-to-CWM round trips are unchanged. `getMIDIUnityNoteRaw` (used by the Akai MESA path) is untouched.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* WAV
  * Fixed: The sample chunk stores a note with a negative fine tuning as the next higher unity note with the complementary positive fraction, but the correction was applied in the wrong direction on both sides: reading added 1 to the unity note where 1 must be subtracted and writing subtracted where it must add. The two errors cancelled between ConvertWithMoss' own reader and writer, which is why round trips never showed it - but any WAV from another tool whose pitch fraction is above 50 cents was read two semitones off, and every written WAV with a negative fine tuning carried a unity note two semitones below what conforming samplers expect.
  * Fixed: A sample chunk whose pitch fraction is above 50 cents overwrote the root key which the preset format itself supplied (e.g. the root of a Bitwig multisample's XML), since the fine-tuning merge was not gated on the root being unset - combined with the direction error above, such a zone ended up more than two octaves off. The root key and fine tuning of the sample chunk are now only used when the format does not provide a root of its own.
```
