### PR TITLE
DecentSampler: read unit-less volume values as linear amplitude

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,8 +16,6 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
-* DecentSampler
-  * Fixed: A volume value without a dB unit is a linear amplitude but was scaled as 'value times 6dB' - volume="0.5" (-6dB) read as +3dB and an explicit volume="1.0" differed from an absent attribute.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,6 +16,8 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
+* DecentSampler
+  * Fixed: A volume value without a dB unit is a linear amplitude but was scaled as 'value times 6dB' - volume="0.5" (-6dB) read as +3dB and an explicit volume="1.0" differed from an absent attribute.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerDetector.java
@@ -27,6 +27,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import de.mossgrabers.convertwithmoss.core.algorithm.MathUtils;
 import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
 import de.mossgrabers.convertwithmoss.core.INotifier;
 import de.mossgrabers.convertwithmoss.core.detector.AbstractDetector;
@@ -795,9 +796,8 @@ public class DecentSamplerDetector extends AbstractDetector<DecentSamplerDetecto
         if (attribute.endsWith ("dB"))
             return Double.parseDouble (attribute.substring (0, attribute.length () - 2));
 
-        // The value is in the range of [0..1] but it is not specified what 0 and 1 means, lets
-        // scale it to [0..6] dB.
-        return Double.parseDouble (attribute) * 6.0;
+        // A value without a unit is a linear amplitude (1.0 = 0dB)
+        return MathUtils.valueToDb (Double.parseDouble (attribute));
     }
 
 


### PR DESCRIPTION
A DecentSampler `volume` attribute without a `dB` suffix is a linear amplitude (1.0 = full volume). The reader scaled it as `value * 6dB` instead: `volume="0.5"` (-6dB) read as **+3dB**, and an explicit `volume="1.0"` (= 0dB) read as +6dB, differing from an absent attribute. Unit-less values now convert as `20*log10(value)` (via `MathUtils.valueToDb`, which also handles 0 safely); dB-suffixed values are unchanged, and ConvertWithMoss' own creator always writes the dB form, so round trips were never affected - this hits presets authored by hand or by other tools.

Verified with a crafted preset (`volume="0.5"`): reads -6.02dB after, +3.00dB before.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* DecentSampler
  * Fixed: A volume value without a dB unit is a linear amplitude but was scaled as 'value times 6dB' - volume="0.5" (-6dB) read as +3dB and an explicit volume="1.0" differed from an absent attribute.
```
