### PR TITLE
E-mu Emulator III: read the chorus flag as a second detuned voice

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator3/Emulator3Constants.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator3/Emulator3Constants.java
@@ -198,6 +198,9 @@ public class Emulator3Constants
     // The flags of a zone
     /** The zone does not transpose its sample across the keyboard. */
     public static final int    ZONE_FLAG_NON_TRANSPOSE         = 0x02;
+
+    /** The flag bit which enables the chorus (a second, slightly detuned voice). */
+    public static final int    ZONE_FLAG_CHORUS                = 0x08;
     /** The zone ignores the loop of its sample. */
     public static final int    ZONE_FLAG_DISABLE_LOOP          = 0x20;
     /** The zone mutes the left channel of its sample. */

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator3/Emulator3Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/emu/emulator3/Emulator3Detector.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -25,6 +26,7 @@ import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
 import de.mossgrabers.convertwithmoss.core.model.IEnvelopeModulator;
 import de.mossgrabers.convertwithmoss.core.model.IFilter;
 import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
 import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
 import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
 import de.mossgrabers.convertwithmoss.core.model.enumeration.FilterType;
@@ -532,7 +534,23 @@ public class Emulator3Detector extends AbstractDetector<Emulator3DetectorUI>
                     continue;
                 final ISampleZone sampleZone = this.parseZone (data, bankFormat, zone, presetOffset, keyLow + Emulator3Constants.KEY_OFFSET, keyHigh + Emulator3Constants.KEY_OFFSET, samplesByIndex, missingSampleIndices, bankName);
                 if (sampleZone != null)
+                {
                     group.addSampleZone (sampleZone);
+
+                    // The chorus doubles the zone with a second, slightly detuned voice on its own
+                    // channel. The width of the detune is not documented anywhere; the pair is
+                    // detuned by +-7 cents, which keeps it centered on the original pitch
+                    if ((data[zone + Emulator3Constants.ZONE_FLAGS] & Emulator3Constants.ZONE_FLAG_CHORUS) > 0)
+                    {
+                        final ISampleZone chorusZone = new DefaultSampleZone (sampleZone);
+                        final Optional<ISampleData> chorusSampleData = sampleZone.getSampleData ();
+                        if (chorusSampleData.isPresent ())
+                            chorusZone.setSampleData (chorusSampleData.get ());
+                        sampleZone.setTuning (sampleZone.getTuning () - 0.07);
+                        chorusZone.setTuning (chorusZone.getTuning () + 0.07);
+                        group.addSampleZone (chorusZone);
+                    }
+                }
             }
 
             if (!group.getSampleZones ().isEmpty ())


### PR DESCRIPTION
The EIII zone flags carry a chorus bit (0x08): the sampler doubles the zone with a slightly detuned second voice on its own channel. The flag was ignored, which is a big part of why the wave-based presets of the library CD-ROMs (single-cycle Proteus/Orbit material) convert noticeably thinner than they sound on the hardware.

A chorused zone is now read as a pair of zones detuned by +-7 cents around the original pitch, so the net tuning is unchanged and every destination format renders the doubling with plain zones - the same approach the Mirage reader takes for its second oscillator. The hardware's actual detune width is not documented anywhere I could find; the +-7 cents live in one place if a measurement ever refines it.

On the Formula 4000 Vol. 5 CD-ROM, **860 of 2723 presets** carry the flag and now convert with the doubling (e.g. "Odd Vibes" goes from 12 to 24 zones as `tune=-7`/`tune=+7` pairs). A full-disc A/B against the unpatched build changes exactly those presets and only by the added twin zones.

---
**Changelog entry** (collected in #283 with the rest of the open batch):
```
* E-mu Emulator III
  * New: The chorus of a zone is now read as a second voice detuned by +-7 cents, which restores the width of the many chorused presets of the library CD-ROMs.
```