### PR TITLE
Renoise: read and write the pitch envelope depth via the pitch modulation range

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,7 +31,6 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
-  * Fixed: The depth of a pitch envelope was read as the model maximum of 120 semitones instead of the pitch modulation range of the modulation set (12 semitones by default) and was dropped entirely when writing - a 2 semitone pitch envelope e.g. inflated to 120 semitones in a round trip. The depth is now read from and written as the pitch modulation range of the mixer device, which also keeps the pitch LFO consistent.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,6 +31,7 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
+  * Fixed: The depth of a pitch envelope was read as the model maximum of 120 semitones instead of the pitch modulation range of the modulation set (12 semitones by default) and was dropped entirely when writing - a 2 semitone pitch envelope e.g. inflated to 120 semitones in a round trip. The depth is now read from and written as the pitch modulation range of the mixer device, which also keeps the pitch LFO consistent.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseCreator.java
@@ -314,9 +314,18 @@ public class RenoiseCreator extends AbstractCreator<EmptySettingsUI>
                 cutoffEnvelope = cutoffModulator.getSource ();
         }
 
+        // The depth of the pitch envelope can only be expressed via the pitch modulation range
+        // of the mixer device (the bipolar AHDSR device has no amount parameter), which also
+        // scales the pitch LFO
+        final IEnvelopeModulator pitchModulator = zone.getPitchEnvelopeModulator ();
+        final double pitchDepth = pitchModulator.getDepth ();
+        int pitchModulationRange = RenoiseValueConverter.PITCH_MODULATION_RANGE;
+        if (pitchDepth != 0)
+            pitchModulationRange = (int) Math.clamp (Math.round (Math.abs (pitchDepth) * IEnvelope.MAX_ENVELOPE_DEPTH / 100.0), 1, 96);
+
         // The mixer device holds the base input values and is required for the filter view to be
         // built; without it Renoise crashes when a filter is active
-        createMixerDevice (document, devicesElement, cutoff, resonance);
+        createMixerDevice (document, devicesElement, cutoff, resonance, pitchModulationRange);
 
         // The amplitude envelope is always present
         createAhdsrDevice (document, devicesElement, RenoiseTag.TARGET_VOLUME, RenoiseTag.OP_MULTIPLY, false, zone.getAmplitudeEnvelopeModulator ().getSource ());
@@ -324,13 +333,12 @@ public class RenoiseCreator extends AbstractCreator<EmptySettingsUI>
         if (cutoffEnvelope != null)
             createAhdsrDevice (document, devicesElement, RenoiseTag.TARGET_CUTOFF, RenoiseTag.OP_ADD, false, cutoffEnvelope);
 
-        final IEnvelopeModulator pitchModulator = zone.getPitchEnvelopeModulator ();
-        if (pitchModulator.getDepth () != 0)
+        if (pitchDepth != 0)
             createAhdsrDevice (document, devicesElement, RenoiseTag.TARGET_PITCH, RenoiseTag.OP_ADD, true, pitchModulator.getSource ());
 
         final ILfoModulator pitchLfoModulator = zone.getPitchLfoModulator ();
         if (pitchLfoModulator.getDepth () != 0 && pitchLfoModulator.getSource ().isSet ())
-            createLfoDevice (document, devicesElement, RenoiseTag.TARGET_PITCH, RenoiseValueConverter.lfoDepthToAmplitude (pitchLfoModulator.getDepth ()), pitchLfoModulator);
+            createLfoDevice (document, devicesElement, RenoiseTag.TARGET_PITCH, RenoiseValueConverter.lfoDepthToAmplitude (pitchLfoModulator.getDepth (), pitchModulationRange), pitchLfoModulator);
 
         final ILfoModulator amplitudeLfoModulator = zone.getAmplitudeLfoModulator ();
         if (amplitudeLfoModulator.getDepth () != 0 && amplitudeLfoModulator.getSource ().isSet ())
@@ -391,8 +399,10 @@ public class RenoiseCreator extends AbstractCreator<EmptySettingsUI>
      * @param devicesElement The devices element to which to add the device
      * @param cutoff The base cutoff value (0..127)
      * @param resonance The base resonance value (0..127)
+     * @param pitchModulationRange The pitch modulation range in semitones, which scales all
+     *            modulation devices targeting the pitch
      */
-    private static void createMixerDevice (final Document document, final Element devicesElement, final double cutoff, final double resonance)
+    private static void createMixerDevice (final Document document, final Element devicesElement, final double cutoff, final double resonance, final int pitchModulationRange)
     {
         final Element deviceElement = XMLUtils.addElement (document, devicesElement, RenoiseTag.MIXER_DEVICE);
         deviceElement.setAttribute (RenoiseTag.ATTR_TYPE, RenoiseTag.MIXER_DEVICE);
@@ -401,7 +411,7 @@ public class RenoiseCreator extends AbstractCreator<EmptySettingsUI>
         addParameter (document, deviceElement, RenoiseTag.VOLUME, 1.0);
         addParameter (document, deviceElement, RenoiseTag.PANNING, 0.0);
         addParameter (document, deviceElement, RenoiseTag.PITCH, 0.0);
-        XMLUtils.addTextElement (document, deviceElement, RenoiseTag.PITCH_MODULATION_RANGE, Integer.toString (RenoiseValueConverter.PITCH_MODULATION_RANGE));
+        XMLUtils.addTextElement (document, deviceElement, RenoiseTag.PITCH_MODULATION_RANGE, Integer.toString (pitchModulationRange));
         addParameter (document, deviceElement, RenoiseTag.CUTOFF, cutoff);
         addParameter (document, deviceElement, RenoiseTag.RESONANCE, resonance);
         addParameter (document, deviceElement, RenoiseTag.DRIVE, 0.0);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseDetector.java
@@ -286,7 +286,9 @@ public class RenoiseDetector extends AbstractDetector<MetadataSettingsUI>
             if (modulationSet.pitchEnvelope != null)
             {
                 zone.getPitchEnvelopeModulator ().setSource (modulationSet.pitchEnvelope);
-                zone.getPitchEnvelopeModulator ().setDepth (1.0);
+                // The full swing of the bipolar pitch AHDSR device is the pitch modulation range
+                // of the mixer device
+                zone.getPitchEnvelopeModulator ().setDepth (modulationSet.pitchModulationRange * 100.0 / IEnvelope.MAX_ENVELOPE_DEPTH);
             }
             if (modulationSet.pitchLfo != null && modulationSet.pitchLfoDepth > 0)
             {
@@ -460,6 +462,7 @@ public class RenoiseDetector extends AbstractDetector<MetadataSettingsUI>
                     pitchModulationRange = XMLUtils.getChildElementIntegerContent (mixerElement, RenoiseTag.PITCH_MODULATION_RANGE, RenoiseValueConverter.PITCH_MODULATION_RANGE);
                 }
 
+                modulationSet.pitchModulationRange = pitchModulationRange;
                 readPitchLfo (devicesElement, modulationSet, pitchModulationRange);
                 readVolumeLfo (devicesElement, modulationSet);
             }
@@ -745,6 +748,7 @@ public class RenoiseDetector extends AbstractDetector<MetadataSettingsUI>
 
         IEnvelope                   volumeEnvelope;
         IEnvelope                   pitchEnvelope;
+        int                         pitchModulationRange = RenoiseValueConverter.PITCH_MODULATION_RANGE;
         IEnvelope                   cutoffEnvelope;
         ILfo                        pitchLfo;
         double                      pitchLfoDepth;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseValueConverter.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseValueConverter.java
@@ -323,12 +323,13 @@ public final class RenoiseValueConverter
      * Renoise LFO amplitude, which is relative to the pitch modulation range of the mixer device.
      *
      * @param depth The modulation depth [-1..1]
+     * @param pitchModulationRange The pitch modulation range of the mixer device in semitones
      * @return The LFO amplitude [0..1]
      */
-    public static double lfoDepthToAmplitude (final double depth)
+    public static double lfoDepthToAmplitude (final double depth, final int pitchModulationRange)
     {
         final double semitones = Math.abs (depth) * IEnvelope.MAX_ENVELOPE_DEPTH / 100.0;
-        return Math.clamp (semitones / PITCH_MODULATION_RANGE, 0, 1);
+        return Math.clamp (semitones / pitchModulationRange, 0, 1);
     }
 
 


### PR DESCRIPTION
The depth of a pitch envelope was hard-coded to `1.0` on read - which in the model means the full 120 semitones - although the actual swing of the bipolar pitch AHDSR device is the *pitch modulation range* of the mixer device (12 semitones by default). On write the model depth was discarded entirely and the range always written as 12. A pitch envelope of 2 semitones therefore came back as 120 semitones from a round trip, 60x too deep, and any destination writing the pitch envelope (QPAT, SF2, SFZ...) received the inflated value.

Since the AHDSR device has no amount parameter, the pitch modulation range *is* the depth control:

* Reading derives the depth from the modulation set's range: `range / 120`.
* Writing chooses the range from the model depth (`|depth| * 120`, clamped to 1..96 semitones) instead of the constant 12.
* The range scales every modulation device targeting the pitch in the same set, so the pitch LFO amplitude conversion now uses the chosen range as well, which keeps vibrato calibrated when both are present.

Round trip of an SFZ with `pitcheg_depth=2400`: the depth read back was **12000** cents before and is 2400 now; the written instrument carries `<PitchModulationRange>24</PitchModulationRange>`.

One inherent limitation, unchanged by this PR: the range is positive, so a negative (inverted) pitch envelope depth writes its magnitude - the sign cannot be expressed in the range field.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
  * Fixed: The depth of a pitch envelope was read as the model maximum of 120 semitones instead of the pitch modulation range of the modulation set (12 semitones by default) and was dropped entirely when writing - a 2 semitone pitch envelope e.g. inflated to 120 semitones in a round trip. The depth is now read from and written as the pitch modulation range of the mixer device, which also keeps the pitch LFO consistent.
```
