### PR TITLE
Ableton Sampler: support round-robin stored as sample-select ranges

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -162,6 +162,7 @@
   * Fixed: The choke group attribute of an unused template slot was written as "okegrp" instead of "chokegrp".
   * Fixed: The MIDI channel of a performance was written one channel too high and MIDI channel 16 was turned into "Off". The value is the MIDI channel 1-16 (where channel 1 doubles as the OMNI mode) and not an additionally offset one; OMNI is now written as channel 1 instead of switching MIDI input off.
 * Ableton
+  * New: Round-robin cycles which are stored as sample-select (selector) ranges - the only round-robin representation the Sampler of Live 10/11 has - are now read as round-robin groups instead of zones which all play at once. When writing, round-robin groups are stored as selector ranges whenever the native round-robin flag of Live 12 is not available (Ableton 11) or does not apply because only some of the groups alternate.
   * Fixed: The warning that the round-robin configuration could not be translated was logged when it could be translated and not when it could not. The written file is not affected.
   * Fixed: No preset was written at all (the conversion failed with a "sample file not found" error) when a zone name contained one of the characters & . ' : / \ * ? " < > | - the sample file is written with those characters replaced by an underscore, but the preset looked it up and referenced it under the unchanged name.
   * Fixed: The upper velocity crossfade was calculated from the lower velocity crossfade value.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -141,6 +141,8 @@ ConvertWithMoss can extract Sampler and Simpler presets from ADV files as well a
 
 ADV files and their samples need to be placed in the Ableton user library in the correct folders to allow Ableton to open it. Therefore, ConvertWithMoss creates the necessary folder structure which can be simply copied to the user library. If the source has sub-folders the global option *Create folder structure* should be deactivated otherwise it can be quite tedious to collect all the results files with their additional Ableton sub-folder structure.
 
+Round-robin is supported in both representations: the native round-robin flag of Live 12 and the classic Sampler way of spreading the cycles across the sample-select (selector) ranges of otherwise identical zones. When writing, the selector representation is used whenever the native flag is not available (Ableton 11) or does not apply (only some of the groups alternate); at the default selector position only the first cycle is heard and the other cycles can be reached by modulating the sample selector.
+
 ### Destination Options
 
 * Option to set the *Ableton Version*. Setting it to *12* will add additional Round-Robin information (but cannot be loaded in Ableton 11).

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonCreator.java
@@ -9,11 +9,14 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeSet;
 import java.util.zip.GZIPOutputStream;
 
 import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
@@ -118,12 +121,19 @@ public class AbletonCreator extends AbstractWavCreator<AbletonCreatorUI>
     {
         try
         {
+            final boolean isVersion12 = this.settingsConfiguration.getAbletonVersion () == 12;
+            final boolean nativeRoundRobin = isVersion12 && multisampleSource.hasRoundRobin () && multisampleSource.isFullRoundRobin ();
+            // Without the native round-robin flag the cycles are spread across the sample-select
+            // (selector) axis, otherwise all cycles would play at the same time
+            final boolean selectorRoundRobin = !nativeRoundRobin && multisampleSource.hasRoundRobin ();
+            if (selectorRoundRobin)
+                this.notifier.log ("IDS_ADV_ROUND_ROBIN_VIA_SELECTOR");
+
             // Add all groups
             final List<IGroup> groups = multisampleSource.getNonEmptyGroups (false);
             final String multiSamplePartTemplate = Functions.textFileFor (TEMPLATE_FOLDER + "ADV-MultiSamplePart-Template.xml");
-            final String multisampleParts = addGroups (groups, multiSamplePartTemplate, createSafeFilename (multisampleSource.getName ()), writtenSamples);
+            final String multisampleParts = addGroups (groups, multiSamplePartTemplate, createSafeFilename (multisampleSource.getName ()), writtenSamples, selectorRoundRobin);
 
-            final boolean isVersion12 = this.settingsConfiguration.getAbletonVersion () == 12;
             String text = Functions.textFileFor (TEMPLATE_FOLDER + (isVersion12 ? "ADV12-Template.xml" : "ADV11-Template.xml"));
 
             int pitchBend = 2;
@@ -186,7 +196,7 @@ public class AbletonCreator extends AbstractWavCreator<AbletonCreatorUI>
             text = text.replace ("%MULTI_SAMPLE_PARTS%", multisampleParts);
             if (isVersion12)
             {
-                text = text.replace ("%ROUND_ROBIN%", this.checkRoundRobin (multisampleSource) ? "true" : FALSE);
+                text = text.replace ("%ROUND_ROBIN%", nativeRoundRobin ? "true" : FALSE);
                 text = text.replace ("%ROUND_ROBIN_MODE%", Integer.toString (getRoundRobinMode (multisampleSource)));
             }
             text = text.replace ("%PITCHBEND_RANGE%", Integer.toString (pitchBend));
@@ -247,8 +257,10 @@ public class AbletonCreator extends AbstractWavCreator<AbletonCreatorUI>
     }
 
 
-    private static String addGroups (final List<IGroup> groups, final String multiSamplePartTemplate, final String sampleSubFolder, final Map<String, File> writtenSamples) throws IOException
+    private static String addGroups (final List<IGroup> groups, final String multiSamplePartTemplate, final String sampleSubFolder, final Map<String, File> writtenSamples, final boolean selectorRoundRobin) throws IOException
     {
+        final Map<ISampleZone, int []> selectorRanges = selectorRoundRobin ? calculateSelectorRanges (groups) : Collections.emptyMap ();
+
         int zoneCount = 0;
         final StringBuilder result = new StringBuilder ();
         for (final IGroup group: groups)
@@ -256,14 +268,72 @@ public class AbletonCreator extends AbstractWavCreator<AbletonCreatorUI>
             {
                 if (zoneCount > 0)
                     result.append ('\n');
-                result.append (addZoneData (zone, zoneCount, multiSamplePartTemplate, sampleSubFolder, writtenSamples));
+                result.append (addZoneData (zone, zoneCount, multiSamplePartTemplate, sampleSubFolder, writtenSamples, selectorRanges.get (zone)));
                 zoneCount++;
             }
         return result.toString ();
     }
 
 
-    private static String addZoneData (final ISampleZone zone, final int zoneCount, final String multiSamplePartTemplate, final String sampleSubFolder, final Map<String, File> writtenSamples) throws IOException
+    /**
+     * Calculate the sample-select (selector) range of each alternating (round-robin or random)
+     * zone. The cycles are spread evenly across the 0-127 selector axis, therefore only the zones
+     * of the first cycle are heard at the default selector position and the other cycles can be
+     * reached by modulating the sample selector. Zones which always play keep the full range.
+     *
+     * @param groups The groups with the zones
+     * @return The selector range (low, high) of each alternating zone
+     */
+    private static Map<ISampleZone, int []> calculateSelectorRanges (final List<IGroup> groups)
+    {
+        // Collect the distinct cycle positions of all alternating zones
+        final TreeSet<Integer> positions = new TreeSet<> ();
+        for (final IGroup group: groups)
+            for (final ISampleZone zone: group.getSampleZones ())
+                if (zone.getPlayLogic () != PlayLogic.ALWAYS)
+                    positions.add (Integer.valueOf (Math.max (1, zone.getSequencePosition ())));
+
+        final Map<ISampleZone, int []> selectorRanges = new HashMap<> ();
+        if (positions.size () > 1)
+        {
+            final List<Integer> orderedPositions = new ArrayList<> (positions);
+            for (final IGroup group: groups)
+                for (final ISampleZone zone: group.getSampleZones ())
+                    if (zone.getPlayLogic () != PlayLogic.ALWAYS)
+                        selectorRanges.put (zone, calculateSelectorSlice (orderedPositions.indexOf (Integer.valueOf (Math.max (1, zone.getSequencePosition ()))), orderedPositions.size ()));
+            return selectorRanges;
+        }
+
+        // Without sequence positions each group which contains alternating zones is one cycle
+        final List<IGroup> cycleGroups = new ArrayList<> ();
+        for (final IGroup group: groups)
+            for (final ISampleZone zone: group.getSampleZones ())
+                if (zone.getPlayLogic () != PlayLogic.ALWAYS)
+                {
+                    cycleGroups.add (group);
+                    break;
+                }
+        final int count = cycleGroups.size ();
+        if (count > 1)
+            for (int i = 0; i < count; i++)
+                for (final ISampleZone zone: cycleGroups.get (i).getSampleZones ())
+                    if (zone.getPlayLogic () != PlayLogic.ALWAYS)
+                        selectorRanges.put (zone, calculateSelectorSlice (i, count));
+        return selectorRanges;
+    }
+
+
+    private static int [] calculateSelectorSlice (final int index, final int count)
+    {
+        return new int []
+        {
+            index * 128 / count,
+            (index + 1) * 128 / count - 1
+        };
+    }
+
+
+    private static String addZoneData (final ISampleZone zone, final int zoneCount, final String multiSamplePartTemplate, final String sampleSubFolder, final Map<String, File> writtenSamples, final int [] selectorRange) throws IOException
     {
         // Must use the same sanitized name which was used for writing the sample file
         final String zoneFileName = createSafeFilename (zone.getName ()) + ".wav";
@@ -300,6 +370,9 @@ public class AbletonCreator extends AbstractWavCreator<AbletonCreatorUI>
         zoneContent = zoneContent.replace ("%KEY_RANGE_HIGH_CROSSFADE%", Integer.toString (Math.min (127, keyHigh + zone.getNoteCrossfadeHigh ())));
         zoneContent = zoneContent.replace ("%VEL_RANGE_LOW_CROSSFADE%", Integer.toString (Math.max (0, velLow - zone.getVelocityCrossfadeLow ())));
         zoneContent = zoneContent.replace ("%VEL_RANGE_HIGH_CROSSFADE%", Integer.toString (Math.min (127, velHigh + zone.getVelocityCrossfadeHigh ())));
+
+        zoneContent = zoneContent.replace ("%SELECTOR_LOW%", Integer.toString (selectorRange == null ? 0 : selectorRange[0]));
+        zoneContent = zoneContent.replace ("%SELECTOR_HIGH%", Integer.toString (selectorRange == null ? 127 : selectorRange[1]));
 
         final double tune = zone.getTuning ();
         int semitones = (int) Math.round (tune);
@@ -361,17 +434,6 @@ public class AbletonCreator extends AbstractWavCreator<AbletonCreatorUI>
                 if (zone.getPlayLogic () == PlayLogic.RANDOM)
                     return AbletonTag.ROUND_ROBIN_MODE_RANDOM;
         return AbletonTag.ROUND_ROBIN_MODE_FORWARD;
-    }
-
-
-    private boolean checkRoundRobin (final IMultisampleSource multisampleSource)
-    {
-        if (!multisampleSource.hasRoundRobin ())
-            return false;
-        final boolean fullRoundRobin = multisampleSource.isFullRoundRobin ();
-        if (!fullRoundRobin)
-            this.notifier.logError ("IDS_ADV_ROUND_ROBIN_GROUPS_DO_NOT_MATCH");
-        return fullRoundRobin;
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonDetector.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -263,6 +264,7 @@ public class AbletonDetector extends AbstractDetector<MetadataSettingsUI>
         final Element samplePartsElement = getRequiredElement (mapElement, AbletonTag.TAG_SAMPLE_PARTS);
 
         final IGroup group = new DefaultGroup ("Group #1");
+        final Map<ISampleZone, int []> selectorRanges = new HashMap<> ();
 
         for (final Element multiSamplePartElement: XMLUtils.getChildElementsByName (samplePartsElement, AbletonTag.TAG_MULTI_SAMPLE_PART, false))
         {
@@ -277,12 +279,18 @@ public class AbletonDetector extends AbstractDetector<MetadataSettingsUI>
                 final String name = FileUtils.getNameWithoutType (new File (zoneName));
                 final ISampleZone zone = new DefaultSampleZone (name, sampleData);
                 readZone (zone, multiSamplePartElement);
+                selectorRanges.put (zone, readSelectorRange (multiSamplePartElement));
                 group.addSampleZone (zone);
             }
         }
 
         // Round-robin support
-        multisampleSource.setGroups (getBooleanValueAttribute (mapElement, AbletonTag.TAG_ROUND_ROBIN_ENABLE) ? applyRoundRobin (mapElement, group) : Collections.singletonList (group));
+        final List<IGroup> groups;
+        if (getBooleanValueAttribute (mapElement, AbletonTag.TAG_ROUND_ROBIN_ENABLE))
+            groups = applyRoundRobin (mapElement, group);
+        else
+            groups = applySelectorRoundRobin (group, selectorRanges);
+        multisampleSource.setGroups (groups);
 
         final Optional<IFilter> filter = readFilter (deviceElement);
         if (filter.isPresent ())
@@ -610,6 +618,115 @@ public class AbletonDetector extends AbstractDetector<MetadataSettingsUI>
         {
             // Ignore missing elements
         }
+    }
+
+
+    /**
+     * Read the sample-select (selector) range of a multi-sample part.
+     *
+     * @param multiSamplePartElement The multi-sample part element
+     * @return Low, high, cross-fade low and cross-fade high of the selector range
+     */
+    private static int [] readSelectorRange (final Element multiSamplePartElement)
+    {
+        final Element selectorRangeElement = XMLUtils.getChildElementByName (multiSamplePartElement, AbletonTag.TAG_SELECTOR_RANGE);
+        if (selectorRangeElement == null)
+            return new int []
+            {
+                0,
+                127,
+                0,
+                127
+            };
+        final int low = getIntegerValueAttribute (selectorRangeElement, AbletonTag.TAG_MINIMUM, 0);
+        final int high = getIntegerValueAttribute (selectorRangeElement, AbletonTag.TAG_MAXIMUM, 127);
+        return new int []
+        {
+            low,
+            high,
+            getIntegerValueAttribute (selectorRangeElement, AbletonTag.TAG_CROSSFADE_MINIMUM, low),
+            getIntegerValueAttribute (selectorRangeElement, AbletonTag.TAG_CROSSFADE_MAXIMUM, high)
+        };
+    }
+
+
+    /**
+     * Detect round-robin cycles which are stored on the sample-select (selector) axis, the only
+     * way to store them before the round-robin flag was added in Live 12: zones which occupy the
+     * same key and velocity range but disjoint selector ranges play one at a time depending on the
+     * selector position. Such zones are split into one group per selector slice in ascending
+     * selector order. Zones with overlapping selector ranges or with selector cross-fades (a
+     * morphing setup rather than round-robin) are left as they are.
+     *
+     * @param group The group with all read zones
+     * @param selectorRanges The selector range of each zone
+     * @return The resulting groups
+     */
+    private static List<IGroup> applySelectorRoundRobin (final IGroup group, final Map<ISampleZone, int []> selectorRanges)
+    {
+        final Map<String, List<ISampleZone>> clusters = new LinkedHashMap<> ();
+        for (final ISampleZone zone: group.getSampleZones ())
+            clusters.computeIfAbsent (zone.getKeyLow () + "," + zone.getKeyHigh () + "," + zone.getVelocityLow () + "," + zone.getVelocityHigh (), _ -> new ArrayList<> ()).add (zone);
+
+        final Set<List<ISampleZone>> roundRobinClusters = new HashSet<> ();
+        for (final List<ISampleZone> cluster: clusters.values ())
+            if (isSelectorRoundRobin (cluster, selectorRanges))
+                roundRobinClusters.add (cluster);
+        if (roundRobinClusters.isEmpty ())
+            return Collections.singletonList (group);
+
+        final List<IGroup> groups = new ArrayList<> ();
+        for (final List<ISampleZone> cluster: clusters.values ())
+        {
+            if (roundRobinClusters.contains (cluster))
+                cluster.sort ((zone1, zone2) -> Integer.compare (selectorRanges.get (zone1)[0], selectorRanges.get (zone2)[0]));
+            for (int i = 0; i < cluster.size (); i++)
+            {
+                final ISampleZone zone = cluster.get (i);
+                final int groupIndex;
+                if (roundRobinClusters.contains (cluster))
+                {
+                    zone.setPlayLogic (PlayLogic.ROUND_ROBIN);
+                    zone.setSequencePosition (i + 1);
+                    groupIndex = i;
+                }
+                else
+                    groupIndex = 0;
+                while (groups.size () <= groupIndex)
+                    groups.add (new DefaultGroup ("Group #" + (groups.size () + 1)));
+                groups.get (groupIndex).addSampleZone (zone);
+            }
+        }
+        return groups;
+    }
+
+
+    /**
+     * Check if the zones of the cluster form a round-robin setup on the selector axis: at least
+     * two zones which all have no selector cross-fade and do not overlap each other.
+     *
+     * @param cluster The zones which occupy the same key and velocity range
+     * @param selectorRanges The selector range of each zone
+     * @return True if the cluster is a round-robin setup
+     */
+    private static boolean isSelectorRoundRobin (final List<ISampleZone> cluster, final Map<ISampleZone, int []> selectorRanges)
+    {
+        if (cluster.size () < 2)
+            return false;
+
+        final List<int []> ranges = new ArrayList<> ();
+        for (final ISampleZone zone: cluster)
+        {
+            final int [] range = selectorRanges.get (zone);
+            if (range[2] != range[0] || range[3] != range[1])
+                return false;
+            ranges.add (range);
+        }
+        ranges.sort ((range1, range2) -> Integer.compare (range1[0], range2[0]));
+        for (int i = 1; i < ranges.size (); i++)
+            if (ranges.get (i)[0] <= ranges.get (i - 1)[1])
+                return false;
+        return true;
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonTag.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/ableton/AbletonTag.java
@@ -75,6 +75,8 @@ public class AbletonTag
     public static final String TAG_KEY_RANGE               = "KeyRange";
     /** The velocity-range tag. */
     public static final String TAG_VELOCITY_RANGE          = "VelocityRange";
+    /** The sample-select (selector) range tag. */
+    public static final String TAG_SELECTOR_RANGE          = "SelectorRange";
     /** The minimum tag. */
     public static final String TAG_MINIMUM                 = "Min";
     /** The maximum tag. */

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -159,7 +159,7 @@ IDS_1010_MUSIC_WRONG_VERSION=Only version 1 is supported but found %1.
 IDS_1010_SOURCE_CONTAINS_OVERLAPS=The source multi-sample contains overlapping sample zones which is not supported by the 1010 samplers.\nOverlapping sample zones have been removed from the output.\n
 
 IDS_ADV_NOT_A_SAMPLER_PRESET=Not a sampler preset file.\n
-IDS_ADV_ROUND_ROBIN_GROUPS_DO_NOT_MATCH=Round robin configuration could not be translated to ADV (all groups need to be part of round-robin).\n
+IDS_ADV_ROUND_ROBIN_VIA_SELECTOR=Round-robin cycles are stored as sample-select (selector) ranges.\n
 
 IDS_AKP_VERSION=Detected Akai Preset (%1).\n
 IDS_AKM_VERSION=Detected Akai Multi (%2 - %1).\n

--- a/src/main/resources/de/mossgrabers/convertwithmoss/templates/adv/ADV-MultiSamplePart-Template.xml
+++ b/src/main/resources/de/mossgrabers/convertwithmoss/templates/adv/ADV-MultiSamplePart-Template.xml
@@ -17,10 +17,10 @@
 							<CrossfadeMax Value="%VEL_RANGE_HIGH_CROSSFADE%" />
 						</VelocityRange>
 						<SelectorRange>
-							<Min Value="0" />
-							<Max Value="127" />
-							<CrossfadeMin Value="0" />
-							<CrossfadeMax Value="127" />
+							<Min Value="%SELECTOR_LOW%" />
+							<Max Value="%SELECTOR_HIGH%" />
+							<CrossfadeMin Value="%SELECTOR_LOW%" />
+							<CrossfadeMax Value="%SELECTOR_HIGH%" />
 						</SelectorRange>
 						<RootKey Value="%ROOT_KEY%" />
 						<Detune Value="%DETUNE%" />


### PR DESCRIPTION
Zones which occupy the same key and velocity range but disjoint `SelectorRange`s are the classic Sampler round-robin: the sample selector picks one of them, and it is the only round-robin representation the Sampler of Live 10 and 11 has - the `RoundRobin` flag only exists in Live 12.

Reading such a preset produced one group with all cycles stacked on top of each other, i.e. every cycle sounding at once instead of one at a time. They are now split into one group per selector slice, in ascending selector order, and marked as round-robin.

Writing uses the selector representation whenever the Live 12 flag is not available (the *Ableton Version* option set to 11) or does not apply because only some of the groups alternate - the case which previously logged that the configuration could not be translated and then wrote the cycles stacked. At the default selector position only the first cycle sounds and the other cycles are reachable by modulating the sample selector.

Verified by round tripping in both directions.