### PR TITLE
NI Kontakt: fix the Kontakt 1 cutoff scale, the NKM clip key and three crossfade mix-ups

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -25,12 +25,6 @@
   * Fixed: Presets which park their cutoff at an end of its range and open it up again with a modulation cord were converted to silence. Only the filter envelope and the key tracking of such a cord have a counterpart in the model - velocity, the assignable MIDI controllers and the LFOs are lost - so what was left was a filter which removes the whole signal (the reported '3DPads - 3DreamSwells' held a high-pass at 14.5 kHz, and every single low-pass voice of 'Old World Instruments' sits at the bottom of its range). Such a voice now gets no filter at all, which is much closer to the original than the silence; a voice whose filter envelope does open the cutoff up again keeps its filter. This affects 10390 of the 38783 filter voices of the E4 factory library.
 * Kurzweil K2x00
   * Fixed: An envelope stage with both a zero time and a zero level is unused on the device and keeps the level of the previous stage, but was read literally. A program which leaves its decay stage unused - like the reported FM basses, which sustain at the attack level and only fade out with a long release - was therefore converted to a silent preset. Additionally, the attack velocity is now converted as a cutoff modulation source of the F1 slot in both directions; the same programs open their nearly closed cutoff by velocity and converted very dull without it.
-* NI Kontakt
-  * Fixed: The filter cutoff of a Kontakt 1 file is stored logarithmically normalized to [0..1] but was read as a frequency in Hertz - a mid-range filter became a low-pass below 1 Hz and the converted preset was practically silent. Writing was already correct, which is why round trips through ConvertWithMoss hid it.
-  * Fixed: The upper key limit of an instrument in a Kontakt 1 multi (NKM) was stored as the lower clip key - the clip range became [high..127] and destinations which apply it dropped or mis-clipped most zones of a performance conversion.
-  * Fixed: The upper velocity crossfade of a written Kontakt 1 file was calculated from the lower velocity crossfade value.
-  * Fixed: The loop cross-fade of a written Kontakt 1 file was the cross-fade fraction cast to a whole number, so every cross-fade became 0 samples. The field is a length in samples.
-  * Fixed: The lower velocity crossfade of a Kontakt 4.2/5+ zone was read from the lower key crossfade field.
 * Roland ZEN-Core
   * Fixed: A bank (a SVZ which holds one tone per preset, as written by the preset library destination) was read as one single multi-sample: all samples of the file were merged into it and only the shaping of its first tone was applied, so every preset but the first was lost. Each tone is now read as a multi-sample of its own, built from the multi-samples which its partials play. A SVZ with one tone is unchanged.
 * Renoise
@@ -132,12 +126,6 @@
   * Fixed: Reading a patch could hang with full CPU load and no output. The loop over the sample slots did not advance on an empty slot, and since a patch rarely uses all of its slots this affected almost every patch.
 * Roland S-7xx
   * Fixed: The two envelope time key-follow fields were read as unsigned although they are signed.
-* NI Kontakt
-  * Fixed: The filter cutoff of a Kontakt 1 file is stored logarithmically normalized to [0..1] but was read as a frequency in Hertz - a mid-range filter became a low-pass below 1 Hz and the converted preset was practically silent. Writing was already correct, which is why round trips through ConvertWithMoss hid it.
-  * Fixed: The upper key limit of an instrument in a Kontakt 1 multi (NKM) was stored as the lower clip key - the clip range became [high..127] and destinations which apply it dropped or mis-clipped most zones of a performance conversion.
-  * Fixed: The upper velocity crossfade of a written Kontakt 1 file was calculated from the lower velocity crossfade value.
-  * Fixed: The loop cross-fade of a written Kontakt 1 file was the cross-fade fraction cast to a whole number, so every cross-fade became 0 samples. The field is a length in samples.
-  * Fixed: The lower velocity crossfade of a Kontakt 4.2/5+ zone was read from the lower key crossfade field.
 * Roland ZEN-Core
   * Fixed: SVZ sample packs produced by Roland's own SF2-to-SVZ converter (e.g. the commercial "ARP Solina Strings" / Vulture Culture SOURCE packs) could not be read - their samples were detected as "50 channels" and the length calculation failed. These chunks embed a complete WAV file rather than raw PCM; the embedded WAV is now read directly.
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -25,6 +25,12 @@
   * Fixed: Presets which park their cutoff at an end of its range and open it up again with a modulation cord were converted to silence. Only the filter envelope and the key tracking of such a cord have a counterpart in the model - velocity, the assignable MIDI controllers and the LFOs are lost - so what was left was a filter which removes the whole signal (the reported '3DPads - 3DreamSwells' held a high-pass at 14.5 kHz, and every single low-pass voice of 'Old World Instruments' sits at the bottom of its range). Such a voice now gets no filter at all, which is much closer to the original than the silence; a voice whose filter envelope does open the cutoff up again keeps its filter. This affects 10390 of the 38783 filter voices of the E4 factory library.
 * Kurzweil K2x00
   * Fixed: An envelope stage with both a zero time and a zero level is unused on the device and keeps the level of the previous stage, but was read literally. A program which leaves its decay stage unused - like the reported FM basses, which sustain at the attack level and only fade out with a long release - was therefore converted to a silent preset. Additionally, the attack velocity is now converted as a cutoff modulation source of the F1 slot in both directions; the same programs open their nearly closed cutoff by velocity and converted very dull without it.
+* NI Kontakt
+  * Fixed: The filter cutoff of a Kontakt 1 file is stored logarithmically normalized to [0..1] but was read as a frequency in Hertz - a mid-range filter became a low-pass below 1 Hz and the converted preset was practically silent. Writing was already correct, which is why round trips through ConvertWithMoss hid it.
+  * Fixed: The upper key limit of an instrument in a Kontakt 1 multi (NKM) was stored as the lower clip key - the clip range became [high..127] and destinations which apply it dropped or mis-clipped most zones of a performance conversion.
+  * Fixed: The upper velocity crossfade of a written Kontakt 1 file was calculated from the lower velocity crossfade value.
+  * Fixed: The loop cross-fade of a written Kontakt 1 file was the cross-fade fraction cast to a whole number, so every cross-fade became 0 samples. The field is a length in samples.
+  * Fixed: The lower velocity crossfade of a Kontakt 4.2/5+ zone was read from the lower key crossfade field.
 * Roland ZEN-Core
   * Fixed: A bank (a SVZ which holds one tone per preset, as written by the preset library destination) was read as one single multi-sample: all samples of the file were merged into it and only the shaping of its first tone was applied, so every preset but the first was lost. Each tone is now read as a multi-sample of its own, built from the multi-samples which its partials play. A SVZ with one tone is unchanged.
 * Renoise
@@ -126,6 +132,12 @@
   * Fixed: Reading a patch could hang with full CPU load and no output. The loop over the sample slots did not advance on an empty slot, and since a patch rarely uses all of its slots this affected almost every patch.
 * Roland S-7xx
   * Fixed: The two envelope time key-follow fields were read as unsigned although they are signed.
+* NI Kontakt
+  * Fixed: The filter cutoff of a Kontakt 1 file is stored logarithmically normalized to [0..1] but was read as a frequency in Hertz - a mid-range filter became a low-pass below 1 Hz and the converted preset was practically silent. Writing was already correct, which is why round trips through ConvertWithMoss hid it.
+  * Fixed: The upper key limit of an instrument in a Kontakt 1 multi (NKM) was stored as the lower clip key - the clip range became [high..127] and destinations which apply it dropped or mis-clipped most zones of a performance conversion.
+  * Fixed: The upper velocity crossfade of a written Kontakt 1 file was calculated from the lower velocity crossfade value.
+  * Fixed: The loop cross-fade of a written Kontakt 1 file was the cross-fade fraction cast to a whole number, so every cross-fade became 0 samples. The field is a length in samples.
+  * Fixed: The lower velocity crossfade of a Kontakt 4.2/5+ zone was read from the lower key crossfade field.
 * Roland ZEN-Core
   * Fixed: SVZ sample packs produced by Roland's own SF2-to-SVZ converter (e.g. the commercial "ARP Solina Strings" / Vulture Culture SOURCE packs) could not be read - their samples were detected as "50 channels" and the length calculation failed. These chunks embed a complete WAV file rather than raw PCM; the embedded WAV is now read directly.
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/AbstractNKIMetadataFileHandler.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/AbstractNKIMetadataFileHandler.java
@@ -405,7 +405,7 @@ public abstract class AbstractNKIMetadataFileHandler
         zoneContent = zoneContent.replace ("%ZONE_KEY_LOW%", Integer.toString (keyLow));
         zoneContent = zoneContent.replace ("%ZONE_KEY_HIGH%", Integer.toString (limitToDefault (zone.getKeyHigh (), 127)));
         zoneContent = zoneContent.replace ("%ZONE_VEL_CROSS_LOW%", Integer.toString (limitToDefault (zone.getVelocityCrossfadeLow (), 0)));
-        zoneContent = zoneContent.replace ("%ZONE_VEL_CROSS_HIGH%", Integer.toString (limitToDefault (zone.getVelocityCrossfadeLow (), 0)));
+        zoneContent = zoneContent.replace ("%ZONE_VEL_CROSS_HIGH%", Integer.toString (limitToDefault (zone.getVelocityCrossfadeHigh (), 0)));
         zoneContent = zoneContent.replace ("%ZONE_KEY_CROSS_LOW%", Integer.toString (limitToDefault (zone.getNoteCrossfadeLow (), 0)));
         zoneContent = zoneContent.replace ("%ZONE_KEY_CROSS_HIGH%", Integer.toString (limitToDefault (zone.getNoteCrossfadeHigh (), 0)));
         zoneContent = zoneContent.replace ("%ZONE_KEY_ROOT%", Integer.toString (limitToDefault (zone.getKeyRoot (), keyLow)));
@@ -429,7 +429,8 @@ public abstract class AbstractNKIMetadataFileHandler
         loopContent = loopContent.replace ("%LOOP_MODE%", loop.isLoopUntilRelease () ? this.tags.untilReleaseValue () : this.tags.untilEndValue ());
         loopContent = loopContent.replace ("%LOOP_ALTERNATING%", loop.getType () == LoopType.ALTERNATING ? "yes" : "no");
         loopContent = loopContent.replace ("%LOOP_TUNING%", Float.toString ((float) Math.pow (2.0, loop.getTuning () / 12.0)));
-        return loopContent.replace ("%LOOP_XFADE%", Integer.toString ((int) loop.getCrossfade ()));
+        // The cross-fade of the format is a length in samples, not the fraction of the loop
+        return loopContent.replace ("%LOOP_XFADE%", Integer.toString (loop.getCrossfadeInSamples ()));
     }
 
 
@@ -611,7 +612,7 @@ public abstract class AbstractNKIMetadataFileHandler
             instrumentSource.setClipKeyLow (Integer.parseInt (lowKey));
         final String highKey = programParameters.get ("highKey");
         if (highKey != null)
-            instrumentSource.setClipKeyLow (Integer.parseInt (highKey));
+            instrumentSource.setClipKeyHigh (Integer.parseInt (highKey));
     }
 
 
@@ -1469,8 +1470,11 @@ public abstract class AbstractNKIMetadataFileHandler
                 return Optional.empty ();
         }
 
+        // The cutoff is stored logarithmically normalized to [0..1] (see the writing side),
+        // 1.0 is the fully open filter at 21.8 kHz
         final String cutoffText = valueMap.get ("cutoff");
-        final double cutoff = cutoffText == null ? 1.0 : Double.parseDouble (cutoffText);
+        final double normalizedCutoff = cutoffText == null ? 1.0 : Double.parseDouble (cutoffText);
+        final double cutoff = MathUtils.denormalizeFrequency (Math.clamp (normalizedCutoff, 0, 1), 21800.0);
         final String resonanceText = valueMap.get ("resonance");
         final double resonance = resonanceText == null ? 0 : Double.parseDouble (resonanceText);
         return Optional.of (new DefaultFilter (filterType, Integer.parseInt (matcher.group (2)), cutoff, resonance));

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/type/AbstractKontaktFormat.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/type/AbstractKontaktFormat.java
@@ -116,7 +116,7 @@ public abstract class AbstractKontaktFormat implements IKontaktFormat
 
             zone.setNoteCrossfadeLow (kontaktZone.getFadeLowKey ());
             zone.setNoteCrossfadeHigh (kontaktZone.getFadeHighKey ());
-            zone.setVelocityCrossfadeLow (kontaktZone.getFadeLowKey ());
+            zone.setVelocityCrossfadeLow (kontaktZone.getFadeLowVelocity ());
             zone.setVelocityCrossfadeHigh (kontaktZone.getFadeHighVelocity ());
 
             // Only on a group level...


### PR DESCRIPTION
Five zone-parameter defects in the Kontakt support, all of the same family: a value read or written with the wrong scale or from the wrong field, while the correct counterpart sits right next to it.

* **Kontakt 1 filter cutoff read as Hertz.** The XML field is logarithmically normalized to [0..1] (the writing side produces it with `MathUtils.normalizeFrequency` against 21.8 kHz), but the reader passed the raw value to `DefaultFilter` as a frequency - a mid-range filter became a low-pass below 1 Hz and the converted preset was practically silent. Round trips through ConvertWithMoss hid it because both errors cancelled.
* **NKM clip key copy-paste.** `readInstrumentParameters` stored the `highKey` of a Kontakt 1 multi's instrument via `setClipKeyLow`, so the clip range became [high..127]; destinations which apply the clip (1010music, Yamaha performance note limits) dropped or mis-clipped most zones. The binary Kontakt 2/5 paths set low and high correctly.
* **Written upper velocity crossfade taken from the lower value** (`%ZONE_VEL_CROSS_HIGH%` filled from `getVelocityCrossfadeLow`) - the same defect that was fixed for Ableton in 19.1.0.
* **Written loop cross-fade cast the 0..1 fraction to int** - every loop cross-fade became 0 samples (loop clicks where the source was seamless); the field is a length in samples, so it now writes `getCrossfadeInSamples`.
* **Kontakt 4.2/5+ velocity crossfade low read from the key fade field** (`getFadeLowKey` instead of the unused `getFadeLowVelocity`).

Verified with an SFZ (2 kHz low-pass, resonance, asymmetric velocity crossfades 19/37, loop) converted to a Kontakt 1 NKI and back, inspecting the decompressed XML as well:

| Case | Before | After |
| --- | --- | --- |
| Written NKI cutoff value | 0.760877 (correct) | unchanged |
| Cutoff read back | **0.76 Hz** | 2000.01 Hz |
| Written `fadeHighVelo` | **19** (copy of low) | 37 |
| Resonance round trip | 2.00 | unchanged |
| Loop points round trip | unchanged | unchanged |

The NKM clip fix and the Kontakt 5 fade fix are single-field corrections verifiable in the code (the correct setter/getter exists and was unused); I have no NKM/K5 test corpus at hand, so they are code-verified only. One observation for a possible follow-up, unrelated to these fixes: reading the velocity crossfades back and writing them to SFZ produces collapsed `xfin`/`xfout` spans, which looks like a separate mapping issue in the SFZ creator.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* NI Kontakt
  * Fixed: The filter cutoff of a Kontakt 1 file is stored logarithmically normalized to [0..1] but was read as a frequency in Hertz - a mid-range filter became a low-pass below 1 Hz and the converted preset was practically silent. Writing was already correct, which is why round trips through ConvertWithMoss hid it.
  * Fixed: The upper key limit of an instrument in a Kontakt 1 multi (NKM) was stored as the lower clip key - the clip range became [high..127] and destinations which apply it dropped or mis-clipped most zones of a performance conversion.
  * Fixed: The upper velocity crossfade of a written Kontakt 1 file was calculated from the lower velocity crossfade value.
  * Fixed: The loop cross-fade of a written Kontakt 1 file was the cross-fade fraction cast to a whole number, so every cross-fade became 0 samples. The field is a length in samples.
  * Fixed: The lower velocity crossfade of a Kontakt 4.2/5+ zone was read from the lower key crossfade field.
```
