### PR TITLE
Synthstrom Deluge: fix the velocity amount slot, the loop mode of non-one-shots and kit drum tuning

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,6 +31,10 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
+* Synthstrom Deluge
+  * Fixed: The velocity sensitivity of the volume (the velocity to volume patch cable) was read into and written from the amplitude envelope modulation depth instead of the velocity modulation amount - a source without velocity response became fully velocity sensitive and vice versa.
+  * Fixed: An instrument without loops which is not a one-shot was written with the loop mode ONCE, which ignores a note-off on the device (and was read back as a one-shot). Such instruments are now written with CUT, which stops the play-back on a note-off.
+  * Fixed: The transpose and detune of a kit drum were discarded when reading a kit, so pitched kit drums lost their tuning even in a Deluge to Deluge conversion.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -115,6 +119,10 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
+* Synthstrom Deluge
+  * Fixed: The velocity sensitivity of the volume (the velocity to volume patch cable) was read into and written from the amplitude envelope modulation depth instead of the velocity modulation amount - a source without velocity response became fully velocity sensitive and vice versa.
+  * Fixed: An instrument without loops which is not a one-shot was written with the loop mode ONCE, which ignores a note-off on the device (and was read back as a one-shot). Such instruments are now written with CUT, which stops the play-back on a note-off.
+  * Fixed: The transpose and detune of a kit drum were discarded when reading a kit, so pitched kit drums lost their tuning even in a Deluge to Deluge conversion.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,10 +31,6 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
-* Synthstrom Deluge
-  * Fixed: The velocity sensitivity of the volume (the velocity to volume patch cable) was read into and written from the amplitude envelope modulation depth instead of the velocity modulation amount - a source without velocity response became fully velocity sensitive and vice versa.
-  * Fixed: An instrument without loops which is not a one-shot was written with the loop mode ONCE, which ignores a note-off on the device (and was read back as a one-shot). Such instruments are now written with CUT, which stops the play-back on a note-off.
-  * Fixed: The transpose and detune of a kit drum were discarded when reading a kit, so pitched kit drums lost their tuning even in a Deluge to Deluge conversion.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -119,10 +115,6 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
-* Synthstrom Deluge
-  * Fixed: The velocity sensitivity of the volume (the velocity to volume patch cable) was read into and written from the amplitude envelope modulation depth instead of the velocity modulation amount - a source without velocity response became fully velocity sensitive and vice versa.
-  * Fixed: An instrument without loops which is not a one-shot was written with the loop mode ONCE, which ignores a note-off on the device (and was read back as a one-shot). Such instruments are now written with CUT, which stops the play-back on a note-off.
-  * Fixed: The transpose and detune of a kit drum were discarded when reading a kit, so pitched kit drums lost their tuning even in a Deluge to Deluge conversion.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeCreator.java
@@ -657,7 +657,14 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
         // Oscillator 1 with the sample(s)
         final Element osc1 = XMLUtils.addElement (document, soundElement, DelugeTag.OSC1);
         XMLUtils.addTextElement (document, osc1, DelugeTag.TYPE, DelugeTag.TYPE_SAMPLE);
-        XMLUtils.addTextElement (document, osc1, DelugeTag.LOOP_MODE, Integer.toString (anyLoop && !allOneShot ? DelugeTag.LOOP_MODE_LOOP : DelugeTag.LOOP_MODE_ONCE));
+        final int loopMode;
+        if (anyLoop && !allOneShot)
+            loopMode = DelugeTag.LOOP_MODE_LOOP;
+        else
+            // 'ONCE' ignores a note-off, therefore an instrument which is not a one-shot must use
+            // 'CUT' which stops the play-back on a note-off
+            loopMode = allOneShot ? DelugeTag.LOOP_MODE_ONCE : DelugeTag.LOOP_MODE_CUT;
+        XMLUtils.addTextElement (document, osc1, DelugeTag.LOOP_MODE, Integer.toString (loopMode));
         XMLUtils.addTextElement (document, osc1, DelugeTag.REVERSED, reversed ? "1" : "0");
         XMLUtils.addTextElement (document, osc1, DelugeTag.TIME_STRETCH_ENABLE, "0");
         XMLUtils.addTextElement (document, osc1, DelugeTag.TIME_STRETCH_AMOUNT, "0");
@@ -797,7 +804,7 @@ public class DelugeCreator extends AbstractWavCreator<DelugeCreatorUI>
         // sounds)
         final Element patchCables = XMLUtils.addElement (document, defaultParams, DelugeTag.PATCH_CABLES);
 
-        final int ampModAmount = (int) DelugeValues.modulationDepthToPatchAmount (amplitudeEnvelopeModulator.getDepth ());
+        final int ampModAmount = (int) DelugeValues.modulationDepthToPatchAmount (firstZone.getAmplitudeVelocityModulator ().getDepth ());
         createPatchCable (document, patchCables, DelugeTag.SOURCE_VELOCITY, DelugeTag.DESTINATION_VOLUME, ampModAmount);
 
         // Amplitude keyboard tracking is the "note" source routed to the volume. There is no

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/synthstrom/DelugeDetector.java
@@ -413,7 +413,12 @@ public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
         final double rootNote = fixedRootNote >= 0 ? fixedRootNote : DelugeValues.rootNoteFromTranspose (transpose, cents);
         final int keyRoot = (int) Math.round (rootNote);
         zone.setKeyRoot (keyRoot);
-        zone.setTuning (rootNote - keyRoot);
+        // A kit drum plays on its own pad, so its oscillator transpose is not a keyboard mapping
+        // but a pitch offset relative to the natural pitch
+        if (fixedRootNote >= 0)
+            zone.setTuning (DelugeValues.rootNoteFromTranspose (transpose, cents) - DelugeValues.REFERENCE_NOTE);
+        else
+            zone.setTuning (rootNote - keyRoot);
 
         // A Deluge oscillator in STRETCH (time-stretch) mode sustains by looping its sample through
         // the granular time-stretch engine. ConvertWithMoss cannot reproduce the time-stretch, but
@@ -569,7 +574,7 @@ public class DelugeDetector extends AbstractDetector<MetadataSettingsUI>
             final IEnvelopeModulator amplitudeModulator = zone.getAmplitudeEnvelopeModulator ();
             if (envelope1.isPresent ())
                 readEnvelope (envelope1.get (), amplitudeModulator.getSource ());
-            amplitudeModulator.setDepth (amplitudeVelocityDepth);
+            zone.getAmplitudeVelocityModulator ().setDepth (amplitudeVelocityDepth);
             zone.setAmplitudeKeyTracking (amplitudeKeyTracking);
 
             // A fresh filter is read per zone so the zones do not share mutable modulators.


### PR DESCRIPTION
Three defects in the Synthstrom Deluge support, verified with an SFZ -> Deluge kit -> SFZ round trip of a two-drum kit (`tune=30`/`tune=-40`, `amp_veltrack=0`, no loops).

* **Velocity sensitivity plumbed through the wrong modulator in both directions.** The detector stored the velocity->volume patch cable amount into the amplitude *envelope* modulation depth and the creator wrote the cable from that same slot (which defaults to 1.0), instead of the zone's *velocity* modulation amount. A source with `amp_veltrack=0` was written as fully velocity sensitive, and reading a Deluge sound put the value where no destination looks for it. Both sides now use the velocity modulator; sources without an explicit setting keep full sensitivity, since the model defaults that slot to 1.0.
* **Non-looped instruments written as ONCE.** The loop mode choice was binary: loop or ONCE. ONCE ignores a note-off on the device, so every ordinary non-looped instrument (piano, strings...) played to the sample end regardless of the release. Such sounds are now written as CUT, which stops on note-off; genuine one-shots still get ONCE. In the round trip the written `<loopMode>` changes from 1 to 0 and the read-back changes from `loop_mode=one_shot` to `loop_mode=no_loop`.
* **Kit drum tuning discarded on read.** A kit drum uses its pad as the root note, and the reader threw the oscillator transpose/cents away entirely - the kit written in this very round trip (`<cents>-30</cents>`, `<cents>40</cents>`) came back with no tuning at all. The transpose is now decoded as a pitch offset relative to the natural pitch (the exact inverse of what the creator writes), so `tune=30`/`tune=-40` survive the round trip.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Synthstrom Deluge
  * Fixed: The velocity sensitivity of the volume (the velocity to volume patch cable) was read into and written from the amplitude envelope modulation depth instead of the velocity modulation amount - a source without velocity response became fully velocity sensitive and vice versa.
  * Fixed: An instrument without loops which is not a one-shot was written with the loop mode ONCE, which ignores a note-off on the device (and was read back as a one-shot). Such instruments are now written with CUT, which stops the play-back on a note-off.
  * Fixed: The transpose and detune of a kit drum were discarded when reading a kit, so pitched kit drums lost their tuning even in a Deluge to Deluge conversion.
```
