### PR TITLE
SFZ: anchor crossfades inside the zone range and write negative filter envelope depths

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -104,9 +104,6 @@
 * Spectrasonics Omnisphere 3
   * Fixed: Envelope stages which are not set were written as "not a number" (attack, hold, decay and release) or as a negative sustain level. Unset times are now written as zero and an unset sustain level as the full level.
   * Fixed: The zone tuning was written and read as cents although the model value is in semi-tones, so the tuning was off by a factor of 100 against every other format (an Omnisphere-to-Omnisphere conversion was not affected since both directions had the same error).
-* SFZ
-  * Fixed: The key and velocity crossfade ranges (xfin/xfout) were written outside of the zone's range, where the zone does not even play - and for zones at the edges the 0/127 clamps collapsed the fade range entirely (e.g. a fade at the top of a full-velocity zone was written as the empty range 127..127 and lost). The fades are now anchored inside the zone's range.
-  * Fixed: A negative filter envelope depth (a downward sweep, e.g. of an 808-style kick) was silently dropped when writing; the fileg_depth opcode is now also written for negative depths.
 * Synthstrom Deluge
   * New: Added an Output Type creator option (Synth/Kit, CLI DelugeOutputType) to write a drum kit instead of a synth (sound) preset. A kit writes one drum per note, consolidating velocity layers and round-robins to the loudest layer (a Deluge drum is a single sample). The type is chosen explicitly because a one-sample-per-note layout is not necessarily a kit (e.g. a per-note synth bass).
   * New: Added a "Consolidate kit" option (CLI DelugeConsolidateKit) which reduces a drum kit to one drum per type (kick, snare, hi-hat, ...) ordered by drum role following the factory TR-808 layout (kick on the lowest row), so a beat can be programmed without switching rows. The consolidated drums are labelled by their role for a clean read-out on the device.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -104,6 +104,9 @@
 * Spectrasonics Omnisphere 3
   * Fixed: Envelope stages which are not set were written as "not a number" (attack, hold, decay and release) or as a negative sustain level. Unset times are now written as zero and an unset sustain level as the full level.
   * Fixed: The zone tuning was written and read as cents although the model value is in semi-tones, so the tuning was off by a factor of 100 against every other format (an Omnisphere-to-Omnisphere conversion was not affected since both directions had the same error).
+* SFZ
+  * Fixed: The key and velocity crossfade ranges (xfin/xfout) were written outside of the zone's range, where the zone does not even play - and for zones at the edges the 0/127 clamps collapsed the fade range entirely (e.g. a fade at the top of a full-velocity zone was written as the empty range 127..127 and lost). The fades are now anchored inside the zone's range.
+  * Fixed: A negative filter envelope depth (a downward sweep, e.g. of an 808-style kick) was silently dropped when writing; the fileg_depth opcode is now also written for negative depths.
 * Synthstrom Deluge
   * New: Added an Output Type creator option (Synth/Kit, CLI DelugeOutputType) to write a drum kit instead of a synth (sound) preset. A kit writes one drum per note, consolidating velocity layers and round-robins to the loudest layer (a Deluge drum is a single sample). The type is chosen explicitly because a one-sample-per-note layout is not necessarily a kit (e.g. a per-note synth bass).
   * New: Added a "Consolidate kit" option (CLI DelugeConsolidateKit) which reduces a drum kit to one drum per type (kick, snare, hi-hat, ...) ordered by drum role following the factory TR-808 layout (kick on the lowest row), so a beat can be programmed without switching rows. The consolidated drums are labelled by their role for a clean read-out on the device.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzCreator.java
@@ -281,17 +281,20 @@ public class SfzCreator extends AbstractWavCreator<SfzCreatorUI>
             addIntegerAttribute (buffer, SfzOpcode.HI_KEY, limitToDefault (keyHigh, 127), true);
         }
 
+        // The fade ranges lie inside of the zone's range - anchoring them outside would both
+        // fade where the zone does not even play and destroy the fade range by the 0/127 clamps
+        // for zones at the edges
         final int crossfadeLow = zone.getNoteCrossfadeLow ();
         if (crossfadeLow > 0)
         {
-            addIntegerAttribute (buffer, SfzOpcode.XF_IN_LO_KEY, Math.max (0, keyLow - crossfadeLow), false);
-            addIntegerAttribute (buffer, SfzOpcode.XF_IN_HI_KEY, keyLow, true);
+            addIntegerAttribute (buffer, SfzOpcode.XF_IN_LO_KEY, keyLow, false);
+            addIntegerAttribute (buffer, SfzOpcode.XF_IN_HI_KEY, Math.min (127, keyLow + crossfadeLow), true);
         }
         final int crossfadeHigh = zone.getNoteCrossfadeHigh ();
         if (crossfadeHigh > 0)
         {
-            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_LO_KEY, keyHigh, false);
-            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_HI_KEY, Math.min (127, keyHigh + crossfadeHigh), true);
+            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_LO_KEY, Math.max (0, keyHigh - crossfadeHigh), false);
+            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_HI_KEY, keyHigh, true);
         }
 
         // -----------------------------------------------------------
@@ -304,18 +307,19 @@ public class SfzCreator extends AbstractWavCreator<SfzCreatorUI>
         if (velocityHigh > 0 && velocityHigh < 127)
             addIntegerAttribute (buffer, SfzOpcode.HI_VEL, limitToDefault (velocityHigh, 127), true);
 
+        // See the key crossfade above: the fade ranges lie inside of the zone's range
         final int crossfadeVelocityLow = zone.getVelocityCrossfadeLow ();
         if (crossfadeVelocityLow > 0)
         {
-            addIntegerAttribute (buffer, SfzOpcode.XF_IN_LO_VEL, Math.max (0, velocityLow - crossfadeVelocityLow), false);
-            addIntegerAttribute (buffer, SfzOpcode.XF_IN_HI_VEL, velocityLow, true);
+            addIntegerAttribute (buffer, SfzOpcode.XF_IN_LO_VEL, Math.max (0, velocityLow), false);
+            addIntegerAttribute (buffer, SfzOpcode.XF_IN_HI_VEL, Math.min (127, velocityLow + crossfadeVelocityLow), true);
         }
 
         final int crossfadeVelocityHigh = zone.getVelocityCrossfadeHigh ();
         if (crossfadeVelocityHigh > 0)
         {
-            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_LO_VEL, velocityHigh, false);
-            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_HI_VEL, Math.min (127, velocityHigh + crossfadeVelocityHigh), true);
+            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_LO_VEL, Math.max (0, velocityHigh - crossfadeVelocityHigh), false);
+            addIntegerAttribute (buffer, SfzOpcode.XF_OUT_HI_VEL, velocityHigh, true);
         }
 
         // -----------------------------------------------------------
@@ -575,7 +579,7 @@ public class SfzCreator extends AbstractWavCreator<SfzCreatorUI>
 
         final IEnvelopeModulator cutoffModulator = filter.getCutoffEnvelopeModulator ();
         final double envelopeDepth = cutoffModulator.getDepth ();
-        if (envelopeDepth > 0)
+        if (envelopeDepth != 0)
         {
             buffer.append (SfzOpcode.FILEG_DEPTH).append ('=').append ((int) Math.round (envelopeDepth * IEnvelope.MAX_ENVELOPE_DEPTH)).append (LINE_FEED);
 


### PR DESCRIPTION
Two defects in the SFZ creator.

* **Crossfades anchored outside the zone and collapsed by clamps.** The writer put `xfin` below the zone start (`lovel - fade .. lovel`) and `xfout` above the zone end (`hivel .. hivel + fade`). That fades the region over key/velocity ranges where it is not even mapped - and for zones at the edges the 0/127 clamps destroyed the fade range altogether: a 27-velocity fade at the top of a full-range zone was written as the empty range `xfout_lovel=127 xfout_hivel=127`, so a plain SFZ -> SFZ round trip lost every top/bottom-edge crossfade. The fades are now anchored inside the zone (`xfin: lovel .. lovel+fade`, `xfout: hivel-fade .. hivel`); the round trip preserves `xfout_lovel=100 xfout_hivel=127` exactly.
* **Negative filter envelope depth dropped.** `fileg_depth` was only written `> 0`; downward sweeps are legal and common (808-style kicks). Now written for any non-zero depth - the SFZ half of the defect whose SF2 half was fixed in #255.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* SFZ
  * Fixed: The key and velocity crossfade ranges (xfin/xfout) were written outside of the zone's range, where the zone does not even play - and for zones at the edges the 0/127 clamps collapsed the fade range entirely (e.g. a fade at the top of a full-velocity zone was written as the empty range 127..127 and lost). The fades are now anchored inside the zone's range.
  * Fixed: A negative filter envelope depth (a downward sweep, e.g. of an 808-style kick) was silently dropped when writing; the fileg_depth opcode is now also written for negative depths.
```
