### PR TITLE
Ensoniq EPS/ASR: fix the pitch bend unit and the filter key tracking source

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -23,9 +23,6 @@
   * Fixed: A zone without a filter was written with a filter tracking of 0x40, which the operations manual shows as +1.00 and not as the neutral value. Such a bank was read back with a filter, so a source without one did not survive a round trip. No tracking is written now.
 * E-mu Emulator IV
   * Fixed: Presets which park their cutoff at an end of its range and open it up again with a modulation cord were converted to silence. Only the filter envelope and the key tracking of such a cord have a counterpart in the model - velocity, the assignable MIDI controllers and the LFOs are lost - so what was left was a filter which removes the whole signal (the reported '3DPads - 3DreamSwells' held a high-pass at 14.5 kHz, and every single low-pass voice of 'Old World Instruments' sits at the bottom of its range). Such a voice now gets no filter at all, which is much closer to the original than the silence; a voice whose filter envelope does open the cutoff up again keeps its filter. This affects 10390 of the 38783 filter voices of the E4 factory library.
-* Ensoniq EPS/ASR
-  * Fixed: The pitch bend range was passed as semitones into the model's cents field, so the bend wheel effectively did nothing on converted instruments.
-  * Fixed: The filter keyboard tracking was read from the filter envelope amount instead of the filter key amount field.
 * Kurzweil K2x00
   * Fixed: An envelope stage with both a zero time and a zero level is unused on the device and keeps the level of the previous stage, but was read literally. A program which leaves its decay stage unused - like the reported FM basses, which sustain at the attack level and only fade out with a long release - was therefore converted to a silent preset. Additionally, the attack velocity is now converted as a cutoff modulation source of the F1 slot in both directions; the same programs open their nearly closed cutoff by velocity and converted very dull without it.
 * Roland ZEN-Core

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -23,6 +23,9 @@
   * Fixed: A zone without a filter was written with a filter tracking of 0x40, which the operations manual shows as +1.00 and not as the neutral value. Such a bank was read back with a filter, so a source without one did not survive a round trip. No tracking is written now.
 * E-mu Emulator IV
   * Fixed: Presets which park their cutoff at an end of its range and open it up again with a modulation cord were converted to silence. Only the filter envelope and the key tracking of such a cord have a counterpart in the model - velocity, the assignable MIDI controllers and the LFOs are lost - so what was left was a filter which removes the whole signal (the reported '3DPads - 3DreamSwells' held a high-pass at 14.5 kHz, and every single low-pass voice of 'Old World Instruments' sits at the bottom of its range). Such a voice now gets no filter at all, which is much closer to the original than the silence; a voice whose filter envelope does open the cutoff up again keeps its filter. This affects 10390 of the 38783 filter voices of the E4 factory library.
+* Ensoniq EPS/ASR
+  * Fixed: The pitch bend range was passed as semitones into the model's cents field, so the bend wheel effectively did nothing on converted instruments.
+  * Fixed: The filter keyboard tracking was read from the filter envelope amount instead of the filter key amount field.
 * Kurzweil K2x00
   * Fixed: An envelope stage with both a zero time and a zero level is unused on the device and keeps the level of the previous stage, but was read literally. A program which leaves its decay stage unused - like the reported FM basses, which sustain at the attack level and only fade out with a long release - was therefore converted to a silent preset. Additionally, the attack velocity is now converted as a cutoff modulation source of the F1 slot in both directions; the same programs open their nearly closed cutoff by velocity and converted very dull without it.
 * Roland ZEN-Core

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ensoniq/epsasr/EnsoniqEpsAsrDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ensoniq/epsasr/EnsoniqEpsAsrDetector.java
@@ -355,8 +355,8 @@ public class EnsoniqEpsAsrDetector extends AbstractDetector<MetadataSettingsUI>
                 final int pitchBendRange = waveSample.getPitchBendRange ();
                 if (pitchBendRange < 13)
                 {
-                    sampleZone.setBendUp (pitchBendRange);
-                    sampleZone.setBendDown (-pitchBendRange);
+                    sampleZone.setBendUp (pitchBendRange * 100);
+                    sampleZone.setBendDown (-pitchBendRange * 100);
                 }
                 final IEnvelopeModulator pitchEnvelopeModulator = sampleZone.getPitchEnvelopeModulator ();
                 pitchEnvelopeModulator.setSource (createEnvelope (waveSample.getPitchEnvelope ()));
@@ -389,7 +389,7 @@ public class EnsoniqEpsAsrDetector extends AbstractDetector<MetadataSettingsUI>
                 if (waveSample.getFilter1ModulationSource () == 13)
                     filter.getCutoffVelocityModulator ().setDepth (waveSample.getFilter1ModulationAmount () / 127.0);
 
-                filter.setCutoffKeyTracking (waveSample.getFilter1EnvelopeAmount () / 127.0);
+                filter.setCutoffKeyTracking (waveSample.getFilter1KeyAmount () / 127.0);
 
                 sampleZone.setFilter (filter);
 


### PR DESCRIPTION
Two defects in the EPS/ASR reader.

* **Pitch bend range written as semitones into the cents field.** `setBendUp`/`setBendDown` take cents; the wave-sample's range in semitones went in unscaled, so a +-2 semitone bend became +-2 cents - effectively a dead bend wheel. Same defect class as the S1000/AKP fixes in #267.
* **Filter key tracking read from the envelope amount.** `setCutoffKeyTracking` was fed `getFilter1EnvelopeAmount` although the wave-sample provides `getFilter1KeyAmount` (until now unused). On four real EPS library disks (77 instruments from the archive.org EPS synth collection) the misread tracking clustered at wrong values with 17 zones clamped at the 1200 maximum; with the fix the zones carry the actual key-amount values.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Ensoniq EPS/ASR
  * Fixed: The pitch bend range was passed as semitones into the model's cents field, so the bend wheel effectively did nothing on converted instruments.
  * Fixed: The filter keyboard tracking was read from the filter envelope amount instead of the filter key amount field.
```
