### PR TITLE
Yamaha YSFC: fix the envelope time quantization, the doubled tuning and duplicated performances

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -34,6 +34,11 @@
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
+* Yamaha YSFC
+  * Fixed: Envelope times were quantized to whole seconds when writing, since the lookup into the time table compared against truncated table entries - every sub-second time became about 0.9 seconds (e.g. a release of 0.3s tripled) in all written amplitude, filter and pitch envelopes.
+  * Fixed: The tuning of a zone was written to both the keybank and the element although the two stack on the device (and when reading), which doubled the detune of every written zone. The element tuning is now left neutral.
+  * Fixed: When reading performances, a performance was added to the result once per part, so a multi-part performance was converted multiple times.
+
 ## 19.1.0
 
 * Many thanks to Douglas Carmichael for plenty of contributions and fixes!

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -34,11 +34,6 @@
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
-* Yamaha YSFC
-  * Fixed: Envelope times were quantized to whole seconds when writing, since the lookup into the time table compared against truncated table entries - every sub-second time became about 0.9 seconds (e.g. a release of 0.3s tripled) in all written amplitude, filter and pitch envelopes.
-  * Fixed: The tuning of a zone was written to both the keybank and the element although the two stack on the device (and when reading), which doubled the detune of every written zone. The element tuning is now left neutral.
-  * Fixed: When reading performances, a performance was added to the result once per part, so a multi-part performance was converted multiple times.
-
 ## 19.1.0
 
 * Many thanks to Douglas Carmichael for plenty of contributions and fixes!

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/yamaha/ysfc/YamahaYsfcCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/yamaha/ysfc/YamahaYsfcCreator.java
@@ -501,12 +501,10 @@ public class YamahaYsfcCreator extends AbstractCreator<YamahaYsfcCreatorUI>
         if (zone.isOneShot ())
             element.setReceiveNoteOff (0);
 
-        // Tuning
-
-        final double tune = zone.getTuning ();
-        final int semitones = (int) Math.round (tune);
-        element.setCoarseTune (semitones + 64);
-        element.setFineTune ((int) Math.round ((tune - semitones) * 100) + 64);
+        // Tuning is already written to the keybank (the reader sums the keybank and element
+        // tuning, therefore it must only be set on one of them), keep the element neutral
+        element.setCoarseTune (64);
+        element.setFineTune (64);
         element.setPitchKeyFollowSensitivity ((int) Math.round (zone.getKeyTracking () * 100));
 
         element.setPan (MathUtils.denormalizeIntegerRange (zone.getPanning (), -63, 63, 64));

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/yamaha/ysfc/YamahaYsfcDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/yamaha/ysfc/YamahaYsfcDetector.java
@@ -340,9 +340,11 @@ public class YamahaYsfcDetector extends AbstractDetector<YamahaYsfcDetectorUI>
                     instrumentSource.setClipKeyLow (part.getNoteLimitLow ());
                     instrumentSource.setClipKeyHigh (part.getNoteLimitHigh ());
                     performanceSource.addInstrument (instrumentSource);
-                    performanceSources.add (performanceSource);
                 }
             }
+
+            if (!performanceSource.getInstruments ().isEmpty ())
+                performanceSources.add (performanceSource);
         }
 
         return performanceSources;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/yamaha/ysfc/file/YamahaYsfcPartElement.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/yamaha/ysfc/file/YamahaYsfcPartElement.java
@@ -2262,7 +2262,7 @@ public class YamahaYsfcPartElement
             return 0;
 
         for (int i = 0; i < 127; i++)
-            if (seconds >= ENVELOPE_TIMES.get (Integer.valueOf (i)).intValue () && seconds < ENVELOPE_TIMES.get (Integer.valueOf (i + 1)).intValue ())
+            if (seconds >= ENVELOPE_TIMES.get (Integer.valueOf (i)).doubleValue () && seconds < ENVELOPE_TIMES.get (Integer.valueOf (i + 1)).doubleValue ())
                 return i;
 
         return 127;


### PR DESCRIPTION
Three defects in the Yamaha YSFC support.

* **Envelope times quantized to ~1-second steps on write.** `convertSecondsToEnvelopeTime` compared the incoming seconds against `.intValue()` of the time table entries. The table entries from 0.2 to 0.99 all truncate to 0, so no sub-second value could ever match its proper slot and everything below ~1s fell onto index 70 (0.9s); longer times snapped to the next whole second. This affected every AEG/FEG/PEG time in every written file. The comparison now uses `.doubleValue()`.
* **Zone tuning written twice.** The creator wrote the full tuning into the keybank (coarse/fine) *and* into the element (coarse/fine). The device applies both, and the performance reader accordingly sums them, so every written zone came back with double its detune. The element is now written neutral (64/64) and the keybank keeps the per-zone tuning, which is also the semantically right place since an element can span several keybanks.
* **Multi-part performances output once per part.** `createPerformancesFromPerformances` added the performance source to the result list inside the parts loop; a 4-part performance was emitted 4 times. The add now happens once after the loop (matching the sibling single-performance method), guarded on the instrument list not being empty.

Verification: converting an SFZ (`tune=30`, `ampeg_decay=0.4`, `ampeg_release=0.3`) to X7U with the old and the new build produces files differing in **exactly 3 bytes**, all in the part element: AEG decay1 index 70 -> 40 (0.9s -> 0.4s), AEG release index 70 -> 10 (0.9s -> 0.3s), element fine tune 94 -> 64 (the +30 cents that stacked on top of the keybank's +30 cents). Reading the file back now yields `tune=30` and the model release 0.3 instead of a doubled detune and a tripled release.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Yamaha YSFC
  * Fixed: Envelope times were quantized to whole seconds when writing, since the lookup into the time table compared against truncated table entries - every sub-second time became about 0.9 seconds (e.g. a release of 0.3s tripled) in all written amplitude, filter and pitch envelopes.
  * Fixed: The tuning of a zone was written to both the keybank and the element although the two stack on the device (and when reading), which doubled the detune of every written zone. The element tuning is now left neutral.
  * Fixed: When reading performances, a performance was added to the result once per part, so a multi-part performance was converted multiple times.
```
