### PR TITLE
Reason NN-XT: decode the velocity fade-out from its inverted storage

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -27,6 +27,8 @@
   * Fixed: An envelope stage with both a zero time and a zero level is unused on the device and keeps the level of the previous stage, but was read literally. A program which leaves its decay stage unused - like the reported FM basses, which sustain at the attack level and only fade out with a long release - was therefore converted to a silent preset. Additionally, the attack velocity is now converted as a cutoff modulation source of the F1 slot in both directions; the same programs open their nearly closed cutoff by velocity and converted very dull without it.
 * Roland ZEN-Core
   * Fixed: A bank (a SVZ which holds one tone per preset, as written by the preset library destination) was read as one single multi-sample: all samples of the file were merged into it and only the shaping of its first tone was applied, so every preset but the first was lost. Each tone is now read as a multi-sample of its own, built from the multi-samples which its partials play. A SVZ with one tone is unchanged.
+* Reason NN-XT
+  * Fixed: The velocity fade-out was read raw although it is stored inverted (0x80 = off, otherwise 127 minus the fade range, as the writer encodes it) - a zone without a fade read as a fade over the whole velocity range and an SXT round trip turned 'off' into a full-range fade.
 * Renoise
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -27,8 +27,6 @@
   * Fixed: An envelope stage with both a zero time and a zero level is unused on the device and keeps the level of the previous stage, but was read literally. A program which leaves its decay stage unused - like the reported FM basses, which sustain at the attack level and only fade out with a long release - was therefore converted to a silent preset. Additionally, the attack velocity is now converted as a cutoff modulation source of the F1 slot in both directions; the same programs open their nearly closed cutoff by velocity and converted very dull without it.
 * Roland ZEN-Core
   * Fixed: A bank (a SVZ which holds one tone per preset, as written by the preset library destination) was read as one single multi-sample: all samples of the file were merged into it and only the shaping of its first tone was applied, so every preset but the first was lost. Each tone is now read as a multi-sample of its own, built from the multi-samples which its partials play. A SVZ with one tone is unchanged.
-* Reason NN-XT
-  * Fixed: The velocity fade-out was read raw although it is stored inverted (0x80 = off, otherwise 127 minus the fade range, as the writer encodes it) - a zone without a fade read as a fade over the whole velocity range and an SXT round trip turned 'off' into a full-range fade.
 * Renoise
   * Fixed: A modulation set was created for every key zone. Now zones with identical modulation share one set, which gives the usual single instrument-wide modulation set; additional sets are only created for zones which genuinely modulate differently.
   * New: A pitch LFO (vibrato) is read from and written as a LFO modulation device (waveform, rate, depth and onset time; the value curves were calibrated against Renoise 3.5.4).

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sxt/SxtZone.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sxt/SxtZone.java
@@ -456,7 +456,9 @@ class SxtZone
         zone.setVelocityLow (this.velocityRangeStart);
         zone.setVelocityHigh (this.velocityRangeEnd);
         zone.setVelocityCrossfadeLow (this.velocityFadeIn);
-        zone.setVelocityCrossfadeHigh (this.velocityFadeOut);
+        // The fade-out is stored inverted: 0x80 means off, otherwise 127 minus the fade range
+        // (see fillFrom)
+        zone.setVelocityCrossfadeHigh (this.velocityFadeOut >= 0x80 ? 0 : 127 - this.velocityFadeOut);
         zone.setKeyRoot (this.rootKey);
         zone.setStart ((int) this.sampleStart);
         zone.setStop ((int) this.sampleEnd);


### PR DESCRIPTION
`SxtZone.fillInto` passed the velocity fade-out to the model raw, although the field is stored inverted - `0x80` means off, otherwise `127 - fadeRange` - which is exactly how `fillFrom` in the same class encodes it. A zone without a fade therefore read as a 128-wide fade, and a real fade of e.g. 27 velocities read as one of 100.

Verified with an SFZ (`xfout_lovel=100 xfout_hivel=127`, i.e. a 27-velocity fade at the top) -> SXT -> SFZ round trip: with the old decode the fade came back as `xfout_lovel=27 xfout_hivel=127` (a 100-wide fade); with the fix the span stays 27. (The test also needs the SFZ crossfade anchoring fix from the companion PR, since the SFZ writer previously collapsed top-edge fades on its own.)

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Reason NN-XT
  * Fixed: The velocity fade-out was read raw although it is stored inverted (0x80 = off, otherwise 127 minus the fade range, as the writer encodes it) - a zone without a fade read as a fade over the whole velocity range and an SXT round trip turned 'off' into a full-range fade.
```
