### PR TITLE
TX16Wx: fix the wave ID scope and the pitch envelope depth scale

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,9 +31,6 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
-* TX16Wx
-  * Fixed: The wave IDs of a written program restarted at 0 for every group, although they must be unique across the program - in a program with several groups all regions resolved to the waves of the last group when read (also in the TX16Wx plug-in itself). Additionally the reader now creates an own zone object per region, since several regions may reference the same wave; before, such regions shared one object and overwrote each other's key and velocity ranges.
-  * Fixed: The depth of a pitch envelope was written in cents of the full model depth (12000 cents) but read as a fraction of 4800 cents, inflating the depth 2.5 times in a round trip.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -118,9 +115,6 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
-* TX16Wx
-  * Fixed: The wave IDs of a written program restarted at 0 for every group, although they must be unique across the program - in a program with several groups all regions resolved to the waves of the last group when read (also in the TX16Wx plug-in itself). Additionally the reader now creates an own zone object per region, since several regions may reference the same wave; before, such regions shared one object and overwrote each other's key and velocity ranges.
-  * Fixed: The depth of a pitch envelope was written in cents of the full model depth (12000 cents) but read as a fraction of 4800 cents, inflating the depth 2.5 times in a round trip.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,6 +31,9 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
+* TX16Wx
+  * Fixed: The wave IDs of a written program restarted at 0 for every group, although they must be unique across the program - in a program with several groups all regions resolved to the waves of the last group when read (also in the TX16Wx plug-in itself). Additionally the reader now creates an own zone object per region, since several regions may reference the same wave; before, such regions shared one object and overwrote each other's key and velocity ranges.
+  * Fixed: The depth of a pitch envelope was written in cents of the full model depth (12000 cents) but read as a fraction of 4800 cents, inflating the depth 2.5 times in a round trip.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -115,6 +118,9 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
+* TX16Wx
+  * Fixed: The wave IDs of a written program restarted at 0 for every group, although they must be unique across the program - in a program with several groups all regions resolved to the waves of the last group when read (also in the TX16Wx plug-in itself). Additionally the reader now creates an own zone object per region, since several regions may reference the same wave; before, such regions shared one object and overwrote each other's key and velocity ranges.
+  * Fixed: The depth of a pitch envelope was written in cents of the full model depth (12000 cents) but read as a fraction of 4800 cents, inflating the depth 2.5 times in a round trip.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxCreator.java
@@ -384,6 +384,8 @@ public class TX16WxCreator extends AbstractWavCreator<WavChunkSettingsUI>
         final List<IGroup> groups = multisampleSource.getNonEmptyGroups (true);
         final List<Element> groupElements = new ArrayList<> ();
         final List<Element> soundshapeElements = new ArrayList<> ();
+        // The wave IDs must be unique across the whole program and not only within one group
+        int waveID = 0;
         for (final IGroup group: groups)
         {
             final Element groupElement = document.createElement (TX16WxTag.GROUP);
@@ -411,7 +413,10 @@ public class TX16WxCreator extends AbstractWavCreator<WavChunkSettingsUI>
             groupElement.setAttribute (TX16WxTag.OUTPUT, "--");
 
             for (int i = 0; i < zones.size (); i++)
-                createSample (document, folderName, programElement, groupElement, zones.get (i), i);
+            {
+                createSample (document, folderName, programElement, groupElement, zones.get (i), waveID);
+                waveID++;
+            }
 
             addGroupModulationAttributes (document, soundshapeElement, zones);
         }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/tx16wx/TX16WxDetector.java
@@ -45,6 +45,7 @@ import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultEnvelope;
 import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultEnvelopeModulator;
 import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultFilter;
 import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultGroup;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleZone;
 import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleLoop;
 import de.mossgrabers.convertwithmoss.core.settings.MetadataWithSearchHeightSettingsUI;
 import de.mossgrabers.convertwithmoss.core.utils.NoteParser;
@@ -462,9 +463,15 @@ public class TX16WxDetector extends AbstractDetector<MetadataWithSearchHeightSet
 
         for (final Element regionElement: XMLUtils.getChildElementsByName (groupElement, TX16WxTag.REGION, false))
         {
-            final ISampleZone zone = sampleMap.get (regionElement.getAttribute (TX16WxTag.SAMPLE));
-            if (zone != null)
+            final ISampleZone waveZone = sampleMap.get (regionElement.getAttribute (TX16WxTag.SAMPLE));
+            if (waveZone != null)
             {
+                // Several regions (also across groups) may reference the same wave, therefore
+                // every region gets its own zone object
+                final ISampleZone zone = new DefaultSampleZone (waveZone);
+                final Optional<ISampleData> sampleData = waveZone.getSampleData ();
+                if (sampleData.isPresent ())
+                    zone.setSampleData (sampleData.get ());
                 this.parseZone (zone, regionElement, groupVolumeOffset, groupPanningOffset, groupTuningOffset);
                 zone.setOneShot (isOneShot);
                 group.addSampleZone (zone);
@@ -700,7 +707,7 @@ public class TX16WxDetector extends AbstractDetector<MetadataWithSearchHeightSet
                 if (modAmoundAsCent.isPresent ())
                 {
                     final IEnvelopeModulator pitchModulator = new DefaultEnvelopeModulator (0);
-                    final double amount = modAmoundAsCent.get ().intValue () / 4800.0;
+                    final double amount = modAmoundAsCent.get ().intValue () / (double) IEnvelope.MAX_ENVELOPE_DEPTH;
                     pitchModulator.setDepth (Math.clamp (amount, -1, 1));
 
                     final Optional<IEnvelope> pitchEnvelope = parsePitchEnvelope (soundShapeElement, modulator.isSource ("ENV1") ? TX16WxTag.ENVELOPE_1 : TX16WxTag.ENVELOPE_2);


### PR DESCRIPTION
Two defects in the TX16Wx support, verified with an SFZ -> TX16Wx -> SFZ round trip of a two-group program (soft layer 1..64 with one sample, hard layer 65..127 with another, pitch envelope of 2400 cents on the soft group).

* **Wave IDs restart per group and zones are shared between regions.** The creator numbered `<tx:wave>` IDs per group (0, 1, ... in each), although the `<tx:region>` `sample` reference resolves against the whole program - with more than one group every ID collided and all regions resolved to the last group's waves. On top of that, the detector kept a single zone object per wave and handed the *same object* to every region referencing it, so their key/velocity ranges and modulators overwrote each other. The creator now numbers waves across the program, and the detector creates a fresh zone object per region (the same pattern the YSFC detector uses for shared waveforms), which also fixes reading genuine TX16Wx programs where several regions play one wave.
* **Pitch envelope depth scale mismatch.** The creator writes the modulation amount in cents of the full model depth (`depth * 12000` with a `Ct` suffix); the reader divided by 4800, inflating the depth 2.5x on every read.

Round trip before: **both** layers came back playing the hard sample with `lovel=65` (the soft layer's audio and range were gone) and the pitch envelope read 6000 cents. After: the two layers keep their own samples and ranges, and the depth stays 2400.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* TX16Wx
  * Fixed: The wave IDs of a written program restarted at 0 for every group, although they must be unique across the program - in a program with several groups all regions resolved to the waves of the last group when read (also in the TX16Wx plug-in itself). Additionally the reader now creates an own zone object per region, since several regions may reference the same wave; before, such regions shared one object and overwrote each other's key and velocity ranges.
  * Fixed: The depth of a pitch envelope was written in cents of the full model depth (12000 cents) but read as a fraction of 4800 cents, inflating the depth 2.5 times in a round trip.
```
