### PR TITLE
Waldorf QPAT: fix the pitch matrix amount offset and the velocity amount source

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -33,8 +33,6 @@
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
-  * Fixed: The amount of a matrix entry modulating the oscillator pitch (the pitch envelope) was read with the wrong offset: a positive amount was read as a negative one (e.g. +50% as -25%) and +100% was dropped entirely.
-  * Fixed: The velocity modulation of the volume was written from the amplitude envelope modulation depth instead of the velocity modulation amount. E.g. a source with a velocity amount of 0% was written as +100%.
 
 ## 19.1.0
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -33,6 +33,8 @@
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
+  * Fixed: The amount of a matrix entry modulating the oscillator pitch (the pitch envelope) was read with the wrong offset: a positive amount was read as a negative one (e.g. +50% as -25%) and +100% was dropped entirely.
+  * Fixed: The velocity modulation of the volume was written from the amplitude envelope modulation depth instead of the velocity modulation amount. E.g. a source with a velocity amount of 0% was written as +100%.
 
 ## 19.1.0
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
@@ -538,7 +538,7 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
                 createEnvelope (parameters, envelope, AMP_ENV, AMP_ENV, flattenAmpEnvelope);
 
                 // AmpVeloAmount: [0.00] "-100.00 %" ... [1.00] "+100.00 %"
-                final double ampVeloAmount = amplitudeEnvelopeModulator.getDepth ();
+                final double ampVeloAmount = firstZone.getAmplitudeVelocityModulator ().getDepth ();
                 parameters.add (new WaldorfQpatParameter ("AmpVeloAmount", StringUtils.formatPercent (ampVeloAmount, 2), (float) ((ampVeloAmount + 1.0) / 2.0)));
             }
         }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatDetector.java
@@ -648,7 +648,7 @@ public class WaldorfQpatDetector extends AbstractDetector<MetadataSettingsUI>
                     if (amountParam.value != 0.5)
                     {
                         // -24..24 needs to translate to -0.5 to 0.5
-                        final IEnvelopeModulator modulator = new DefaultEnvelopeModulator (amountParam.value - 1.0);
+                        final IEnvelopeModulator modulator = new DefaultEnvelopeModulator (amountParam.value - 0.5);
                         final String prefix = "FreeEnv" + (int) (sourceParam.value - 3.0);
                         final IEnvelope envelope = parseEnvelope (parameters, prefix, prefix);
                         modulator.setSource (envelope);


### PR DESCRIPTION
Two defects in the Waldorf Quantum/Iridium support, both verified with an SFZ -> QPAT -> SFZ round trip.

* **Pitch matrix amount read with the wrong offset.** The creator encodes the pitch-envelope matrix amount as `value = depth + 0.5` (`WaldorfQpatCreator.createPitchModMatrixEntry`), but the detector decoded it as `value - 1.0`. Every positive amount came back negative (+50% read as -25%), and +100% decoded to exactly 0, so the pitch envelope was dropped altogether. The decode is now `value - 0.5`, the exact inverse of the encode.
* **AmpVeloAmount written from the wrong modulator.** The creator wrote the velocity amount from the *amplitude envelope* modulation depth (which defaults to 1.0) instead of the zone's *velocity* modulation amount - the slot its own detector reads the value back into. A source with `amp_veltrack=0` was written as +100%.

Round trip of an SFZ with `pitcheg_depth=2400` and `amp_veltrack=0`:

| Opcode | Before | After |
|---|---|---|
| `pitcheg_depth` | **-3600** (inverted and rescaled) | 2400 |
| `amp_veltrack` | **absent** (falls back to 100) | 0 |

Not touched here: the QPAT pitch scale equates a modulation depth of 1.0 with 48 semitones while SFZ/SF2/DLS/Renoise use the model maximum of 120 semitones, so cross-format conversions scale pitch-envelope depths accordingly. That is a model-wide topic rather than a QPAT defect and is left as is.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
  * Fixed: The amount of a matrix entry modulating the oscillator pitch (the pitch envelope) was read with the wrong offset: a positive amount was read as a negative one (e.g. +50% as -25%) and +100% was dropped entirely.
  * Fixed: The velocity modulation of the volume was written from the amplitude envelope modulation depth instead of the velocity modulation amount. E.g. a source with a velocity amount of 0% was written as +100%.
```
