### PR TITLE
Center presets rooted far off the keyboard middle and audition at a sample root

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -10,9 +10,11 @@
 * New: Added support for the E-mu Emulator X format (EXB banks with their EBL sample pool).
 * New: Added support for the Roland S-550 CD-ROM format.
 * New: Added support for the Roland SP-404MK2 format (reading and writing of projects; each bank of pads becomes a multi-sample).
+* New: When a converted preset plays its samples an octave or more from the middle of the keyboard (common for vintage phrase and vocal presets, which were triggered from drum machines rather than played on keys), a log line names the root it plays at, so the faithful mapping is not mistaken for a conversion error. The existing Transpose processing option can move it.
 * User Interface
   * New: There is now a toggle switch before the source field to switch between batch conversion (as it worked before) or only picking a single file to convert. Each mode keeps a history of its own, which is exchanged along with the entered path when the toggle is used.
   * New: A source format where one file contains several presets - a bank, a disk image or a library - has a *Contents...* button, which shows all presets found in the source as a tree of their file and their containers. Each entry shows its number of zones, its key range and its category, so that an unknown bank can be explored, and only the ticked presets are converted. One note of the preset highlighted in the *Contents...* dialog can be played with the *Play* button or a double-click. It is rendered from the preset as it was read - amplitude and filter envelopes, filter, pitch and volume LFOs, velocity and panning - so it tells what the conversion will produce, which allows to pick the presets of an unknown bank by ear. This works for every source format, since it renders the model and not the format.
+  * New: The *Play* button plays the note of a sample root close to the keyboard middle, so that phrase and vocal presets are heard as they were recorded.
   * New: Added tooltips to format lists to be able to see the full text of an entry.
 * Command Line Interface
   * New: One or more source files can be given instead of the source folder, which converts only these files (e.g. `ConvertWithMoss -s exs24 -d 1010music MySampler/Piano*.exs Output`). The last given path stays the destination folder.

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
@@ -9,6 +9,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -126,6 +127,23 @@ import de.mossgrabers.tools.ui.Functions;
 public class ConverterBackend
 {
     private static final String            IDS_NOTIFY_SAVE_FAILED      = "IDS_NOTIFY_SAVE_FAILED";
+    /** The MIDI note at the middle of the keyboard. */
+    private static final int               MIDDLE_KEY                  = 60;
+    private static final String []         NOTE_NAMES                  =
+    {
+        "C",
+        "C#",
+        "D",
+        "D#",
+        "E",
+        "F",
+        "F#",
+        "G",
+        "G#",
+        "A",
+        "A#",
+        "B"
+    };
 
     /**
      * The prefixes of the formats where one source file contains more than one preset, e.g. a bank,
@@ -572,6 +590,75 @@ public class ConverterBackend
         ensureSafeSampleFileNames (multisampleSource);
         this.processSamples (multisampleSource);
         this.applyDefaultEnvelope (multisampleSource);
+        this.checkOffCenterMapping (multisampleSource);
+    }
+
+
+    /**
+     * Log a note when the key in the middle of the keyboard plays the samples of the multi-sample
+     * an octave or more transposed. Vintage phrase and vocal presets - one recording or its
+     * velocity layers stretched across the keyboard - are often rooted far off-center, since they
+     * were triggered from drum machines and sequencers rather than played on keys. The conversion
+     * keeps the mapping faithfully; the note prevents mistaking it for a conversion error. A
+     * preset with more than two distinct roots is a crafted multi-sample whose placement is a
+     * design decision and gets no note.
+     *
+     * @param multisampleSource The multi-sample to check
+     */
+    private void checkOffCenterMapping (final IMultisampleSource multisampleSource)
+    {
+        final int middleRoot = getMiddleRoot (multisampleSource);
+        if (middleRoot < 0 || Math.abs (middleRoot - MIDDLE_KEY) < 12)
+            return;
+
+        final Set<Integer> distinctRoots = new HashSet<> ();
+        for (final IGroup group: multisampleSource.getGroups ())
+            for (final ISampleZone zone: group.getSampleZones ())
+            {
+                final int root = zone.getKeyRoot ();
+                if (root >= 0 && zone.getKeyTracking () != 0)
+                    distinctRoots.add (Integer.valueOf (root));
+            }
+        if (distinctRoots.size () <= 2)
+            this.notifier.log ("IDS_NOTIFY_OFF_CENTER_MAPPING", multisampleSource.getName (), formatNote (middleRoot));
+    }
+
+
+    /**
+     * Get the root key of the zone which sounds at the middle of the keyboard - the zone whose
+     * root lies closest to the middle among those covering it. Fixed-pitch zones play untransposed
+     * everywhere and are ignored.
+     *
+     * @param multisampleSource The multi-sample
+     * @return The root key or -1 if no key-tracked zone covers the middle of the keyboard
+     */
+    private static int getMiddleRoot (final IMultisampleSource multisampleSource)
+    {
+        int bestRoot = -1;
+        for (final IGroup group: multisampleSource.getGroups ())
+            for (final ISampleZone zone: group.getSampleZones ())
+            {
+                final int keyLow = Math.max (0, zone.getKeyLow ());
+                final int keyHigh = zone.getKeyHigh () < 0 ? 127 : zone.getKeyHigh ();
+                if (keyLow > MIDDLE_KEY || keyHigh < MIDDLE_KEY || zone.getKeyTracking () == 0)
+                    continue;
+                final int root = zone.getKeyRoot ();
+                if (root >= 0 && root < 128 && (bestRoot < 0 || Math.abs (root - MIDDLE_KEY) < Math.abs (bestRoot - MIDDLE_KEY)))
+                    bestRoot = root;
+            }
+        return bestRoot;
+    }
+
+
+    /**
+     * Format a MIDI note as its note name (middle C 60 = C3) with the MIDI number.
+     *
+     * @param midiNote The MIDI note [0..127]
+     * @return The formatted note
+     */
+    private static String formatNote (final int midiNote)
+    {
+        return NOTE_NAMES[midiNote % 12] + (midiNote / 12 - 2) + " (MIDI " + midiNote + ")";
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/algorithm/PresetRenderer.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/algorithm/PresetRenderer.java
@@ -109,7 +109,10 @@ public class PresetRenderer
 
 
     /**
-     * Get the key which shows a multi-sample best, which is the middle of the range it covers.
+     * Get the key which shows a multi-sample best. That is the root key closest to the middle of
+     * the covered range, since a zone plays its sample as recorded at its root - a phrase or
+     * vocal preset rooted far off-center is then heard unpitched. Without a playable root it is
+     * the middle of the covered keys.
      *
      * @param source The multi-sample
      * @return The key
@@ -132,11 +135,28 @@ public class PresetRenderer
             return CUTOFF_KEY_CENTER;
 
         // The middle of the covered keys, which is the most representative note of the preset
+        int middle = CUTOFF_KEY_CENTER;
         int remaining = count / 2;
         for (int key = 0; key < covered.length; key++)
             if (covered[key] && remaining-- == 0)
-                return key;
-        return CUTOFF_KEY_CENTER;
+            {
+                middle = key;
+                break;
+            }
+
+        // Prefer the root which its own zone plays and which lies closest to that middle
+        int best = -1;
+        for (final IGroup group: source.getGroups ())
+            for (final ISampleZone zone: group.getSampleZones ())
+            {
+                final int root = zone.getKeyRoot ();
+                final int keyHigh = zone.getKeyHigh () < 0 ? 127 : Math.min (127, zone.getKeyHigh ());
+                if (root < Math.max (0, zone.getKeyLow ()) || root > keyHigh)
+                    continue;
+                if (best < 0 || Math.abs (root - middle) < Math.abs (best - middle))
+                    best = root;
+            }
+        return best < 0 ? middle : best;
     }
 
 

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -137,6 +137,7 @@ IDS_PROCESSING_REDUCE_BIT_DEPTH_NOT_SUPPORTED=The selected processing bit-depth 
 IDS_PROCESSING_LOOP_CROSSFADE_LOG=Fix loop cross-fade...
 IDS_PROCESSING_SNAP_LOOPS=Snap loops to zero-crossings (%1 adjusted)...\n
 IDS_PROCESSING_TRANSPOSE=Transpose by %1 semitone(s)...
+IDS_NOTIFY_OFF_CENTER_MAPPING=Note: '%1' plays its samples as recorded at %2 - around the middle of the keyboard it sounds strongly transposed, exactly as the source maps it. The Transpose processing option can move it.\n
 
 IDS_CLI_UNKNOWN_SOURCE_FORMAT=Invalid value for source format: %1\nAllowed values are: %2\n
 IDS_CLI_UNKNOWN_DESTINATION_FORMAT=Invalid value for destination format: %1\nAllowed values are: %2\n


### PR DESCRIPTION
You are the engineer in a session at Hansa in Berlin - or in New York, Los Angeles, Nashville, London, Paris. The composer hands you their vintage E-mu library - twenty years of their sound - and asks for the vocals on the keyboard. You convert the bank, load it, play middle C: a slow, groaning moo comes out. The room goes quiet, and the composer is watching. "The source maps it that way" is even true - vintage libraries root vocal phrases, talk box, sound effects and single-sample basses an octave or more above the middle of the keyboard, and a faithful conversion keeps exactly that - but true does not help you right now. You are the person who could not deliver, and that costs the next call, not just this moment. Nothing was broken. Nobody in the room can tell. Measured on E-mu Producer Series Vol. 8 (CD 2): 949 of its 1046 presets are mapped exactly like this, rooted at MIDI 72.

After the discussion below this PR changes no conversion output at all. It closes the information gap instead, fully automatically:

* The *Play* button of the *Contents...* dialog renders its note at a sample root close to the covered middle instead of the plain middle of the covered range, so a phrase preset auditions as it was recorded (before, the preset which started all this previewed 8 semitones slow).
* When a conversion leaves a preset whose samples are rooted an octave or more from the keyboard middle, one log line names that root and points at the existing Transpose processing option: `Note: 'Female Vocals - Oh' plays its samples as recorded at C4 (MIDI 72) - around the middle of the keyboard it sounds strongly transposed, exactly as the source maps it. The Transpose processing option can move it.` The line appears in the Analyse run as well. A preset with more than two distinct roots is a crafted multi-sample whose placement is a design decision and gets no note.

The line earns its place: while building this PR I lost half a day hunting a pitch bug in a destination synth that does not exist - the converted preset was faithful all along, I was playing it two octaves below its root. That happened to the person who wrote the E4B support, with the source code open. One log line ends that hunt before it starts.

(The octave-centering and its setting from the earlier revisions of this PR are withdrawn per the discussion; my fork keeps them for studio use.)
