### PR TITLE
SoundFont 2: apply preset-level generators to defaults, fix the resonance decade and keep negative envelope amounts

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,6 +31,11 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
+* SoundFont 2
+  * Fixed: Generators which only appear on the preset level were dropped entirely when the instrument level did not carry the same generator, although the specification defines them as offsets to the default value in that case. A preset whose global zone transposes a plain instrument down an octave was read an octave too high, preset-level attenuation and envelope offsets vanished, and a preset-level filter offset never created a filter. Such generators are routine in commercial and General MIDI SoundFonts.
+  * Fixed: A preset-level generator offset was added without the signed conversion when the instrument level carried the generator and the value was looked up unsigned - a negative offset (e.g. lowering the filter cutoff) was added as a huge positive number.
+  * Fixed: The filter resonance was read as centibels divided by 100 instead of 10, so every resonance came out ten times too small (20 dB read as 2 dB) and each SoundFont-to-SoundFont round trip divided it by ten again. Writing was already correct.
+  * Fixed: Negative pitch and filter envelope modulation amounts (downward sweeps, e.g. the pitch drop of an 808-style kick) were dropped when writing; both generators are signed in the format and reading them was already correct.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -115,6 +120,11 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
+* SoundFont 2
+  * Fixed: Generators which only appear on the preset level were dropped entirely when the instrument level did not carry the same generator, although the specification defines them as offsets to the default value in that case. A preset whose global zone transposes a plain instrument down an octave was read an octave too high, preset-level attenuation and envelope offsets vanished, and a preset-level filter offset never created a filter. Such generators are routine in commercial and General MIDI SoundFonts.
+  * Fixed: A preset-level generator offset was added without the signed conversion when the instrument level carried the generator and the value was looked up unsigned - a negative offset (e.g. lowering the filter cutoff) was added as a huge positive number.
+  * Fixed: The filter resonance was read as centibels divided by 100 instead of 10, so every resonance came out ten times too small (20 dB read as 2 dB) and each SoundFont-to-SoundFont round trip divided it by ten again. Writing was already correct.
+  * Fixed: Negative pitch and filter envelope modulation amounts (downward sweeps, e.g. the pitch drop of an 808-style kick) were dropped when writing; both generators are signed in the format and reading them was already correct.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,11 +31,6 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
-* SoundFont 2
-  * Fixed: Generators which only appear on the preset level were dropped entirely when the instrument level did not carry the same generator, although the specification defines them as offsets to the default value in that case. A preset whose global zone transposes a plain instrument down an octave was read an octave too high, preset-level attenuation and envelope offsets vanished, and a preset-level filter offset never created a filter. Such generators are routine in commercial and General MIDI SoundFonts.
-  * Fixed: A preset-level generator offset was added without the signed conversion when the instrument level carried the generator and the value was looked up unsigned - a negative offset (e.g. lowering the filter cutoff) was added as a huge positive number.
-  * Fixed: The filter resonance was read as centibels divided by 100 instead of 10, so every resonance came out ten times too small (20 dB read as 2 dB) and each SoundFont-to-SoundFont round trip divided it by ten again. Writing was already correct.
-  * Fixed: Negative pitch and filter envelope modulation amounts (downward sweeps, e.g. the pitch drop of an 808-style kick) were dropped when writing; both generators are signed in the format and reading them was already correct.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -120,11 +115,6 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
-* SoundFont 2
-  * Fixed: Generators which only appear on the preset level were dropped entirely when the instrument level did not carry the same generator, although the specification defines them as offsets to the default value in that case. A preset whose global zone transposes a plain instrument down an octave was read an octave too high, preset-level attenuation and envelope offsets vanished, and a preset-level filter offset never created a filter. Such generators are routine in commercial and General MIDI SoundFonts.
-  * Fixed: A preset-level generator offset was added without the signed conversion when the instrument level carried the generator and the value was looked up unsigned - a negative offset (e.g. lowering the filter cutoff) was added as a huge positive number.
-  * Fixed: The filter resonance was read as centibels divided by 100 instead of 10, so every resonance came out ten times too small (20 dB read as 2 dB) and each SoundFont-to-SoundFont round trip divided it by ten again. Writing was already correct.
-  * Fixed: Negative pitch and filter envelope modulation amounts (downward sweeps, e.g. the pitch drop of an 808-style kick) were dropped when writing; both generators are signed in the format and reading them was already correct.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/GeneratorHierarchy.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/GeneratorHierarchy.java
@@ -173,22 +173,22 @@ public class GeneratorHierarchy
 
         Integer value = this.instrumentZone.get (key);
         if (value == null)
-        {
             value = this.instrumentZoneGlobal.get (key);
-            if (value == null)
-                return Generator.getDefaultValue (key);
-        }
+        int result = value == null ? Generator.getDefaultValue (key).intValue () : value.intValue ();
 
+        // A preset level generator is a signed offset which is added to the value of the
+        // instrument level - or to the default value when the instrument level does not use
+        // the generator at all
         if (!Generator.isOnlyInstrument (generator))
         {
             Integer offset = this.presetZone.get (key);
             if (offset == null)
                 offset = this.presetZoneGlobal.get (key);
             if (offset != null)
-                return Integer.valueOf (value.intValue () + offset.intValue ());
+                result += MathUtils.fromSignedComplement (offset.intValue ());
         }
 
-        return value;
+        return Integer.valueOf (result);
     }
 
 
@@ -205,24 +205,22 @@ public class GeneratorHierarchy
 
         Integer value = this.instrumentZone.get (key);
         if (value == null)
-        {
             value = this.instrumentZoneGlobal.get (key);
-            if (value == null)
-                return Generator.getDefaultValue (key);
-        }
+        int result = value == null ? Generator.getDefaultValue (key).intValue () : MathUtils.fromSignedComplement (value.intValue ());
 
-        int v = MathUtils.fromSignedComplement (value.intValue ());
-
+        // A preset level generator is a signed offset which is added to the value of the
+        // instrument level - or to the default value when the instrument level does not use
+        // the generator at all
         if (!Generator.isOnlyInstrument (generator))
         {
             Integer offset = this.presetZone.get (key);
             if (offset == null)
                 offset = this.presetZoneGlobal.get (key);
             if (offset != null)
-                v = v + MathUtils.fromSignedComplement (offset.intValue ());
+                result += MathUtils.fromSignedComplement (offset.intValue ());
         }
 
-        return Integer.valueOf (v);
+        return Integer.valueOf (result);
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Creator.java
@@ -410,7 +410,8 @@ public class Sf2Creator extends AbstractCreator<Sf2CreatorUI>
         // supports one modulation envelope
         final IEnvelopeModulator pitchModulator = sampleZone.getPitchEnvelopeModulator ();
         final double pitchModDepth = pitchModulator.getDepth ();
-        if (pitchModDepth > 0)
+        // The modulation amount is signed - a negative value sweeps downwards
+        if (pitchModDepth != 0)
         {
             instrumentZone.addSignedGenerator (Generator.MOD_ENV_TO_PITCH, (int) Math.round (pitchModDepth * IEnvelope.MAX_ENVELOPE_DEPTH));
             final IEnvelope pitchEnvelope = pitchModulator.getSource ();
@@ -484,7 +485,8 @@ public class Sf2Creator extends AbstractCreator<Sf2CreatorUI>
 
                 final IEnvelopeModulator cutoffModulator = filter.getCutoffEnvelopeModulator ();
                 final double cutoffModDepth = cutoffModulator.getDepth ();
-                if (cutoffModDepth > 0)
+                // The modulation amount is signed - a negative value sweeps downwards
+                if (cutoffModDepth != 0)
                 {
                     instrumentZone.addSignedGenerator (Generator.MOD_ENV_TO_FILTER_CUTOFF, (int) (cutoffModDepth * IEnvelope.MAX_ENVELOPE_DEPTH));
                     final IEnvelope filterEnvelope = cutoffModulator.getSource ();

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sf2/Sf2Detector.java
@@ -812,8 +812,9 @@ public class Sf2Detector extends AbstractDetector<Sf2DetectorUI>
                     if (initialResonanceValue != null)
                     {
                         final int initialResonance = initialResonanceValue.intValue ();
+                        // The resonance is stored in centi-bel (dB * 10) in the range of [0..960]
                         if (initialResonance > 0 && initialResonance < 960)
-                            resonance = initialResonance / 100.0;
+                            resonance = initialResonance / 10.0;
                     }
 
                     final IFilter filter = new DefaultFilter (FilterType.LOW_PASS, 2, frequency, resonance / IFilter.MAX_RESONANCE);


### PR DESCRIPTION
Three related reading/writing defects in the SoundFont 2 support.

**Preset-level generators were dropped when the instrument level does not carry the same generator.** `GeneratorHierarchy.getSignedValue`/`getUnsignedValue` returned the generator's default as soon as neither instrument-level map held a value, without ever consulting the preset zones - but the specification (SF2 2.04, section 9.4) defines preset generators as additive offsets which apply to the instrument value *or to the default* when the instrument omits the generator; FluidSynth implements exactly that. A preset whose global zone carries `coarseTune=-12` over a plain instrument was read an octave too high, preset-level `initialAttenuation`/`fineTune`/envelope offsets vanished, and a preset-level `initialFilterFc` offset never created a filter (the untouched default 13500 is the "no filter" gate). Such generators are routine in commercial and General MIDI SoundFonts. On the unsigned lookup path the offset was additionally added without the signed conversion, so a negative offset was added as a huge positive number.

**The filter resonance was read a decade too small.** `initialFilterQ` is centibels; the writer stores dB x 10 (with a comment saying so), but the reader divided by 100 - every resonance came out ten times too small (20 dB read as 2 dB) and each SoundFont-to-SoundFont round trip divided by ten again.

**Negative envelope modulation amounts were dropped on write.** `modEnvToPitch` and `modEnvToFilterFc` are signed generators and the reader takes them signed, but the writer gated both on `> 0` - a downward filter sweep or the pitch drop of an 808-style kick lost its whole modulation envelope.

Verified with crafted SoundFonts (a preset-level-offset zone over a bare instrument, and an instrument-level resonance case), before vs. after:

| Case | Before | After |
| --- | --- | --- |
| Preset zone: coarseTune -12, fineTune -25, attenuation 100 cB, filterFc -1200 over bare instrument | no tuning, no volume, no filter | tune -1225 ct, volume -10 dB, low-pass at 9956 Hz |
| Instrument initialFilterQ = 200 (20 dB) | resonance 2 dB | resonance 20 dB |
| SFZ with resonance=3 to SF2 and back | 0.30 | 3.00 |
| SFZ with fileg_depth=-1200 to SF2 | generator absent | `modEnvToFilterFc = -1200` plus the envelope times |
| File with no preset-level generators | - | unchanged |

The read side of the negative amounts and all other generator laws were already correct and are untouched. (The SFZ creator has the same `> 0` gate on its own output side; that is a separate format and will come separately.)

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* SoundFont 2
  * Fixed: Generators which only appear on the preset level were dropped entirely when the instrument level did not carry the same generator, although the specification defines them as offsets to the default value in that case. A preset whose global zone transposes a plain instrument down an octave was read an octave too high, preset-level attenuation and envelope offsets vanished, and a preset-level filter offset never created a filter. Such generators are routine in commercial and General MIDI SoundFonts.
  * Fixed: A preset-level generator offset was added without the signed conversion when the instrument level carried the generator and the value was looked up unsigned - a negative offset (e.g. lowering the filter cutoff) was added as a huge positive number.
  * Fixed: The filter resonance was read as centibels divided by 100 instead of 10, so every resonance came out ten times too small (20 dB read as 2 dB) and each SoundFont-to-SoundFont round trip divided it by ten again. Writing was already correct.
  * Fixed: Negative pitch and filter envelope modulation amounts (downward sweeps, e.g. the pitch drop of an 808-style kick) were dropped when writing; both generators are signed in the format and reading them was already correct.
```
