### PR TITLE
1010music: fix the blackbox loop cross-fade attribute and four bento defects

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,6 +16,12 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
+* 1010music blackbox / bento
+  * Fixed: The loop cross-fade of a blackbox pad was read from the loop-end attribute instead of the fade-amount attribute - virtually every looped pad got a cross-fade spanning the entire loop, which destinations that bake cross-fades into the audio smeared audibly.
+  * Fixed: A performance instrument on OMNI was written into a bento project with MIDI input channel 'Off', so the track received no MIDI at all - the same defect was fixed for the blackbox in 19.1.0.
+  * Fixed: The loop type and cross-fade of a bento cell were assigned from themselves instead of the cell's default loop - a ping-pong loop read as a forward loop.
+  * Fixed: The sample length attribute of a bento cell was treated as an absolute end position although it is the play-back length (the blackbox reading is correct) - a cell with a moved sample start lost that many frames from its end.
+  * Fixed: The root velocity written into a bento project was half of the velocity range's width instead of its mid-point, which for a layer of 80..127 lies outside of the layer.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,12 +16,6 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
-* 1010music blackbox / bento
-  * Fixed: The loop cross-fade of a blackbox pad was read from the loop-end attribute instead of the fade-amount attribute - virtually every looped pad got a cross-fade spanning the entire loop, which destinations that bake cross-fades into the audio smeared audibly.
-  * Fixed: A performance instrument on OMNI was written into a bento project with MIDI input channel 'Off', so the track received no MIDI at all - the same defect was fixed for the blackbox in 19.1.0.
-  * Fixed: The loop type and cross-fade of a bento cell were assigned from themselves instead of the cell's default loop - a ping-pong loop read as a forward loop.
-  * Fixed: The sample length attribute of a bento cell was treated as an absolute end position although it is the play-back length (the blackbox reading is correct) - a cell with a moved sample start lost that many frames from its end.
-  * Fixed: The root velocity written into a bento project was half of the velocity range's width instead of its mid-point, which for a layer of 80..127 lies outside of the layer.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoCreator.java
@@ -262,8 +262,8 @@ public class BentoCreator extends AbstractMusic1010Creator
             final Element trackParamsElement = XMLUtils.addElement (document, trackElement, Music1010Tag.PARAMS);
             for (final Map.Entry<String, String> entry: TRACK_PARAM_ATTRIBUTES.entrySet ())
                 trackParamsElement.setAttribute (entry.getKey (), entry.getValue ());
-            // MIDI input channel: 0 = Off, 1..16
-            final int midiChannel = instrumentSource.getMidiChannel () % 16 + 1;
+            // MIDI input channel: 0 = Off, 1..16 - OMNI (-1) becomes channel 1
+            final int midiChannel = Math.max (0, instrumentSource.getMidiChannel ()) % 16 + 1;
             trackParamsElement.setAttribute (Music1010Tag.ATTR_MIDI_INPUT_CHANNEL, Integer.toString (midiChannel));
 
             trackParamsElement.setAttribute (Music1010Tag.ATTR_CELLNAME, multisampleSource.getName ());
@@ -410,7 +410,7 @@ public class BentoCreator extends AbstractMusic1010Creator
         // No zone.getKeyTracking ()
         final int loVel = limitToDefault (zone.getVelocityLow (), 1);
         final int hiVel = limitToDefault (zone.getVelocityHigh (), 127);
-        XMLUtils.setIntegerAttribute (paramsElement, Music1010Tag.ATTR_ROOT_VEL, (hiVel - loVel) / 2);
+        XMLUtils.setIntegerAttribute (paramsElement, Music1010Tag.ATTR_ROOT_VEL, (hiVel + loVel) / 2);
         XMLUtils.setIntegerAttribute (paramsElement, Music1010Tag.ATTR_LO_VEL, loVel);
         XMLUtils.setIntegerAttribute (paramsElement, Music1010Tag.ATTR_HI_VEL, hiVel);
         // No fades info.getVelocityCrossfadeLow ()

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoDetector.java
@@ -376,10 +376,12 @@ public class BentoDetector extends AbstractDetector<MetadataSettingsUI>
         // -----------------------------------------------------------
         // Play-range & Loops
 
-        sampleZone.setStart (XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_SAMPLE_START, 0));
-        final int stop = XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_SAMPLE_LENGTH, -1);
-        if (stop > 0)
-            sampleZone.setStop (stop);
+        final int start = XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_SAMPLE_START, 0);
+        sampleZone.setStart (start);
+        // The attribute is the play-back length, not an absolute end position
+        final int length = XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_SAMPLE_LENGTH, -1);
+        if (length > 0)
+            sampleZone.setStop (start + length);
 
         if (defaultLoop != null)
         {
@@ -388,8 +390,8 @@ public class BentoDetector extends AbstractDetector<MetadataSettingsUI>
             if (loopStart >= 0 && loopEnd > 0)
             {
                 final ISampleLoop loop = new DefaultSampleLoop ();
-                loop.setCrossfade (loop.getCrossfade ());
-                loop.setType (loop.getType ());
+                loop.setCrossfade (defaultLoop.getCrossfade ());
+                loop.setType (defaultLoop.getType ());
                 loop.setStart (loopStart);
                 loop.setEnd (loopEnd);
                 sampleZone.addLoop (loop);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Detector.java
@@ -270,7 +270,7 @@ public class Music1010Detector extends AbstractDetector<MetadataSettingsUI>
                 loop.setType (loopMode == 2 ? LoopType.ALTERNATING : LoopType.FORWARDS);
                 loop.setStart (XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_LOOP_START, 0));
                 loop.setEnd (XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_LOOP_END, 0));
-                loop.setCrossfade (XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_LOOP_END, 0) / 1000.0);
+                loop.setCrossfade (XMLUtils.getIntegerAttribute (paramsElement, Music1010Tag.ATTR_LOOP_FADE_AMOUNT, 0) / 1000.0);
                 sampleZone.addLoop (loop);
             }
         }


### PR DESCRIPTION
Five defects in the 1010music support.

* **blackbox: loop cross-fade read from the loop-end attribute.** `Music1010Detector` fed `loopend / 1000` into the cross-fade instead of `loopfadeamt / 1000` - any loop ending past frame 1000 clamps to a 100% cross-fade, which Renoise/Deluge/Tonverk then bake across the whole loop. Measured with a pad cell (`loopstart=100 loopend=8000 loopfadeamt=250`): the converted loop cross-fade was **7900 samples (the entire loop)** before and is 1975 samples (the intended 25%) after.
* **bento: OMNI performance instruments written as MIDI 'Off'.** `-1 % 16 + 1 = 0` = Off - the track receives no MIDI. The blackbox creator received exactly this `Math.max (0, ...)` fix in 19.1.0; the bento creator missed it.
* **bento: loop type/cross-fade self-assignment.** `loop.setCrossfade (loop.getCrossfade ()); loop.setType (loop.getType ());` was meant to copy from the cell's default loop - a ping-pong loop read as a plain forward loop.
* **bento: sample length treated as an absolute end.** The blackbox reading computes `start + samlen`; the bento reading used `samlen` as the stop position, so a cell with a moved sample start lost that many frames from its end. Both creators write `samstart=0`, so ConvertWithMoss round trips are unchanged by this.
* **bento: root velocity written as half the range width** (`(hi - lo) / 2`) instead of the mid-point (`(hi + lo) / 2`) - for an 80..127 layer the written value 23 lies outside the layer.

One observation from testing, left alone: the blackbox creator writes asset paths with device-style backslashes (`\Presets\Name\Sample.wav`), which the detector cannot resolve on macOS/Linux, so reading ConvertWithMoss' own blackbox output fails on those platforms ("Sample file does not exist"). That is a path-handling topic of its own.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* 1010music blackbox / bento
  * Fixed: The loop cross-fade of a blackbox pad was read from the loop-end attribute instead of the fade-amount attribute - virtually every looped pad got a cross-fade spanning the entire loop, which destinations that bake cross-fades into the audio smeared audibly.
  * Fixed: A performance instrument on OMNI was written into a bento project with MIDI input channel 'Off', so the track received no MIDI at all - the same defect was fixed for the blackbox in 19.1.0.
  * Fixed: The loop type and cross-fade of a bento cell were assigned from themselves instead of the cell's default loop - a ping-pong loop read as a forward loop.
  * Fixed: The sample length attribute of a bento cell was treated as an absolute end position although it is the play-back length (the blackbox reading is correct) - a cell with a moved sample start lost that many frames from its end.
  * Fixed: The root velocity written into a bento project was half of the velocity range's width instead of its mid-point, which for a layer of 80..127 lies outside of the layer.
```
