### PR TITLE
Keep Command-H and Command-Q working while a path field has the focus

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerCreatorUI.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/decentsampler/DecentSamplerCreatorUI.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import de.mossgrabers.convertwithmoss.core.INotifier;
 import de.mossgrabers.convertwithmoss.core.settings.WavChunkSettingsUI;
+import de.mossgrabers.convertwithmoss.ui.SystemShortcuts;
 import de.mossgrabers.tools.ui.BasicConfig;
 import de.mossgrabers.tools.ui.Functions;
 import de.mossgrabers.tools.ui.control.TitledSeparator;
@@ -126,6 +127,7 @@ public class DecentSamplerCreatorUI extends WavChunkSettingsUI
         }
         this.templateFolderPathField.getItems ().addAll (this.templateFolderPathHistory);
         this.templateFolderPathField.setEditable (true);
+        SystemShortcuts.keepWorkingIn (this.templateFolderPathField);
         if (!this.templateFolderPathHistory.isEmpty ())
             this.templateFolderPathField.getEditor ().setText (this.templateFolderPathHistory.get (0));
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
@@ -530,6 +530,7 @@ public class MainFrame extends AbstractFrame implements INotifier
         final List<String> activeHistory = this.activeSourceHistory ();
         this.sourcePathField.getItems ().addAll (activeHistory);
         this.sourcePathField.setEditable (true);
+        SystemShortcuts.keepWorkingIn (this.sourcePathField);
         if (!activeHistory.isEmpty ())
             this.sourcePathField.getEditor ().setText (activeHistory.get (0));
 
@@ -551,6 +552,7 @@ public class MainFrame extends AbstractFrame implements INotifier
         }
         this.destinationPathField.getItems ().addAll (this.destinationPathHistory);
         this.destinationPathField.setEditable (true);
+        SystemShortcuts.keepWorkingIn (this.destinationPathField);
         if (!this.destinationPathHistory.isEmpty ())
             this.destinationPathField.getEditor ().setText (this.destinationPathHistory.get (0));
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/ui/SystemShortcuts.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/ui/SystemShortcuts.java
@@ -1,0 +1,77 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.ui;
+
+import de.mossgrabers.tools.OperatingSystem;
+
+import javafx.event.EventDispatcher;
+import javafx.scene.control.ComboBox;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+
+/**
+ * Keeps the shortcuts of the macOS application menu working while an editable combo box has the
+ * focus.
+ *
+ * <p>
+ * An editable combo box hands every key stroke to its internal editor and consumes the original
+ * event. macOS offers a Command shortcut to the application menu only if nothing inside the window
+ * handled it, therefore Command-H and Command-Q do nothing at all as long as such a combo box has
+ * the focus - and the application starts with the focus in the source path combo box, which makes
+ * both shortcuts look permanently dead.
+ * </p>
+ *
+ * @author Jürgen Moßgraber
+ */
+public final class SystemShortcuts
+{
+    /**
+     * Constructor. Private due to utility class.
+     */
+    private SystemShortcuts ()
+    {
+        // Intentionally empty
+    }
+
+
+    /**
+     * Route the shortcuts of the macOS application menu around the given editable combo box, so
+     * that the combo box cannot consume them. All other key strokes - among them the editing
+     * shortcuts like Command-C and Command-V - keep their normal way into the editor of the combo
+     * box. Does nothing on other operating systems, which have their menus inside of the window.
+     *
+     * @param comboBox The editable combo box
+     */
+    public static void keepWorkingIn (final ComboBox<?> comboBox)
+    {
+        if (!OperatingSystem.isMacOS ())
+            return;
+
+        final EventDispatcher comboBoxDispatcher = comboBox.getEventDispatcher ();
+        comboBox.setEventDispatcher ( (event, tail) -> {
+
+            if (event instanceof final KeyEvent keyEvent && isApplicationMenuShortcut (keyEvent))
+                return tail.dispatchEvent (event);
+            return comboBoxDispatcher.dispatchEvent (event, tail);
+        });
+    }
+
+
+    /**
+     * Test if the given key event is one of the shortcuts of the macOS application menu: Command-H
+     * hides the application, Alt-Command-H hides all others and Command-Q quits it.
+     *
+     * @param keyEvent The key event to test
+     * @return True if it is a shortcut of the application menu
+     */
+    private static boolean isApplicationMenuShortcut (final KeyEvent keyEvent)
+    {
+        if (!keyEvent.isShortcutDown ())
+            return false;
+        final KeyCode keyCode = keyEvent.getCode ();
+        return keyCode == KeyCode.H || keyCode == KeyCode.Q;
+    }
+}


### PR DESCRIPTION
After #251 the application menu is there and its *Hide* and *Quit* items work when they are clicked, but the shortcuts still do nothing in the state the application starts in.

An editable JavaFX combo box hands every key stroke to its internal editor and consumes the original event - `ComboBoxPopupControl` registers a `KeyEvent.ANY` filter on the combo box which does `textField.fireEvent (ke.copyFor (textField, textField)); ke.consume ();` for every key except ESCAPE, F10 and ENTER. macOS offers a Command shortcut to the application menu only if nothing inside the window handled it, so a consumed event never reaches *Hide* or *Quit*. The application starts with the focus in the source path combo box, which makes both shortcuts look permanently dead.

Measured on macOS 15 with JavaFX 26.0.2, in a minimal application with nothing but a system menu bar and one focused control, 100% reproducible over repeated trials:

| Focus owner | Command-Q |
| --- | --- |
| nothing, Button, CheckBox, ListView, TextField | quits |
| editable ComboBox | does nothing |

A plain `TextField` is not affected, so this is specific to the editable combo box. Whether the menu bar carries menus of its own makes no difference. A control run in which a scene event filter consumed every key while a button had the focus was equally dead, which confirms that any consumption on the JavaFX side is what stops the menu.

The new `SystemShortcuts` wraps the event dispatcher of the three editable combo boxes - source path, destination path and the DecentSampler template folder - so that only Command-H and Command-Q are routed around the filter of the combo box and stay unconsumed. Everything else keeps its normal way into the editor; Command-A, Command-C, Command-V and Command-Z were compared with and without the change and reach the editor identically. Like the menu bar itself the change is limited to macOS, since other systems draw their menus inside the window.

No CHANGELOG entry, since the shortcuts of #251 have not been released yet.