### PR TITLE
Roland ZEN-Core: read the partial pan and velocity window and signed envelope levels

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,6 +31,9 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
+* Roland ZEN-Core
+  * Fixed: The pan and the velocity window of the tone partials were ignored when reading, so a stereo instrument (two hard-panned partials over two mono multi-samples) collapsed into stacked centered zones and velocity layers all sounded at once. Each partial's zones now carry its pan and velocity range; a partial whose right wave differs from its left one is read as a stereo pair.
+  * Fixed: The levels of the pitch and filter (TVF) envelopes are signed 16 bit values but were read unsigned, so e.g. a pitch envelope starting at -1023 (a classic pitch drop) read as starting at the positive maximum.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -115,6 +118,9 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
+* Roland ZEN-Core
+  * Fixed: The pan and the velocity window of the tone partials were ignored when reading, so a stereo instrument (two hard-panned partials over two mono multi-samples) collapsed into stacked centered zones and velocity layers all sounded at once. Each partial's zones now carry its pan and velocity range; a partial whose right wave differs from its left one is read as a stereo pair.
+  * Fixed: The levels of the pitch and filter (TVF) envelopes are signed 16 bit values but were read unsigned, so e.g. a pitch envelope starting at -1023 (a classic pitch drop) read as starting at the positive maximum.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,9 +31,6 @@
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).
   * New: A volume LFO (tremolo) is read from and written as a LFO modulation device targeting the volume; since the volume chain is linear, the depth in decibels is expressed as the linear swing whose lowest point lies that many decibels below full volume.
-* Roland ZEN-Core
-  * Fixed: The pan and the velocity window of the tone partials were ignored when reading, so a stereo instrument (two hard-panned partials over two mono multi-samples) collapsed into stacked centered zones and velocity layers all sounded at once. Each partial's zones now carry its pan and velocity range; a partial whose right wave differs from its left one is read as a stereo pair.
-  * Fixed: The levels of the pitch and filter (TVF) envelopes are signed 16 bit values but were read unsigned, so e.g. a pitch envelope starting at -1023 (a classic pitch drop) read as starting at the positive maximum.
 * Waldorf Quantum/Iridium
   * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
 
@@ -118,9 +115,6 @@
   * Fixed: Disabled groups were only skipped when written as enabled="0" but not as enabled="false". Presets that switch between several kits via a drop-down in their UI (each kit is a group and only one is enabled) were converted with all kits stacked on the same keys and playing at once.
 * TX16Wx
   * Fixed: Envelope levels which are not set were written as -100%, which is a valid but completely different envelope. They now fall back to the neutral level.
-* Roland ZEN-Core
-  * Fixed: The pan and the velocity window of the tone partials were ignored when reading, so a stereo instrument (two hard-panned partials over two mono multi-samples) collapsed into stacked centered zones and velocity layers all sounded at once. Each partial's zones now carry its pan and velocity range; a partial whose right wave differs from its left one is read as a stereo pair.
-  * Fixed: The levels of the pitch and filter (TVF) envelopes are signed 16 bit values but were read unsigned, so e.g. a pitch envelope starting at -1023 (a classic pitch drop) read as starting at the positive maximum.
 * Waldorf Quantum/Iridium
   * New: Added a creator option to prefix written preset file names with a 5-digit import number (e.g. 05002-Name.qpat), mirroring the device's own export naming so the device assigns each preset to that number on import.
   * New: The oscillator volume and panning are now preserved instead of always being written as 0 dB / Center, so a Quantum/Iridium round-trip keeps them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreDetector.java
@@ -98,9 +98,8 @@ public class ZenCoreDetector extends AbstractDetector<MetadataSettingsUI>
             for (final SvzInstrument tone: tones)
             {
                 final IGroup toneGroup = new DefaultGroup ("Samples");
-                for (final int waveNumber: tone.waveNumbers)
-                    if (waveNumber > 0 && waveNumber <= keyMaps.size ())
-                        buildZonesFromKeyMap (toneGroup, samples, keyMaps.get (waveNumber - 1));
+                for (final ZenCoreSvz.SvzTonePartial partial: tone.tonePartials)
+                    addPartialZones (toneGroup, samples, keyMaps, partial);
                 if (toneGroup.getSampleZones ().isEmpty ())
                     continue;
                 applyToneShaping (toneGroup, tone);
@@ -121,6 +120,13 @@ public class ZenCoreDetector extends AbstractDetector<MetadataSettingsUI>
                 if (sample.getSampleData () != null)
                     group.addSampleZone (createZone (sample, sample.getOriginalKey (), sample.getOriginalKey ()));
         }
+        else if (tones.size () == 1 && !tones.get (0).tonePartials.isEmpty ())
+        {
+            // A single tone also carries the partial pans and velocity windows, e.g. the two
+            // hard-panned partials of a stereo instrument
+            for (final ZenCoreSvz.SvzTonePartial partial: tones.get (0).tonePartials)
+                addPartialZones (group, samples, keyMaps, partial);
+        }
         else
             buildZonesFromKeyMap (group, samples, keyMaps.get (0));
 
@@ -137,6 +143,50 @@ public class ZenCoreDetector extends AbstractDetector<MetadataSettingsUI>
             applyToneShaping (group, tones.get (0));
         this.notifier.log ("IDS_ZENCORE_READING_SVZ", fileName, Integer.toString (group.getSampleZones ().size ()));
         return Collections.singletonList (this.createMultisampleSource (svzFile, fileName, List.of (group)));
+    }
+
+
+    /**
+     * Add the zones of one tone partial: the zones of the multi-sample(s) it plays with the
+     * partial's pan and velocity window applied. A partial whose right wave differs from its left
+     * one plays the two multi-samples as a stereo pair.
+     *
+     * @param toneGroup The group to which to add the zones
+     * @param samples The sample pool of the file
+     * @param keyMaps The key maps of all multi-samples of the file
+     * @param partial The partial to add
+     */
+    private static void addPartialZones (final IGroup toneGroup, final List<ZenCoreSample> samples, final List<ZenCoreKeyMap> keyMaps, final ZenCoreSvz.SvzTonePartial partial)
+    {
+        final boolean stereoPair = partial.waveRight > 0 && partial.waveRight != partial.waveLeft;
+        final double leftPanning = stereoPair ? (partial.pan - 64) / 64.0 : partial.pan / 64.0;
+        addPartialWaveZones (toneGroup, samples, keyMaps, partial, partial.waveLeft, Math.clamp (leftPanning, -1, 1));
+        if (stereoPair)
+            addPartialWaveZones (toneGroup, samples, keyMaps, partial, partial.waveRight, Math.clamp ((partial.pan + 64) / 64.0, -1, 1));
+    }
+
+
+    private static void addPartialWaveZones (final IGroup toneGroup, final List<ZenCoreSample> samples, final List<ZenCoreKeyMap> keyMaps, final ZenCoreSvz.SvzTonePartial partial, final int waveNumber, final double panning)
+    {
+        if (waveNumber <= 0 || waveNumber > keyMaps.size ())
+            return;
+
+        final int sizeBefore = toneGroup.getSampleZones ().size ();
+        buildZonesFromKeyMap (toneGroup, samples, keyMaps.get (waveNumber - 1));
+
+        final boolean hasVelocityWindow = partial.velLow > 1 || partial.velHigh < 127;
+        final List<ISampleZone> zones = toneGroup.getSampleZones ();
+        for (int i = sizeBefore; i < zones.size (); i++)
+        {
+            final ISampleZone zone = zones.get (i);
+            if (panning != 0)
+                zone.setPanning (Math.clamp (zone.getPanning () + panning, -1, 1));
+            if (hasVelocityWindow)
+            {
+                zone.setVelocityLow (partial.velLow);
+                zone.setVelocityHigh (partial.velHigh);
+            }
+        }
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
@@ -239,6 +239,24 @@ public final class ZenCoreSvz
 
 
     /**
+     * One enabled partial of a tone as read from a preset or bank file.
+     */
+    public static final class SvzTonePartial
+    {
+        /** The 1-based number of the left (or only) multi-sample the partial plays. */
+        public int waveLeft;
+        /** The 1-based number of the right multi-sample; 0 or equal to the left one for mono. */
+        public int waveRight;
+        /** Pan -64 (hard left) .. 0 (centre) .. +63 (hard right). */
+        public int pan;
+        /** Velocity range lower 1-127. */
+        public int velLow  = 1;
+        /** Velocity range upper 1-127. */
+        public int velHigh = 127;
+    }
+
+
+    /**
      * One instrument (tone) that maps keys onto samples of the shared pool. A mono instrument has
      * one multi-sample played by a one-partial tone. A stereo instrument stores its left and right
      * channels as separate mono samples in two multi-samples, played by a two-partial tone (Partial
@@ -270,8 +288,8 @@ public final class ZenCoreSvz
          * partial has its own multi-sample, pan and velocity window.
          */
         public List<SvzPartial> partials;
-        /** The wave numbers of the multi-samples which the partials of the tone play (read side). */
-        public int []           waveNumbers      = new int [0];
+        /** The enabled partials with their multi-sample numbers, pan and velocity window (read side). */
+        public final List<SvzTonePartial> tonePartials = new ArrayList<> ();
 
         // ----------------------------------------------------------------------------------------
         // Optional Partial-1 tone parameters taken from the source; -1 keeps the template default
@@ -818,7 +836,7 @@ public final class ZenCoreSvz
     /**
      * Read all tones of the <i>PATa</i> section. A preset file holds one tone, a bank holds one per
      * preset - all of them sharing the sample pool of the file - which is why each tone names the
-     * multi-samples it plays in {@link SvzInstrument#waveNumbers}.
+     * multi-samples it plays in {@link SvzInstrument#tonePartials}.
      *
      * @param container The SVZ container
      * @return The tones in the order in which they are stored, empty if the container holds none
@@ -847,28 +865,32 @@ public final class ZenCoreSvz
         final SvzInstrument tone = new SvzInstrument ();
         tone.name = ZenCoreUtil.readName (file, r, NAME_LENGTH);
 
-        // The multi-samples which the enabled partials play. A partial whose wave group is zero is
-        // switched off and plays nothing, see buildTone.
-        final List<Integer> waves = new ArrayList<> ();
+        // The multi-samples which the enabled partials play with the partial's pan and velocity
+        // window. A partial whose wave group is zero is switched off and plays nothing, see
+        // buildTone.
         for (int p = 0; p < 4; p++)
         {
             final int oscBase = p * PAT_PARTIAL_STRIDE;
             if (file[r + PAT_WAVE_GROUP + oscBase] == 0)
                 continue;
-            for (final int offset: new int []
+
+            final SvzTonePartial partial = new SvzTonePartial ();
+            partial.waveLeft = ZenCoreUtil.readUnsigned16 (file, r + PAT_WAVE_L + oscBase, false);
+            partial.waveRight = ZenCoreUtil.readUnsigned16 (file, r + PAT_WAVE_R + oscBase, false);
+            partial.pan = file[r + PAT_PAN + oscBase];
+
+            final int kbdBase = p * PAT_KBD_STRIDE;
+            final int velLow = file[r + PAT_VEL_LOW + kbdBase] & 0xFF;
+            final int velHigh = file[r + PAT_VEL_HIGH + kbdBase] & 0xFF;
+            if (velLow >= 1 && velHigh >= velLow && velHigh <= 127)
             {
-                PAT_WAVE_L,
-                PAT_WAVE_R
-            })
-            {
-                final int wave = ZenCoreUtil.readUnsigned16 (file, r + offset + oscBase, false);
-                if (wave > 0 && !waves.contains (Integer.valueOf (wave)))
-                    waves.add (Integer.valueOf (wave));
+                partial.velLow = velLow;
+                partial.velHigh = velHigh;
             }
+
+            if (partial.waveLeft > 0 || partial.waveRight > 0)
+                tone.tonePartials.add (partial);
         }
-        tone.waveNumbers = new int [waves.size ()];
-        for (int i = 0; i < waves.size (); i++)
-            tone.waveNumbers[i] = waves.get (i).intValue ();
 
         tone.filterType = ZenCoreUtil.readUnsigned16 (file, r + PAT_FILTER_TYPE, false) / 0x100;
         tone.cutoff = ZenCoreUtil.readUnsigned16 (file, r + PAT_CUTOFF, false);
@@ -881,10 +903,10 @@ public final class ZenCoreSvz
         tone.envSustain = ZenCoreUtil.readUnsigned16 (file, r + PAT_TVA_LEVEL + 4, false);
         tone.pitchEnvDepth = file[r + PAT_PITCH_ENV_DEPTH];
         tone.pitchEnvTimes = readEnvBlock (file, r + PAT_PITCH_ENV_TIME, 4);
-        tone.pitchEnvLevels = readEnvBlock (file, r + PAT_PITCH_ENV_LEVEL, 5);
+        tone.pitchEnvLevels = readEnvBlockSigned (file, r + PAT_PITCH_ENV_LEVEL, 5);
         tone.filterEnvDepth = file[r + PAT_FILTER_ENV_DEPTH];
         tone.filterEnvTimes = readEnvBlock (file, r + PAT_FILTER_ENV_TIME, 4);
-        tone.filterEnvLevels = readEnvBlock (file, r + PAT_FILTER_ENV_LEVEL, 5);
+        tone.filterEnvLevels = readEnvBlockSigned (file, r + PAT_FILTER_ENV_LEVEL, 5);
         return tone;
     }
 
@@ -894,6 +916,15 @@ public final class ZenCoreSvz
         final int [] values = new int [count];
         for (int i = 0; i < count; i++)
             values[i] = ZenCoreUtil.readUnsigned16 (file, offset + i * 2, false);
+        return values;
+    }
+
+
+    private static int [] readEnvBlockSigned (final byte [] file, final int offset, final int count)
+    {
+        final int [] values = new int [count];
+        for (int i = 0; i < count; i++)
+            values[i] = (short) ZenCoreUtil.readUnsigned16 (file, offset + i * 2, false);
         return values;
     }
 


### PR DESCRIPTION
Two defects in the ZEN-Core SVZ reader.

* **Partial pan and velocity window ignored.** `readTone` collected only the wave numbers of the enabled partials, so all zones of a tone came back centered and full-velocity-range. A stereo instrument - two hard-panned partials over two mono multi-samples, exactly what ConvertWithMoss' own creator writes - collapsed into stacked centered zones (doubled mono), and a velocity-layered tone sounded all layers at once. The reader now keeps one record per enabled partial (wave L/R, pan, velocity window, per `ZENCORE_FORMAT.md`: pan at 0x0CE stride 0x7C, velocities at 0x0A0/0x0A1 stride 0x0C) and applies them to the partial's zones in both the bank path and the single-tone path; a partial whose right wave number differs from its left one is read as a stereo pair.

  SFZ -> SVZ -> SFZ round trip of a stereo two-velocity-layer instrument with a pitch envelope, read-back before: only `pitcheg_depth=2400` survived - no `pan`, no `lovel`/`hivel`. After: `pan=-100`/`pan=98`, `lovel=65`/`hivel=64` and the depth.

* **Pitch/TVF envelope levels read unsigned.** The level blocks are signed s16 (the writer writes them signed, the format doc says signed); reading them unsigned inverted every negative level to a huge positive one. Hex-patching a written SVZ's pitch envelope to `L0=-1023` (a classic pitch drop): before it read back as `pitcheg_start=100` (**+**100%), after the bogus positive start is gone. Envelope times remain unsigned as documented.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Roland ZEN-Core
  * Fixed: The pan and the velocity window of the tone partials were ignored when reading, so a stereo instrument (two hard-panned partials over two mono multi-samples) collapsed into stacked centered zones and velocity layers all sounded at once. Each partial's zones now carry its pan and velocity range; a partial whose right wave differs from its left one is read as a stereo pair.
  * Fixed: The levels of the pitch and filter (TVF) envelopes are signed 16 bit values but were read unsigned, so e.g. a pitch envelope starting at -1023 (a classic pitch drop) read as starting at the positive maximum.
```
