### PR TITLE
Fix the path history losing entries when switching between the source modes

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/ui/MainFrame.java
@@ -528,7 +528,7 @@ public class MainFrame extends AbstractFrame implements INotifier
         }
         this.sourceModeChoiceBox.getSelectionModel ().select (this.config.getBoolean (SOURCE_BATCH_MODE, true) ? 0 : 1);
         final List<String> activeHistory = this.activeSourceHistory ();
-        this.sourcePathField.getItems ().addAll (activeHistory);
+        this.sourcePathField.getItems ().setAll (activeHistory);
         this.sourcePathField.setEditable (true);
         SystemShortcuts.keepWorkingIn (this.sourcePathField);
         if (!activeHistory.isEmpty ())
@@ -953,7 +953,7 @@ public class MainFrame extends AbstractFrame implements INotifier
     {
         if (!this.applySourcePath ())
             return false;
-        this.activeSourceHistory ().add (0, this.sourcePathField.getEditor ().getText ());
+        updateHistory (this.sourcePathField.getEditor ().getText (), this.activeSourceHistory ());
 
         // Check output folder
         this.detectSettings.outputFolder = new File (this.destinationPathField.getEditor ().getText ());
@@ -969,7 +969,7 @@ public class MainFrame extends AbstractFrame implements INotifier
             this.destinationPathField.requestFocus ();
             return false;
         }
-        this.destinationPathHistory.add (0, this.detectSettings.outputFolder.getAbsolutePath ());
+        updateHistory (this.detectSettings.outputFolder.getAbsolutePath (), this.destinationPathHistory);
 
         // Output folder must be empty or add new must be active
         return this.addNewFiles || this.isEmptyFolder (this.detectSettings.outputFolder.getPath ());
@@ -1424,6 +1424,8 @@ public class MainFrame extends AbstractFrame implements INotifier
 
     private static void updateHistory (final String newItem, final List<String> history)
     {
+        if (newItem.isBlank ())
+            return;
         history.remove (newItem);
         history.add (0, newItem);
     }


### PR DESCRIPTION
Fixes the history loss of the new folder/file source toggle, as reported: the history loses entries when switching between the two modes, and after a switch the path field is empty although the first entry of that mode's history should be shown. The suspicion in the report was close - the empty path is inserted in front of the first entry rather than overwriting it, and the actual loss happens on the next program start.

Cause: the mode choice box fires its action handler while `loadConfiguration` selects the stored mode, at which point the path field is still empty. `updateHistory` had no blank guard, so an empty string was inserted at the front of the other mode's history on every start. On save the empty string occupies a slot, and the loader stops at the first blank slot - every entry behind it was discarded on the next start. Launching the application twice was enough to wipe the history of the mode that was not active. The same empty entry is what showed up as the empty path field when switching modes.

Changes:
* `updateHistory` ignores blank entries.
* The initial fill of the source path box uses `setAll` - the action handler firing during `loadConfiguration` has already set the items, so `addAll` duplicated every dropdown entry.
* `verifyFolders` runs the entered paths through `updateHistory` instead of a plain `add (0, ...)`, so converting the same folder repeatedly no longer pushes older entries over the 20-entry limit.