### PR TITLE
NI Kontakt: apply the program-level group solo flag

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 20.1.0 (work-in-progress)
+
+* NI Kontakt
+  * Fixed: The soloed groups of a Kontakt 4.2/5+ program were honored even when the program has group solo switched off. Kontakt keeps the solo flags of the groups when solo mode is left, so a program with such left-overs converted to those groups only and dropped every other group.
+
 ## 20.0.0
 
 * Many thanks to Douglas Carmichael for plenty of contributions and fixes!
@@ -82,7 +87,6 @@
   * Fixed: The loop cross-fade of a written Kontakt 1 file was the cross-fade fraction cast to a whole number, so every cross-fade became 0 samples. The field is a length in samples.
   * Fixed: The lower velocity crossfade of a Kontakt 4.2/5+ zone was read from the lower key crossfade field.
   * Fixed: Muted and soloed groups were ignored when reading Kontakt 4.2/5+ files - the zones of muted groups (often alternate articulations parked by the sound designer) stacked onto the active ones. Zones of muted groups are now skipped, and if any group is soloed only the soloed groups are converted.
-  * Fixed: The soloed groups of a Kontakt 4.2/5+ program were honored even when the program has group solo switched off. Kontakt keeps the solo flags of the groups when solo mode is left, so a program with such left-overs converted to those groups only and dropped every other group.
 * NI Maschine
   * Fixed: The velocity to volume amount was written from the amplitude envelope modulation depth instead of the velocity modulation amount (both the Maschine 1 and 2 writers) - a source without velocity response became fully velocity sensitive.
 * Reason NN-XT

--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -82,6 +82,7 @@
   * Fixed: The loop cross-fade of a written Kontakt 1 file was the cross-fade fraction cast to a whole number, so every cross-fade became 0 samples. The field is a length in samples.
   * Fixed: The lower velocity crossfade of a Kontakt 4.2/5+ zone was read from the lower key crossfade field.
   * Fixed: Muted and soloed groups were ignored when reading Kontakt 4.2/5+ files - the zones of muted groups (often alternate articulations parked by the sound designer) stacked onto the active ones. Zones of muted groups are now skipped, and if any group is soloed only the soloed groups are converted.
+  * Fixed: The soloed groups of a Kontakt 4.2/5+ program were honored even when the program has group solo switched off. Kontakt keeps the solo flags of the groups when solo mode is left, so a program with such left-overs converted to those groups only and dropped every other group.
 * NI Maschine
   * Fixed: The velocity to volume amount was written from the amplitude envelope modulation depth instead of the velocity modulation amount (both the Maschine 1 and 2 writers) - a source without velocity response became fully velocity sensitive.
 * Reason NN-XT

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/type/AbstractKontaktFormat.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/type/AbstractKontaktFormat.java
@@ -79,7 +79,9 @@ public abstract class AbstractKontaktFormat implements IKontaktFormat
 
         final List<File> files = this.lookupFiles (filePaths, multiSample.getSourceFile ().getParent (), isMonolith);
         final Map<Integer, Pair<IGroup, Group>> indexedGroups = createGroups (program);
-        final boolean hasSoloedGroup = program.getGroups ().stream ().anyMatch (Group::isSoloed);
+        // The soloed state of the groups is only in effect if the program has group solo enabled;
+        // otherwise the flags of the groups are left-overs of a previously active solo
+        final boolean hasSoloedGroup = program.isGroupSolo () && program.getGroups ().stream ().anyMatch (Group::isSoloed);
         for (final Zone kontaktZone: program.getZones ())
         {
             // Zones without a sample file might be present

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/type/kontakt5/Program.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ni/kontakt/type/kontakt5/Program.java
@@ -585,6 +585,18 @@ public class Program
 
 
     /**
+     * Is the solo of groups active? The soloed state of the individual groups is only in effect
+     * if this is enabled.
+     *
+     * @return True if group solo is active
+     */
+    public boolean isGroupSolo ()
+    {
+        return this.groupSolo;
+    }
+
+
+    /**
      * Get the volume of the instrument.
      *
      * @return The volume in the range of [0..1]


### PR DESCRIPTION
The soloed state of the individual groups is only in effect when the program has group solo enabled. Kontakt keeps the solo flags of the groups when solo mode is switched off again, so a program carrying such left-overs was converted to those groups only and every other group was silently dropped.

`Program` already read and wrote the flag but it had no getter and no consumer; the flag now gates the solo handling which was added in #274.

Closes the remaining half of #197.