### PR TITLE
Sample Files: prefer the embedded root note of a sample file over the file name

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -99,6 +99,8 @@
   * Fixed: All loops were lost when reading a preset: the loop was created but never added to the zone. Writing loops was not affected.
   * Fixed: The pitch key tracking was never read, so zones with a reduced key tracking (e.g. fixed-pitch percussion) were imported as fully tracking.
   * Fixed: The depth of the filter envelope was written into the field of the pitch envelope, so the filter modulation was lost and the pitch modulation was overwritten with it.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: The velocity range was taken from the cross-fade opcodes, so it grew by the width of the cross-fade with every conversion (e.g. lovel/hivel 40/100 became 30/110 and then 20/120). The same was already fixed for the key range.
 * Spectrasonics Omnisphere 3
@@ -270,6 +272,8 @@
 * NI
   * New: Renamed "Kontakt NKI" to "NI Kontakt".
   * New: Renamed "Maschine Sound" to "NI Maschine".
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Improved layout of metadata header with long description texts.
 * WAV
@@ -362,6 +366,8 @@
   * New: The root note is now modified instead re-pitching it via tuning parameter.
 * Akai XPM
   * Fixed: Never read loops from WAV files.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Prevent creation of filter type with poles not supported by SFZ (2 poles will be set in such a case).
 
@@ -422,6 +428,8 @@
   * Fixed: Loop cross-fade was written as samples not as milliseconds.
 * SF2
   * New: Use all metadata fields for category detection if none could be extracted from the path.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Read loop cross-fade was not calculated correctly (integer instead of double).
   * Fixed: Writing loop cross-fade was not calculated correctly (was rounded to full seconds).
@@ -482,6 +490,8 @@
   * New: KSC files get now a DOS-safe filename as well. Check for duplicated names is now separate for folders and normal files.
 * Sample Files
   * New: Added option to ignore the loops in the source sample files.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Amplitude envelope settings are now aggregated to group or global level if they are identical.
 
@@ -518,6 +528,8 @@
   * Fixed: The loop end was off by 1.
 * SF2
   * Fixed: Added support for reading missing generators: startAddrsOffset, endAddrsOffset, startloopAddrsOffset and endloopAddrsOffset.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Loops were not read from wave files when loop info was missing in SFZ file.
 
@@ -595,6 +607,8 @@
 * EXS24
   * New: Added support for round-robin. Files are larger now since this info is in an additional block.
   * Fixed: Reading: group indices were off by 1.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Added support for round-robin on group-level (not only zone-level).
 * Kontakt
@@ -664,6 +678,8 @@
   * Fixed: Prevent several characters in file names which could crash the workstation.
 * MPC Keygroups
   * New: Added option to create up to 8 layers which is now supported with MPC Firmware 3.4.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Added support for reading SFZ files which reference other SFZ files with #include statements.
   * New: Added option to (not) log unsupported SFZ opcodes. This is off by default since the warnings confused many users.
@@ -736,6 +752,8 @@
   * New: Added an option to trim samples with a delayed start.
   * Fixed: The MIDI note for the switch (SW) was off by 1 octave (disting assumes C3 as MIDI note 48 instead of 60). This caused playback issues.
   * Fixed: Release trigger groups are now removed from the output since the distingEX does not support release triggers.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Pitch bend was by factor 100 too small (semi-tones instead of cents).
 
@@ -945,6 +963,8 @@
 * MPC keygroups
   * Fixed: Read/Write: Improved mapping of envelopes.
   * Fixed: Write: Pitch was not correct.
+* Sample Files
+  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Increased allowed range of pitch values.
   * Fixed: Panning was not read / written.

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -99,8 +99,6 @@
   * Fixed: All loops were lost when reading a preset: the loop was created but never added to the zone. Writing loops was not affected.
   * Fixed: The pitch key tracking was never read, so zones with a reduced key tracking (e.g. fixed-pitch percussion) were imported as fully tracking.
   * Fixed: The depth of the filter envelope was written into the field of the pitch envelope, so the filter modulation was lost and the pitch modulation was overwritten with it.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: The velocity range was taken from the cross-fade opcodes, so it grew by the width of the cross-fade with every conversion (e.g. lovel/hivel 40/100 became 30/110 and then 20/120). The same was already fixed for the key range.
 * Spectrasonics Omnisphere 3
@@ -272,8 +270,6 @@
 * NI
   * New: Renamed "Kontakt NKI" to "NI Kontakt".
   * New: Renamed "Maschine Sound" to "NI Maschine".
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Improved layout of metadata header with long description texts.
 * WAV
@@ -366,8 +362,6 @@
   * New: The root note is now modified instead re-pitching it via tuning parameter.
 * Akai XPM
   * Fixed: Never read loops from WAV files.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Prevent creation of filter type with poles not supported by SFZ (2 poles will be set in such a case).
 
@@ -428,8 +422,6 @@
   * Fixed: Loop cross-fade was written as samples not as milliseconds.
 * SF2
   * New: Use all metadata fields for category detection if none could be extracted from the path.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Read loop cross-fade was not calculated correctly (integer instead of double).
   * Fixed: Writing loop cross-fade was not calculated correctly (was rounded to full seconds).
@@ -490,8 +482,6 @@
   * New: KSC files get now a DOS-safe filename as well. Check for duplicated names is now separate for folders and normal files.
 * Sample Files
   * New: Added option to ignore the loops in the source sample files.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Amplitude envelope settings are now aggregated to group or global level if they are identical.
 
@@ -528,8 +518,6 @@
   * Fixed: The loop end was off by 1.
 * SF2
   * Fixed: Added support for reading missing generators: startAddrsOffset, endAddrsOffset, startloopAddrsOffset and endloopAddrsOffset.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Loops were not read from wave files when loop info was missing in SFZ file.
 
@@ -607,8 +595,6 @@
 * EXS24
   * New: Added support for round-robin. Files are larger now since this info is in an additional block.
   * Fixed: Reading: group indices were off by 1.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Added support for round-robin on group-level (not only zone-level).
 * Kontakt
@@ -678,8 +664,6 @@
   * Fixed: Prevent several characters in file names which could crash the workstation.
 * MPC Keygroups
   * New: Added option to create up to 8 layers which is now supported with MPC Firmware 3.4.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * New: Added support for reading SFZ files which reference other SFZ files with #include statements.
   * New: Added option to (not) log unsupported SFZ opcodes. This is off by default since the warnings confused many users.
@@ -752,8 +736,6 @@
   * New: Added an option to trim samples with a delayed start.
   * Fixed: The MIDI note for the switch (SW) was off by 1 octave (disting assumes C3 as MIDI note 48 instead of 60). This caused playback issues.
   * Fixed: Release trigger groups are now removed from the output since the distingEX does not support release triggers.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Pitch bend was by factor 100 too small (semi-tones instead of cents).
 
@@ -963,8 +945,6 @@
 * MPC keygroups
   * Fixed: Read/Write: Improved mapping of envelopes.
   * Fixed: Write: Pitch was not correct.
-* Sample Files
-  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
 * SFZ
   * Fixed: Increased allowed range of pitch values.
   * Fixed: Panning was not read / written.

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/KeyMapping.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/KeyMapping.java
@@ -416,6 +416,29 @@ public class KeyMapping
      * @throws MultisampleException There was a pattern detected but (or more) of the samples could
      *             not be matched
      */
+    /**
+     * Create a sample zone and fill it with the metadata of the sample file (e.g. the root note
+     * and loops of a WAV 'smpl' chunk), so the mapping can prefer the file's own root over one
+     * parsed from the file name.
+     *
+     * @param sampleData The sample data from which to create the zone
+     * @return The zone
+     */
+    private static ISampleZone createZone (final IFileBasedSampleData sampleData)
+    {
+        final ISampleZone zone = new DefaultSampleZone (FileUtils.getNameWithoutType (new File (sampleData.getFilename ())), sampleData);
+        try
+        {
+            sampleData.addZoneData (zone, true, true);
+        }
+        catch (final IOException ex)
+        {
+            // The metadata cannot be read - the root note then needs to come from the file name
+        }
+        return zone;
+    }
+
+
     private static Map<Integer, List<ISampleZone>> detectGroups (final List<IFileBasedSampleData> sampleData, final String [] groupPatterns) throws MultisampleException
     {
         final Map<Integer, List<ISampleZone>> groups = new TreeMap<> ();
@@ -426,7 +449,7 @@ public class KeyMapping
         {
             final List<ISampleZone> zones = new ArrayList<> (sampleData.size ());
             for (final IFileBasedSampleData si: sampleData)
-                zones.add (new DefaultSampleZone (FileUtils.getNameWithoutType (new File (si.getFilename ())), si));
+                zones.add (createZone (si));
             groups.put (Integer.valueOf (0), zones);
             return groups;
         }
@@ -445,7 +468,7 @@ public class KeyMapping
                 final Integer id = Integer.valueOf (number);
                 // Matcher group "prefix" not used
                 // Matcher group "postfix" not used
-                final ISampleZone zone = new DefaultSampleZone (FileUtils.getNameWithoutType (new File (filename)), si);
+                final ISampleZone zone = createZone (si);
                 groups.computeIfAbsent (id, _ -> new ArrayList<> ()).add (zone);
             }
             catch (final NumberFormatException _)

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/samplefile/SampleFileDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/samplefile/SampleFileDetector.java
@@ -154,6 +154,11 @@ public class SampleFileDetector extends AbstractDetector<SampleFileDetectorUI>
                     group.addSampleZone (sampleZone);
                     sampleFileType.fillInstrumentData (sampleZone, fileSampleData);
                     filenames.add (new File (fileSampleData.getFilename ()).getName ());
+
+                    // Merge the metadata of the sample file itself (e.g. WAV 'smpl' chunks) on top
+                    final Optional<ISampleData> sampleDataOpt = sampleZone.getSampleData ();
+                    if (sampleDataOpt.isPresent ())
+                        sampleDataOpt.get ().addZoneData (sampleZone, true, true);
                 }
                 name = KeyMapping.findCommonPrefix (filenames);
                 if (name.isBlank ())
@@ -179,14 +184,6 @@ public class SampleFileDetector extends AbstractDetector<SampleFileDetectorUI>
                 name = FileUtils.getNameWithoutType (sampleData.get (0).getFilename ());
             }
             name = cleanupName (name, this.settingsConfiguration.getPostfixTexts ());
-
-            for (final IGroup group: groups)
-                for (final ISampleZone zone: group.getSampleZones ())
-                {
-                    final Optional<ISampleData> sampleDataOpt = zone.getSampleData ();
-                    if (sampleDataOpt.isPresent ())
-                        sampleDataOpt.get ().addZoneData (zone, true, true);
-                }
 
             // Remove all loops if requested
             if (this.settingsConfiguration.isShouldIgnoreLoops ())


### PR DESCRIPTION
When building a multi-sample from plain sample files, `SampleFileDetector` ran the `KeyMapping` *before* any file metadata was loaded (`addZoneData` only ran afterwards), so the mapping's chunk-root branch always saw -1. File name digits won over embedded roots: three WAVs "Marimba-01..03" with `smpl` roots 60/64/67 mapped to the MIDI notes 1..3 - or note detection failed outright although every file carried its root.

`KeyMapping` now fills each zone from the file's metadata when it creates it (root, tuning, loops; a file whose metadata cannot be read falls back to the name as before), and the detector no longer re-applies the metadata afterwards, which would have doubled the loops. The instrument-chunk branch merges the sample-file metadata as before.

Verified with the crafted "Marimba" folder: `pitch_keycenter=1/3` (one zone lost) before, `60/64/67` after.

---
**Changelog entry** (all entries of this PR batch are collected in #283, so the fix PRs themselves do not touch the changelog and merge conflict-free in any order):
```
* Sample Files
  * Fixed: When building a multi-sample from plain sample files, an embedded root note (e.g. from the WAV 'smpl' chunk) was ignored since the key mapping ran before the file metadata was loaded - file name digits won instead ("Marimba-01..03" mapped to the MIDI notes 1..3) or the detection failed although every file carries its root. The file's own root note now takes precedence over the name.
```
