### PR TITLE
Akai legacy formats: fix signed reads, tuning and volume laws, bend range and 12 bit unpacking

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,6 +16,19 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
+* Akai AKP/AKM
+  * Fixed: The pitch bend range was passed as semitones into the model's cents field, so the bend wheel effectively did nothing on converted programs.
+  * Fixed: The volume of a multi part was multiplied onto the dB gain of the zones (a no-op for 0dB zones) instead of being added as a dB offset, and the part panning was scaled twice as wide as the field allows.
+* Akai MPC2000/3000
+  * Fixed: The tune of a program pad and of a SND sample were read unsigned - every negatively tuned pad of e.g. the factory library CD came out drastically sharp (a -0.05 semitone pad read as more than +600 semitones and was clamped to +12).
+* Akai MPC60
+  * Fixed: The 12 bit sample data was unpacked with the low nibble at 1/16 of its weight and the result byte-swapped, which reduced the audio to roughly 8 bit quality with a signal-correlated error. The 12 bits are now left-justified as in the reference implementation.
+* Akai S900/S950
+  * Fixed: The fractional part of the nominal pitch was applied with an inverted sign: a sample recorded e.g. a quarter tone sharp was played another quarter tone sharp instead of being corrected. Also the loudness offset was read unsigned, so any attenuation became a boost.
+* Akai S1000/S3000
+  * Fixed: The pitch bend range was passed as semitones into the model's cents field - the bend wheel effectively did nothing.
+  * Fixed: The program volume (a 0..1 value) was written directly as the dB gain of every zone, overwriting the per-layer loudness set before - the velocity-layer balance of every program was discarded.
+  * Fixed: The fraction byte of the keygroup and keygroup-sample fixed point tunings was treated as signed, so negative fine tunes came out about a semitone flat (e.g. -0.05 semitones read as -1.05). The sample header tuning in literal cents is no longer rescaled.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,19 +16,6 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
-* Akai AKP/AKM
-  * Fixed: The pitch bend range was passed as semitones into the model's cents field, so the bend wheel effectively did nothing on converted programs.
-  * Fixed: The volume of a multi part was multiplied onto the dB gain of the zones (a no-op for 0dB zones) instead of being added as a dB offset, and the part panning was scaled twice as wide as the field allows.
-* Akai MPC2000/3000
-  * Fixed: The tune of a program pad and of a SND sample were read unsigned - every negatively tuned pad of e.g. the factory library CD came out drastically sharp (a -0.05 semitone pad read as more than +600 semitones and was clamped to +12).
-* Akai MPC60
-  * Fixed: The 12 bit sample data was unpacked with the low nibble at 1/16 of its weight and the result byte-swapped, which reduced the audio to roughly 8 bit quality with a signal-correlated error. The 12 bits are now left-justified as in the reference implementation.
-* Akai S900/S950
-  * Fixed: The fractional part of the nominal pitch was applied with an inverted sign: a sample recorded e.g. a quarter tone sharp was played another quarter tone sharp instead of being corrected. Also the loudness offset was read unsigned, so any attenuation became a boost.
-* Akai S1000/S3000
-  * Fixed: The pitch bend range was passed as semitones into the model's cents field - the bend wheel effectively did nothing.
-  * Fixed: The program volume (a 0..1 value) was written directly as the dB gain of every zone, overwriting the per-layer loudness set before - the velocity-layer balance of every program was discarded.
-  * Fixed: The fraction byte of the keygroup and keygroup-sample fixed point tunings was treated as signed, so negative fine tunes came out about a semitone flat (e.g. -0.05 semitones read as -1.05). The sample header tuning in literal cents is no longer rescaled.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/akp/AkpDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/akp/AkpDetector.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import de.mossgrabers.convertwithmoss.core.algorithm.MathUtils;
 import de.mossgrabers.convertwithmoss.core.IInstrumentSource;
 import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
 import de.mossgrabers.convertwithmoss.core.INotifier;
@@ -203,13 +204,13 @@ public class AkpDetector extends AbstractDetector<MetadataSettingsUI>
         if (groups.isEmpty ())
             return Optional.empty ();
 
-        final double panningFactor = part.getPanning () / 50.0 * 2.0;
-        final double volumeFactor = part.getVolume () / 100.0;
-        if (panningFactor != 0 || volumeFactor != 1)
+        final double panningOffset = part.getPanning () / 50.0;
+        final double volumeOffset = MathUtils.valueToDb (part.getVolume () / 100.0);
+        if (panningOffset != 0 || volumeOffset != 0)
             for (final ISampleZone zone: groups.get (0).getSampleZones ())
             {
-                zone.setPanning (Math.clamp (zone.getPanning () + panningFactor, -1.0, 1.0));
-                zone.setGain (zone.getGain () * volumeFactor);
+                zone.setPanning (Math.clamp (zone.getPanning () + panningOffset, -1.0, 1.0));
+                zone.setGain (zone.getGain () + volumeOffset);
             }
 
         return Optional.of (instrumentSource);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/akp/riff/AkpKeygroup.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/akp/riff/AkpKeygroup.java
@@ -255,8 +255,8 @@ public class AkpKeygroup extends AbstractSpecificRIFFChunk
                     pitchModulator.setDepth ((pitchMod1UsesAuxEnv ? pitchMod1 : pitchMod2) / 100.0);
                     pitchModulator.setSource (auxEnvelope);
                 }
-                sampleZone.setBendUp (pitchbendUp);
-                sampleZone.setBendDown (-pitchbendDown);
+                sampleZone.setBendUp (pitchbendUp * 100);
+                sampleZone.setBendDown (-pitchbendDown * 100);
             }
 
             zonePosition += sizeOfZone + 8;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc2000/AkaiMPC2000Pad.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc2000/AkaiMPC2000Pad.java
@@ -83,7 +83,7 @@ public class AkaiMPC2000Pad
         this.voiceOverlap = input.read ();
         this.polyNote1 = input.read ();
         this.polyNote2 = input.read ();
-        this.tune = StreamUtils.readUnsigned16 (input, false);
+        this.tune = StreamUtils.readSigned16 (input, false);
         this.attack = input.read ();
         this.decay = input.read ();
         this.decayMode = input.read ();

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc2000/AkaiMPC2000Sound.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc2000/AkaiMPC2000Sound.java
@@ -122,7 +122,7 @@ public class AkaiMPC2000Sound
         // Parameters (4 bytes)
         this.pad = buffer.get () & 0xFF;
         this.level = buffer.get () & 0xFF;
-        this.tune = buffer.get () & 0xFF;
+        this.tune = buffer.get ();
         // 0=Mono 1=Stereo
         this.channels = (buffer.get () & 0xFF) + 1;
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc60/AkaiMPC60Set.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/mpc60/AkaiMPC60Set.java
@@ -223,17 +223,12 @@ public class AkaiMPC60Set
             final int b1 = input.read () & 0xFF;
             final int b2 = input.read () & 0xFF;
 
-            // Extract two 12-bit samples
-            sampleData[outIndex++] = swapBytes ((short) (b0 | (b2 & 0x0F) << 8));
-            sampleData[outIndex++] = swapBytes ((short) (b1 | (b2 & 0xF0) << 4));
+            // Extract two 12-bit samples - the full byte holds the upper 8 bits, the nibble the
+            // lower 4 bits; the 12 bits are left-justified in the 16 bit result
+            sampleData[outIndex++] = (short) (b0 << 8 | (b2 & 0x0F) << 4);
+            sampleData[outIndex++] = (short) (b1 << 8 | (b2 & 0xF0));
         }
 
         return sampleData;
-    }
-
-
-    private static short swapBytes (final short value)
-    {
-        return (short) ((value & 0xFF) << 8 | value >> 8 & 0xFF);
     }
 }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s1000/AkaiS1000ProgramConverter.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s1000/AkaiS1000ProgramConverter.java
@@ -7,6 +7,7 @@ package de.mossgrabers.convertwithmoss.format.akai.s1000;
 import java.util.List;
 import java.util.Optional;
 
+import de.mossgrabers.convertwithmoss.core.algorithm.MathUtils;
 import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
 import de.mossgrabers.convertwithmoss.core.INotifier;
 import de.mossgrabers.convertwithmoss.core.model.IAudioMetadata;
@@ -65,16 +66,16 @@ public class AkaiS1000ProgramConverter
 
         // Set global values
         final int pitchBendRange = program.getBendToPitch () & 0xFF;
-        final double gain = (program.getVolume () & 0xFF) / 99.0;
+        final double gain = MathUtils.valueToDb ((program.getVolume () & 0xFF) / 99.0);
         final double velocityToVolume = Math.clamp (program.getVelocityToVolume () / 50.0, -1.0, 1.0);
         // The native range of the key to volume intensity is [-50..50] which maps to the model
         // range of [-1..1]
         final double keyToVolume = Math.clamp (program.getKeyToVolume () / 50.0, -1.0, 1.0);
         for (final ISampleZone zone: group.getSampleZones ())
         {
-            zone.setBendUp (pitchBendRange);
-            zone.setBendDown (-pitchBendRange);
-            zone.setGain (gain);
+            zone.setBendUp (pitchBendRange * 100);
+            zone.setBendDown (-pitchBendRange * 100);
+            zone.setGain (zone.getGain () + gain);
             zone.getAmplitudeVelocityModulator ().setDepth (velocityToVolume);
             zone.setAmplitudeKeyTracking (keyToVolume);
         }
@@ -213,7 +214,8 @@ public class AkaiS1000ProgramConverter
                 // Pitch
                 sampleZone.setKeyTracking (sampleKeyTracking[i] ? 1 : 0);
                 final double keygroupSampleTuning = calculateTuning (keygroupSample.getTuneSemitones (), keygroupSample.getTuneCents ());
-                final double sampleTuning = calculateTuning (sample.getTuneSemitones (), sample.getTuneCents ());
+                // The sample header stores literal cents in contrast to the fixed point values
+                final double sampleTuning = sample.getTuneSemitones () + sample.getTuneCents () / 100.0;
                 sampleZone.setTuning (keygroupTuning + keygroupSampleTuning + sampleTuning);
                 if (pitchModulation != 0)
                 {
@@ -240,20 +242,17 @@ public class AkaiS1000ProgramConverter
 
 
     /**
-     * Combine the semi-tone and fine tuning.
+     * Combine the semi-tone and fine tuning of a fixed point tune value. The keygroup and
+     * keygroup-sample tunings are 16 bit fixed point values: a signed semi-tone byte and an
+     * unsigned fraction byte in 1/256 semi-tone steps.
      *
      * @param tuneSemitones The semi-tones in the range of [-50..50]
-     * @param tuneCents The tuning by in the range of [-128..127], needs to be scaled to [-50..+50]
-     * @return The semi-tones with cents as fractions
+     * @param tuneFraction The fraction of a semi-tone in 1/256 steps
+     * @return The semi-tones with the fraction
      */
-    private static double calculateTuning (final int tuneSemitones, final int tuneCents)
+    private static double calculateTuning (final int tuneSemitones, final int tuneFraction)
     {
-        double cents = 0;
-        if (tuneCents < 0)
-            cents = tuneCents / 128.0 * 0.5;
-        else if (tuneCents > 0)
-            cents = tuneCents / 127.0 * 0.5;
-        return tuneSemitones + cents;
+        return tuneSemitones + (tuneFraction & 0xFF) / 256.0;
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s900/AkaiS900Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s900/AkaiS900Detector.java
@@ -148,7 +148,9 @@ public class AkaiS900Detector extends AbstractDetector<MetadataSettingsUI>
         final double nominalPitch = sample.getNominalPitch () / 16.0;
         final int rootNote = (int) Math.round (nominalPitch);
         sampleZone.setKeyRoot (rootNote);
-        sampleZone.setTuning (nominalPitch - rootNote);
+        // The nominal pitch is the recorded pitch of the sample. A sample which was recorded
+        // e.g. a quarter tone sharp must be played back a quarter tone lower to be in tune
+        sampleZone.setTuning (rootNote - nominalPitch);
         sampleZone.setKeyTracking ((keygroup.getFlags () & 0x01) > 0 ? 0 : 1.0);
 
         // Mixing

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s900/AkaiS900Sample.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s900/AkaiS900Sample.java
@@ -51,7 +51,7 @@ public class AkaiS900Sample
         this.sampleLength = StreamUtils.readUnsigned32 (input, false);
         this.sampleRate = StreamUtils.readUnsigned16 (input, false);
         this.nominalPitch = StreamUtils.readUnsigned16 (input, false);
-        this.loudness = StreamUtils.readUnsigned16 (input, false);
+        this.loudness = StreamUtils.readSigned16 (input, false);
         this.playbackMode = (char) input.read ();
         input.skipNBytes (1);
         this.end = StreamUtils.readUnsigned32 (input, false);


### PR DESCRIPTION
Eight defects across the legacy Akai formats (MPC2000/3000, MPC60, S900/S950, S1000/S3000, S5000/S6000 AKP/AKM). Verified against real factory media: the MPC2000XL library CD (164 programs), the S900 SL5000 factory floppy set (71 programs) and the Akai CD-ROM Sound Library Volume 1 for S1000/S3000 (1095 programs).

* **MPC2000/3000: pad and SND tune read unsigned.** `AkaiMPC2000Pad` read the 16-bit tune with `readUnsigned16`, `AkaiMPC2000Sound` masked its tune byte with `& 0xFF`. On the factory CD, every negatively tuned pad decoded as `tune=65516...65531` **cents** before (655 semitones, then clamped) and reads -5/-10/-20 cents now - 111 of the MPC3000 disk zones alone were affected.
* **S1000/S3000: bend range written as semitones into the cents field.** All 8719 zones of the CD read `bend_up=2/7/12` before (a dead bend wheel) and `200/700/1200` cents now.
* **S1000/S3000: program volume overwrote the layer loudness.** The 0..1 program volume was passed directly to `setGain` *after* the per-layer loudness had been set - every zone of every program read a uniform ~+0.8 "dB" and the velocity-layer balance was gone. It is now converted to dB and added as an offset.
* **S1000/S3000: fixed-point tune fraction treated as signed.** The keygroup tunings are s8.8 fixed point: signed semitone byte + unsigned 1/256 fraction byte. Reading the fraction signed sent negative fine tunes a semitone flat: ~540 zones on the CD read -1.02..-1.05 semitones before where the real values are -2..-5 *cents*. The sample-header tune (literal cents by spec) is no longer run through the fraction rescale either.
* **AKP/AKM: bend range same unit defect** (semitones into the cents field), and **multi-part volume/pan laws**: the part volume was *multiplied* onto the zone dB gain - a no-op for 0dB zones, so e.g. a volume-20 part stayed at full volume - and the part panning was scaled to twice the +-1 range. The volume is now a dB offset (`valueToDb`), the panning scaled like every other +-50 Akai pan field.
* **S900/S950: fractional nominal pitch sign inverted.** A sample recorded a quarter tone sharp must be corrected *down*; the detector applied the deviation upward, doubling the error. On the SL5000 factory set the fine tunes flip sign accordingly (e.g. +13 -> -12 cents on 10 zones). The loudness offset was also read unsigned (documented signed), turning any attenuation into a boost.
* **MPC60: 12-bit unpacking at 1/16 weight.** The two packed 12-bit samples per 3 bytes were assembled with the full byte in the low bits plus a byte swap, leaving the low nibble at 1/16 of its weight - roughly 8-bit audio with a signal-correlated error. The bits are now left-justified (full byte high, nibble at bits 7..4), matching the mpc2emu reference implementation.

One open question, unchanged: the MPC2000 pad tune is decoded as cents (/100, per its getter contract). The device UI range of -120..+120 suggests it might be tenths of a semitone; settling that needs a program with a known on-device tune value, and the sign fix is correct either way.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Akai AKP/AKM
  * Fixed: The pitch bend range was passed as semitones into the model's cents field, so the bend wheel effectively did nothing on converted programs.
  * Fixed: The volume of a multi part was multiplied onto the dB gain of the zones (a no-op for 0dB zones) instead of being added as a dB offset, and the part panning was scaled twice as wide as the field allows.
* Akai MPC2000/3000
  * Fixed: The tune of a program pad and of a SND sample were read unsigned - every negatively tuned pad of e.g. the factory library CD came out drastically sharp (a -0.05 semitone pad read as more than +600 semitones and was clamped to +12).
* Akai MPC60
  * Fixed: The 12 bit sample data was unpacked with the low nibble at 1/16 of its weight and the result byte-swapped, which reduced the audio to roughly 8 bit quality with a signal-correlated error. The 12 bits are now left-justified as in the reference implementation.
* Akai S900/S950
  * Fixed: The fractional part of the nominal pitch was applied with an inverted sign: a sample recorded e.g. a quarter tone sharp was played another quarter tone sharp instead of being corrected. Also the loudness offset was read unsigned, so any attenuation became a boost.
* Akai S1000/S3000
  * Fixed: The pitch bend range was passed as semitones into the model's cents field - the bend wheel effectively did nothing.
  * Fixed: The program volume (a 0..1 value) was written directly as the dB gain of every zone, overwriting the per-layer loudness set before - the velocity-layer balance of every program was discarded.
  * Fixed: The fraction byte of the keygroup and keygroup-sample fixed point tunings was treated as signed, so negative fine tunes came out about a semitone flat (e.g. -0.05 semitones read as -1.05). The sample header tuning in literal cents is no longer rescaled.
```
