### PR TITLE
Disting EX: accept the creator's _RR round-robin suffix in the file name pattern

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,6 +16,8 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
+* Disting EX
+  * Fixed: The creator names round-robin samples with an '_RR<n>' suffix but the detector's file name pattern only accepted '_R<n>' - such file names did not match at all, so the note and velocity information of every round-robin sample was lost when reading. Both spellings are accepted now.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -16,8 +16,6 @@
   * New: Added support for a LFO modulating the volume (tremolo) with its rate, depth and delay: DecentSampler, DLS, Renoise, SFZ, SoundFont 2. Other formats pending.
   * New: The Korg KSC/KMP/KSF, Kurzweil K2x00, Roland MV-8000 and Roland ZEN-Core destinations have an option to shorten a name to its last separated segment for the short name field of the device (e.g. 'Greek Bazouki - Dark Tremolo' becomes 'Dark Tremolo'), which otherwise cuts off exactly the part that tells the presets apart. Disabled by default.
   * Fixed: Detecting a source which contains many presets was dominated by a fixed 10 millisecond pause taken after every single detected preset. A CD-ROM image of an E-mu sampler with 812 presets needed 11 seconds, of which 8 were that pause; two of them with 2339 presets needed 36 seconds. The pause is now taken every 64 presets, which keeps a cancellation responsive but takes the two images down to 1.4 seconds.
-* Disting EX
-  * Fixed: The creator names round-robin samples with an '_RR<n>' suffix but the detector's file name pattern only accepted '_R<n>' - such file names did not match at all, so the note and velocity information of every round-robin sample was lost when reading. Both spellings are accepted now.
 * E-mu Emulator III
   * New: Banks which the EIIIX and ESI samplers saved onto floppy disks are now read, including banks which span several disks. All disks of a set need to be in the same folder.
   * Fixed: The preset link is a single byte followed by a separate parameter, not a 16 bit value. A few presets whose second byte is set lost the preset which is layered on top of them.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/disting/DistingExDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/disting/DistingExDetector.java
@@ -46,7 +46,7 @@ import de.mossgrabers.tools.ui.Functions;
  */
 public class DistingExDetector extends AbstractDetector<MetadataSettingsUI>
 {
-    private static final Pattern FILE_NAME_QUERY = Pattern.compile ("(.*)_(?<note>[A-Ga-g]#?\\d)(_SW(?<switch>\\d+))?(_V(?<velocity>\\d+))?(_R(?<roundrobin>\\d+))?");
+    private static final Pattern FILE_NAME_QUERY = Pattern.compile ("(.*)_(?<note>[A-Ga-g]#?\\d)(_SW(?<switch>\\d+))?(_V(?<velocity>\\d+))?(_RR?(?<roundrobin>\\d+))?");
 
     /** The number of voices of the disting EX, see its 8 'Voice N detune' parameters. */
     private static final int     MAX_VOICES      = 8;


### PR DESCRIPTION
The creator suffixes round-robin samples with `_RR<n>` (`DistingExCreator`), but the detector's `FILE_NAME_QUERY` only accepted `_R<n>` - and since it is applied with `matches()`, a name like `RRTest_C3_SW60_RR2` did not match *at all*, losing the note/key-switch/velocity metadata of every round-robin sample. The pattern now accepts both spellings (`_RR?<n>`); plain `_R<n>` names parse exactly as before.

While testing this I noticed a separate, pre-existing issue that blocks a full ConvertWithMoss -> ConvertWithMoss round trip: the detector reads the sample sub-folder name from a different byte position than the creator writes it (the written preset has the folder string at offset 732; the reader ends up mid-parameter-block and fails with "The sample folder does not exist"). Settling which side matches the real device needs a preset saved by an actual disting EX, so I left both layouts untouched here.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Disting EX
  * Fixed: The creator names round-robin samples with an '_RR<n>' suffix but the detector's file name pattern only accepted '_R<n>' - such file names did not match at all, so the note and velocity information of every round-robin sample was lost when reading. Both spellings are accepted now.
```
