### PR TITLE
Waldorf Quantum/Iridium: do not cut off the preset name at the bank

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -122,7 +122,7 @@
 * TAL Sampler
   * Fixed: The creator omitted the volume attribute for 0dB zones but the reader decodes a missing attribute as about -21.8dB, so every zone of a read-back .talsmpl dropped by that amount. The volume is now always written and the reader's default is the raw value which represents 0dB.
 * Waldorf Quantum/Iridium
-  * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it.
+  * New: A source which carries its bank in front of its name is written without it in the preset name, since the device shows the bank in a field of its own. The file name keeps the full name. An explicit Bank from the settings replaces the source's bank, in which case the name keeps it - but only as long as it fits into the 32 character name field of the device. Everything beyond that is cut off, which removes exactly the part that tells the presets of one bank apart: 'Full Arco String - Arco Strings Lo' and '... Hi' both ended up as 'Full Arco String - Arco Strings' on the display. Such a name is now written without the bank of the source, which the file name still carries.
   * Fixed: The amount of a matrix entry modulating the oscillator pitch (the pitch envelope) was read with the wrong offset: a positive amount was read as a negative one (e.g. +50% as -25%) and +100% was dropped entirely.
   * Fixed: The velocity modulation of the volume was written from the amplitude envelope modulation depth instead of the velocity modulation amount. E.g. a source with a velocity amount of 0% was written as +100%.
 * WAV

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
@@ -130,6 +130,25 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
 
 
     /**
+     * Choose the name to write into the name field of the preset. The field holds a fixed number of
+     * characters and everything beyond that is cut off, therefore the alternative is used as soon
+     * as the preferred name does not fit.
+     *
+     * @param preferredName The name to use if it fits into the field
+     * @param alternativeName The name to use otherwise
+     * @return The name to write
+     */
+    private String fitIntoNameField (final String preferredName, final String alternativeName)
+    {
+        // The name is converted to ASCII before it is written, which can change its length
+        if (StringUtils.fixASCII (preferredName).length () <= WaldorfQpatConstants.MAX_STRING_LENGTH)
+            return preferredName;
+        this.notifier.log ("IDS_QPAT_NOTIFY_NAME_WITHOUT_BANK", preferredName, alternativeName);
+        return alternativeName;
+    }
+
+
+    /**
      * Create the QPAT file and store it.
      *
      * @param multisampleSource The multi-sample source
@@ -155,10 +174,16 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
         // The device has a field of its own for the bank, so the preset name does not need to
         // repeat it - only the file name keeps it, for the user to tell the files apart. An
         // explicit bank from the settings replaces the source's one, which is then no longer
-        // written anywhere, so in that case the name keeps it
+        // written anywhere, so in that case the name keeps it - but only as long as the qualified
+        // name fits into the name field. What does not fit is cut off, and that is exactly the part
+        // which tells the presets of one bank apart: 'Full Arco String - Arco Strings Lo' and
+        // '... Hi' both end up as 'Full Arco String - Arco Strings' on the display of the device.
+        // Losing the bank is the better trade in that case, since the preset name is what is looked
+        // for and the bank of the source is still in the file name.
         final String bank = this.settingsConfiguration.getBank ();
         final boolean replacesSourceBank = bank != null && !bank.isBlank ();
-        final String presetName = replacesSourceBank ? multisampleSource.getName () : createNameWithoutBank (multisampleSource);
+        final String nameWithoutBank = createNameWithoutBank (multisampleSource);
+        final String presetName = replacesSourceBank ? this.fitIntoNameField (multisampleSource.getName (), nameWithoutBank) : nameWithoutBank;
         if (replacesSourceBank)
             metadata.setDescription (bank);
 

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -417,6 +417,7 @@ IDS_QPAT_VERSION=Detected preset version %1, written on %2. %3.\n
 IDS_QPAT_UNKNOWN_RESOURCE_TYPE=Unknown resource type: %1.\n
 IDS_QPAT_NOT_SAMPLE_BASED=Preset is not sample based.\n
 IDS_QPAT_OSC_SILENCED=Volume of oscillator %1 is set to -Infinity and might therefore not sound.\n
+IDS_QPAT_NOTIFY_NAME_WITHOUT_BANK=The name "%1" does not fit into the name field of the device, therefore the bank of the source is dropped from it: "%2".\n
 
 IDS_S3P_NOT_A_S3P_FILE=This is not a S3P file.\n
 IDS_S3P_INVALID_MIDI_MESSAGE=This is not a proper S1000/S3000 MIDI SysEx message.\n


### PR DESCRIPTION
When an explicit *Bank* is configured, the preset name keeps the bank of the source, so that it is not lost entirely. But the name field of the device holds 32 characters and everything beyond that is cut off - which is exactly the part that tells the presets of one bank apart. Converting an E-mu library CD with *Bank* set, 'Full Arco String - Arco Strings Lo' and 'Full Arco String - Arco Strings Hi' both ended up as 'Full Arco String - Arco Strings ' and were indistinguishable in the browser of the device.

The bank of the source is now dropped from the name as soon as the qualified name does not fit the field, which is logged; the file name carries the full name as before, so nothing is lost on the computer. A qualified name which fits - e.g. 'Full Arco String - Dull Arcos', 29 characters - is written unchanged.

Verified by reading the written headers back: with *Bank* set, the two colliding presets now store 'Arco Strings Lo' and 'Arco Strings Hi' with the bank in the Bank field; without *Bank* the output is unchanged.
