### PR TITLE
Add support for the Teenage Engineering OP-XY format (#72)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Many thanks to Douglas Carmichael for plenty of contributions and fixes!
 * Many thanks to David García Goñi for providing specifications of the E-mu formats and refined Kurzweil specifications!
 * Many thanks to Linus Wileryd for the improved icon set!
+* New: Added support for the Teenage Engineering OP-XY multi-sample preset format (reading and writing of the *.preset folders with their patch.json description file).
 * New: Added support for the Arturia Synclavier V format (reading and writing of SYNX preset and bank exports; partials which play a sound file become sample zones).
 * New: Added support for the E-mu Emulator III/IIIX/ESI bank format (E3B, E3X, ESI).
 * New: Added support for the E-mu Emulator IV bank format (E4B). Banks can also be read directly from CD-ROM and hard disk images of the EOS samplers (ISO, IMG, HDA), including via the ISO/IMG source format. New: Writing creates a bank as a ready-to-use CD-ROM image for SCSI CD-ROM emulators (e.g. ZuluSCSI), which is the only way to load banks on units running EOS versions before 4.7. Written banks have not been tested on real hardware yet.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -851,6 +851,14 @@ TAL-Sampler is an analog modeled synthesizer with a sampler engine as the sound 
 Choosing TAL Sampler as the destination format, creates a *talsmpl*
 file and stores all samples in a sub-folder by the same name. The samples of the source groups are distributed across the 4 layers of TAL Sampler in such a way that the key and velocity splits do not overlap. This is a workaround for the fact that TAL Sampler does not support overlapping samples. Since groups have only the name and trigger type as attributes, which are not supported in TAL Sampler anyway, this should work in most cases. If there are still overlapping samples a warning is displayed.
 
+## Teenage Engineering OP-XY
+
+The OP-XY is a portable sampler and sequencer from Teenage Engineering. Its multi-sample presets are open: a preset is a folder with the ending *.preset* which contains all samples as WAV files and a *patch.json* file with the mapping and the settings of the synthesizer engine.
+
+Reading a preset gives the key range, root key, tuning, gain, play range and loop of every region, plus the amplitude envelope and the pitch bend range which the device stores once for the whole preset.
+
+Writing creates such a folder, which only needs to be copied to the device. Note the limits of the format: it maps a preset only across the keyboard, so of several zones which cover the same keys only the one which plays at the highest velocity is kept, and the device plays at most 24 regions per preset. The regions are written as the device expects them, i.e. covering the keyboard without gaps: a region ends at its own upper key and starts one key above the previous one. Samples are written as 16 bit WAV files with at most 44.1 kHz.
+
 ## Waldorf Quantum MkI, MkII / Iridium / Iridium Core
 
 This family of Waldorf synthesizers supports the playback of multi-samples. One preset can contain 2 layers. A layer is a complete preset in itself and simply concatenates 2 single presets. Each preset can have up to 3 oscillators of which each oscillator can contain its own multi-sample.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -857,7 +857,7 @@ The OP-XY is a portable sampler and sequencer from Teenage Engineering. Its mult
 
 Reading a preset gives the key range, root key, tuning, gain, play range and loop of every region, plus the amplitude envelope and the pitch bend range which the device stores once for the whole preset.
 
-Writing creates such a folder, which only needs to be copied to the device. Note the limits of the format: it maps a preset only across the keyboard, so of several zones which cover the same keys only the one which plays at the highest velocity is kept, and the device plays at most 24 regions per preset. The regions are written as the device expects them, i.e. covering the keyboard without gaps: a region ends at its own upper key and starts one key above the previous one. Samples are written as 16 bit WAV files with at most 44.1 kHz.
+Writing creates such a folder, which only needs to be copied to the device. Note the limits which the device manual states: a preset holds at most 24 zones, a sample may be at most 20 seconds long (longer ones are reported), and multiple velocities are not supported - of several zones which cover the same keys only the one which plays at the highest velocity is kept. The regions are written as the device expects them, i.e. covering the keyboard without gaps: a region ends at its own upper key and starts one key above the previous one. Samples are written as 16 bit WAV files with at most 44.1 kHz.
 
 ## Waldorf Quantum MkI, MkII / Iridium / Iridium Core
 

--- a/documentation/SupportedFeaturesSampleFormats.fods
+++ b/documentation/SupportedFeaturesSampleFormats.fods
@@ -8923,6 +8923,150 @@
      <table:table-cell table:number-columns-repeated="67"/>
      <table:table-cell table:style-name="ce7" table:number-columns-repeated="16248"/>
     </table:table-row>
+    <table:table-row table:style-name="ro5">
+     <table:table-cell table:style-name="ce2" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>Teenage Engineering OP-XY</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Read</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce10" office:value-type="string" calcext:value-type="string"><text:p>preset folder</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce13" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce13" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>All</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" office:value-type="string" calcext:value-type="string"><text:p>All</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce17"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>from the preset folder name</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>from filename</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce63" office:value-type="string" calcext:value-type="string"><text:p>from filename</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce4"/>
+     <table:table-cell table:style-name="ce10" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>pitch.keycenter</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce4" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>lokey / hikey</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>The format has no velocity ranges</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce4" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>sample.start</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce4" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>sample.end</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>tune (semitones)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce10" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>reverse</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce4" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>gain</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>loop.enabled</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce17" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>Forward only</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce56" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>loop.onrelease</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce4" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>loop.start</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce4" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>loop.end</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce10" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>loop.crossfade</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>Global only</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce17" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>envelope.amp (global, A/D/S/R)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce21"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>Global only</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce17" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>engine.bendrange (global)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce17" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>engine.bendrange (global)</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce12" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce21"/>
+     <table:table-cell table:style-name="ce14"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1" office:value-type="string" calcext:value-type="string"><text:p>TODO Check for support</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:style-name="ce14" table:number-rows-spanned="2" table:number-columns-spanned="1"/>
+     <table:table-cell table:number-columns-repeated="16315"/>
+    </table:table-row>
+    <table:table-row table:style-name="ro10">
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string"><text:p>Write</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce10" office:value-type="string" calcext:value-type="string"><text:p>preset folder</text:p></table:table-cell>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>16</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>Up to 44.1 kHz</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce3"/>
+     <table:table-cell table:style-name="ce17"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>the preset folder name</text:p></table:table-cell>
+     <table:table-cell table:style-name="ce12"/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce12"/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce4"/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>loop.enabled</text:p></table:table-cell>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce23"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>Global only</text:p></table:table-cell>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce21"/>
+     <table:table-cell table:style-name="ce17" office:value-type="string" calcext:value-type="string"><text:p>Global only</text:p></table:table-cell>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:style-name="ce21"/>
+     <table:table-cell table:style-name="ce14"/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:covered-table-cell/>
+     <table:table-cell table:number-columns-repeated="16315"/>
+    </table:table-row>
     <table:table-row table:style-name="ro2">
      <table:table-cell table:style-name="ce2" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
       <text:p>Waldorf Qpat</text:p>

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/ConverterBackend.java
@@ -109,6 +109,8 @@ import de.mossgrabers.convertwithmoss.format.synthstrom.DelugeCreator;
 import de.mossgrabers.convertwithmoss.format.synthstrom.DelugeDetector;
 import de.mossgrabers.convertwithmoss.format.tal.TALSamplerCreator;
 import de.mossgrabers.convertwithmoss.format.tal.TALSamplerDetector;
+import de.mossgrabers.convertwithmoss.format.teenage.opxy.OpXyCreator;
+import de.mossgrabers.convertwithmoss.format.teenage.opxy.OpXyDetector;
 import de.mossgrabers.convertwithmoss.format.tx16wx.TX16WxCreator;
 import de.mossgrabers.convertwithmoss.format.tx16wx.TX16WxDetector;
 import de.mossgrabers.convertwithmoss.format.waldorf.qpat.WaldorfQpatCreator;
@@ -225,6 +227,7 @@ public class ConverterBackend
         this.detectors.add (new SynclavierRegenDetector (notifier));
         this.detectors.add (new SynclavierVDetector (notifier));
         this.detectors.add (new DelugeDetector (notifier));
+        this.detectors.add (new OpXyDetector (notifier));
         this.detectors.add (new TALSamplerDetector (notifier));
         this.detectors.add (new WaldorfQpatDetector (notifier));
         this.detectors.add (new YamahaYsfcDetector (notifier));
@@ -264,6 +267,7 @@ public class ConverterBackend
         this.creators.add (new SynclavierRegenCreator (notifier));
         this.creators.add (new SynclavierVCreator (notifier));
         this.creators.add (new DelugeCreator (notifier));
+        this.creators.add (new OpXyCreator (notifier));
         this.creators.add (new TALSamplerCreator (notifier));
         this.creators.add (new WaldorfQpatCreator (notifier));
         this.creators.add (new YamahaYsfcCreator (notifier));

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyCreator.java
@@ -86,6 +86,7 @@ public class OpXyCreator extends AbstractWavCreator<WavChunkSettingsUI>
             return;
         }
 
+        this.checkSampleLengths (zones);
         this.writeSamples (presetFolder, multisampleSource, DESTINATION_FORMAT);
         Files.write (patchFile.toPath (), this.createPatch (zones).getBytes (StandardCharsets.UTF_8));
 
@@ -133,6 +134,30 @@ public class OpXyCreator extends AbstractWavCreator<WavChunkSettingsUI>
             return zones.subList (0, MAX_REGIONS);
         }
         return zones;
+    }
+
+
+    /**
+     * Warn about samples which are longer than the device plays.
+     *
+     * @param zones The zones to check
+     * @throws IOException Could not read the audio metadata
+     */
+    private void checkSampleLengths (final List<ISampleZone> zones) throws IOException
+    {
+        int tooLong = 0;
+        for (final ISampleZone zone: zones)
+        {
+            final Optional<ISampleData> sampleData = zone.getSampleData ();
+            if (sampleData.isEmpty ())
+                continue;
+            final IAudioMetadata audioMetadata = sampleData.get ().getAudioMetadata ();
+            final int sampleRate = audioMetadata.getSampleRate ();
+            if (sampleRate > 0 && audioMetadata.getNumberOfSamples () / (double) sampleRate > OpXyTag.MAX_SAMPLE_SECONDS)
+                tooLong++;
+        }
+        if (tooLong > 0)
+            this.notifier.log ("IDS_OPXY_SAMPLE_TOO_LONG", Integer.toString (tooLong), Integer.toString ((int) OpXyTag.MAX_SAMPLE_SECONDS));
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyCreator.java
@@ -1,0 +1,246 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.teenage.opxy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.INotifier;
+import de.mossgrabers.convertwithmoss.core.creator.AbstractWavCreator;
+import de.mossgrabers.convertwithmoss.core.creator.DestinationAudioFormat;
+import de.mossgrabers.convertwithmoss.core.model.IAudioMetadata;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
+import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
+import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.core.settings.WavChunkSettingsUI;
+import de.mossgrabers.tools.ui.Functions;
+
+
+/**
+ * Creator for Teenage Engineering OP-XY presets. A preset is a folder with the ending
+ * <i>.preset</i> which contains the description file <i>patch.json</i> and all samples as WAV
+ * files.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class OpXyCreator extends AbstractWavCreator<WavChunkSettingsUI>
+{
+    /** The device plays 16 bit / 44.1 kHz samples. */
+    private static final DestinationAudioFormat DESTINATION_FORMAT = new DestinationAudioFormat (new int []
+    {
+        16
+    }, 44100, false);
+
+    private static final int                    MAX_REGIONS        = 24;
+
+    private final ObjectMapper                  mapper             = new ObjectMapper ();
+
+
+    /**
+     * Constructor.
+     *
+     * @param notifier The notifier
+     */
+    public OpXyCreator (final INotifier notifier)
+    {
+        super ("Teenage Engineering OP-XY", "OPXY", notifier, new WavChunkSettingsUI ("OPXY"));
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    public void createPreset (final File destinationFolder, final IMultisampleSource multisampleSource) throws IOException
+    {
+        final String safeName = createSafeFilename (multisampleSource.getName ());
+
+        final File presetFolder = this.createUniqueFilename (destinationFolder, safeName, "preset");
+        if (!presetFolder.mkdirs ())
+        {
+            this.notifier.logError ("IDS_NOTIFY_FOLDER_COULD_NOT_BE_CREATED", presetFolder.getAbsolutePath ());
+            return;
+        }
+
+        final File patchFile = new File (presetFolder, OpXyTag.PATCH_FILE);
+        this.notifier.log ("IDS_NOTIFY_STORING", patchFile.getAbsolutePath ());
+
+        final List<ISampleZone> zones = this.collectZones (multisampleSource);
+        if (zones.isEmpty ())
+        {
+            this.notifier.logError ("IDS_OPXY_NO_REGIONS", presetFolder.getAbsolutePath ());
+            return;
+        }
+
+        this.writeSamples (presetFolder, multisampleSource, DESTINATION_FORMAT);
+        Files.write (patchFile.toPath (), this.createPatch (zones).getBytes (StandardCharsets.UTF_8));
+
+        this.progress.notifyDone ();
+    }
+
+
+    /**
+     * Collect the zones to write. The device maps a preset only across the keyboard, therefore
+     * only the zones of the first velocity layer are written; it also plays at most
+     * {@link #MAX_REGIONS} regions.
+     *
+     * @param multisampleSource The multi-sample source
+     * @return The zones sorted by their key range
+     */
+    private List<ISampleZone> collectZones (final IMultisampleSource multisampleSource)
+    {
+        // The format maps only across the keyboard: of all zones which cover the same key range
+        // the one which plays at the highest velocity is kept
+        final Map<Integer, ISampleZone> zonesByKey = new TreeMap<> ();
+        int dropped = 0;
+        for (final IGroup group: multisampleSource.getNonEmptyGroups (false))
+            for (final ISampleZone zone: group.getSampleZones ())
+            {
+                final Integer highKey = Integer.valueOf (Math.clamp (limitToDefault (zone.getKeyHigh (), 127), 0, 127));
+                final ISampleZone present = zonesByKey.get (highKey);
+                if (present == null)
+                {
+                    zonesByKey.put (highKey, zone);
+                    continue;
+                }
+                dropped++;
+                if (limitToDefault (zone.getVelocityHigh (), 127) > limitToDefault (present.getVelocityHigh (), 127))
+                    zonesByKey.put (highKey, zone);
+            }
+
+        if (dropped > 0)
+            this.notifier.log ("IDS_OPXY_DROPPED_VELOCITY_LAYERS", Integer.toString (dropped));
+
+        final List<ISampleZone> zones = new ArrayList<> (zonesByKey.values ());
+
+        if (zones.size () > MAX_REGIONS)
+        {
+            this.notifier.log ("IDS_OPXY_TOO_MANY_REGIONS", Integer.toString (zones.size ()), Integer.toString (MAX_REGIONS));
+            return zones.subList (0, MAX_REGIONS);
+        }
+        return zones;
+    }
+
+
+    /**
+     * Create the content of the description file.
+     *
+     * @param zones The zones to write
+     * @return The JSON document
+     * @throws IOException Could not create the document
+     */
+    private String createPatch (final List<ISampleZone> zones) throws IOException
+    {
+        final ObjectNode root = this.mapper.createObjectNode ();
+        root.put (OpXyTag.TAG_TYPE, OpXyTag.TYPE_MULTISAMPLER);
+        root.put (OpXyTag.TAG_PLATFORM, OpXyTag.PLATFORM);
+        root.put (OpXyTag.TAG_VERSION, 4);
+        root.put (OpXyTag.TAG_OCTAVE, 0);
+
+        final ISampleZone firstZone = zones.get (0);
+
+        final ObjectNode engine = root.putObject (OpXyTag.TAG_ENGINE);
+        engine.put (OpXyTag.TAG_PLAYMODE, OpXyTag.PLAYMODE_POLY);
+        engine.put (OpXyTag.TAG_TRANSPOSE, 0);
+        engine.put (OpXyTag.TAG_VOLUME, OpXyTag.CENTER_VALUE);
+        final int bendUp = firstZone.getBendUp ();
+        if (bendUp > 0)
+            engine.put (OpXyTag.TAG_BEND_RANGE, OpXyTag.fromFactor (bendUp / 100.0 / OpXyTag.MAX_BEND_RANGE));
+
+        final IEnvelope ampEnvelope = firstZone.getAmplitudeEnvelopeModulator ().getSource ();
+        final ObjectNode amp = root.putObject (OpXyTag.TAG_ENVELOPE).putObject (OpXyTag.TAG_AMP);
+        putEnvelopeTime (amp, OpXyTag.TAG_ATTACK, ampEnvelope.getAttackTime (), 0);
+        putEnvelopeTime (amp, OpXyTag.TAG_DECAY, Math.max (0, ampEnvelope.getHoldTime ()) + Math.max (0, ampEnvelope.getDecayTime ()), OpXyTag.MAX_VALUE);
+        amp.put (OpXyTag.TAG_SUSTAIN, ampEnvelope.getSustainLevel () < 0 ? OpXyTag.MAX_VALUE : OpXyTag.fromFactor (ampEnvelope.getSustainLevel ()));
+        putEnvelopeTime (amp, OpXyTag.TAG_RELEASE, ampEnvelope.getReleaseTime (), 0);
+
+        final ArrayNode regions = root.putArray (OpXyTag.TAG_REGIONS);
+        // The device expects the regions to cover the keyboard without gaps: each region ends at
+        // its own upper key and starts one key above the previous one
+        int lowKey = 0;
+        for (final ISampleZone zone: zones)
+        {
+            final int highKey = Math.clamp (limitToDefault (zone.getKeyHigh (), 127), 0, 127);
+            regions.add (this.createRegion (zone, lowKey, highKey));
+            lowKey = highKey + 1;
+        }
+
+        return this.mapper.writerWithDefaultPrettyPrinter ().writeValueAsString (root);
+    }
+
+
+    /**
+     * Create one region from a zone.
+     *
+     * @param zone The zone
+     * @param lowKey The lowest key of the region
+     * @param highKey The highest key of the region
+     * @return The region
+     * @throws IOException Could not read the audio metadata
+     */
+    private ObjectNode createRegion (final ISampleZone zone, final int lowKey, final int highKey) throws IOException
+    {
+        final Optional<ISampleData> sampleData = zone.getSampleData ();
+        if (sampleData.isEmpty ())
+            throw new IOException (Functions.getMessage ("IDS_NOTIFY_ERR_MISSING_SAMPLE_DATA", zone.getName (), ""));
+        final IAudioMetadata audioMetadata = sampleData.get ().getAudioMetadata ();
+        final int frames = audioMetadata.getNumberOfSamples ();
+
+        final ObjectNode region = this.mapper.createObjectNode ();
+        region.put (OpXyTag.TAG_SAMPLE, createSafeFilename (zone.getName ()) + ".wav");
+        region.put (OpXyTag.TAG_FRAME_COUNT, frames);
+        region.put (OpXyTag.TAG_LOW_KEY, lowKey);
+        region.put (OpXyTag.TAG_HIGH_KEY, highKey);
+        region.put (OpXyTag.TAG_KEY_CENTER, Math.clamp (limitToDefault (zone.getKeyRoot (), highKey), 0, 127));
+        region.put (OpXyTag.TAG_GAIN, (int) Math.round (zone.getGain ()));
+        region.put (OpXyTag.TAG_TUNE, (int) Math.round (zone.getTuning ()));
+        region.put (OpXyTag.TAG_REVERSE, zone.isReversed ());
+
+        final int start = Math.clamp (zone.getStart (), 0, frames);
+        final int stop = zone.getStop () <= 0 ? frames : Math.clamp (zone.getStop (), start, frames);
+        region.put (OpXyTag.TAG_SAMPLE_START, start);
+        region.put (OpXyTag.TAG_SAMPLE_END, stop);
+
+        final List<ISampleLoop> loops = zone.getLoops ();
+        final boolean hasLoop = !loops.isEmpty ();
+        region.put (OpXyTag.TAG_LOOP_ENABLED, hasLoop);
+        if (hasLoop)
+        {
+            final ISampleLoop loop = loops.get (0);
+            region.put (OpXyTag.TAG_LOOP_START, Math.clamp (loop.getStart (), 0, frames));
+            region.put (OpXyTag.TAG_LOOP_END, Math.clamp (loop.getEnd (), 0, frames));
+            region.put (OpXyTag.TAG_LOOP_CROSSFADE, Math.max (0, loop.getCrossfadeInSamples ()));
+            region.put (OpXyTag.TAG_LOOP_ON_RELEASE, loop.isLoopUntilRelease ());
+        }
+        else
+        {
+            region.put (OpXyTag.TAG_LOOP_START, 0);
+            region.put (OpXyTag.TAG_LOOP_END, stop);
+            region.put (OpXyTag.TAG_LOOP_CROSSFADE, 0);
+            region.put (OpXyTag.TAG_LOOP_ON_RELEASE, false);
+        }
+
+        return region;
+    }
+
+
+    private static void putEnvelopeTime (final ObjectNode node, final String name, final double time, final int defaultValue)
+    {
+        final int value = OpXyTag.fromEnvelopeTime (time);
+        node.put (name, value < 0 ? defaultValue : value);
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyDetector.java
@@ -1,0 +1,232 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.teenage.opxy;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
+import de.mossgrabers.convertwithmoss.core.INotifier;
+import de.mossgrabers.convertwithmoss.core.detector.AbstractDetector;
+import de.mossgrabers.convertwithmoss.core.model.IEnvelope;
+import de.mossgrabers.convertwithmoss.core.model.IGroup;
+import de.mossgrabers.convertwithmoss.core.model.ISampleData;
+import de.mossgrabers.convertwithmoss.core.model.ISampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.ISampleZone;
+import de.mossgrabers.convertwithmoss.core.model.enumeration.LoopType;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultGroup;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleLoop;
+import de.mossgrabers.convertwithmoss.core.model.implementation.DefaultSampleZone;
+import de.mossgrabers.convertwithmoss.core.settings.MetadataSettingsUI;
+import de.mossgrabers.tools.FileUtils;
+
+
+/**
+ * Detects Teenage Engineering OP-XY presets. A preset is a folder with the ending <i>.preset</i>
+ * which contains the description file <i>patch.json</i> and all samples as WAV files.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class OpXyDetector extends AbstractDetector<MetadataSettingsUI>
+{
+    private final ObjectMapper mapper = new ObjectMapper ();
+
+
+    /**
+     * Constructor.
+     *
+     * @param notifier The notifier
+     */
+    public OpXyDetector (final INotifier notifier)
+    {
+        super ("Teenage Engineering OP-XY", "OPXY", notifier, new MetadataSettingsUI ("OPXY"), ".json");
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
+    protected List<IMultisampleSource> readPresetFile (final File file)
+    {
+        // Only the description file of a preset is of interest
+        if (!OpXyTag.PATCH_FILE.equalsIgnoreCase (file.getName ()))
+            return Collections.emptyList ();
+
+        if (this.waitForDelivery ())
+            return Collections.emptyList ();
+
+        try
+        {
+            final JsonNode root = this.mapper.readTree (file);
+            final JsonNode typeNode = root.get (OpXyTag.TAG_TYPE);
+            if (typeNode == null || !OpXyTag.TYPE_MULTISAMPLER.equals (typeNode.asText ()))
+            {
+                this.notifier.logError ("IDS_OPXY_NOT_A_MULTISAMPLE", file.getAbsolutePath ());
+                return Collections.emptyList ();
+            }
+            return this.parsePatch (file, root);
+        }
+        catch (final IOException ex)
+        {
+            this.notifier.logError ("IDS_NOTIFY_ERR_LOAD_FILE", ex);
+            return Collections.emptyList ();
+        }
+    }
+
+
+    /**
+     * Parse the description file of a preset.
+     *
+     * @param file The description file
+     * @param root The parsed JSON document
+     * @return The multi-sample source
+     * @throws IOException Could not read a sample
+     */
+    private List<IMultisampleSource> parsePatch (final File file, final JsonNode root) throws IOException
+    {
+        final File presetFolder = file.getParentFile ();
+        final IGroup group = new DefaultGroup ("Group #1");
+
+        final JsonNode regionsNode = root.get (OpXyTag.TAG_REGIONS);
+        if (regionsNode != null)
+            for (final JsonNode regionNode: regionsNode)
+            {
+                final ISampleZone zone = this.parseRegion (presetFolder, regionNode);
+                if (zone != null)
+                    group.addSampleZone (zone);
+            }
+
+        if (group.getSampleZones ().isEmpty ())
+        {
+            this.notifier.logError ("IDS_OPXY_NO_REGIONS", file.getAbsolutePath ());
+            return Collections.emptyList ();
+        }
+
+        applyGlobals (root, group);
+
+        final IMultisampleSource multisampleSource = this.createMultisampleSource (file, getPresetName (presetFolder));
+        multisampleSource.setGroups (Collections.singletonList (group));
+        return Collections.singletonList (multisampleSource);
+    }
+
+
+    /**
+     * Parse one region into a sample zone.
+     *
+     * @param presetFolder The folder which contains the samples
+     * @param regionNode The region to parse
+     * @return The zone or null if the sample could not be found
+     * @throws IOException Could not read the sample
+     */
+    private ISampleZone parseRegion (final File presetFolder, final JsonNode regionNode) throws IOException
+    {
+        final String sampleName = getText (regionNode, OpXyTag.TAG_SAMPLE, null);
+        if (sampleName == null || sampleName.isBlank ())
+            return null;
+        final File sampleFile = new File (presetFolder, sampleName);
+        if (!sampleFile.exists ())
+        {
+            this.notifier.logError ("IDS_NOTIFY_ERR_SAMPLE_DOES_NOT_EXIST", sampleFile.getAbsolutePath ());
+            return null;
+        }
+
+        final ISampleData sampleData = createSampleData (sampleFile, this.notifier);
+        final ISampleZone zone = new DefaultSampleZone (FileUtils.getNameWithoutType (sampleFile), sampleData);
+
+        zone.setKeyLow (Math.clamp (getInt (regionNode, OpXyTag.TAG_LOW_KEY, 0), 0, 127));
+        zone.setKeyHigh (Math.clamp (getInt (regionNode, OpXyTag.TAG_HIGH_KEY, 127), 0, 127));
+        zone.setKeyRoot (Math.clamp (getInt (regionNode, OpXyTag.TAG_KEY_CENTER, 60), 0, 127));
+        zone.setTuning (getInt (regionNode, OpXyTag.TAG_TUNE, 0));
+        zone.setGain (getInt (regionNode, OpXyTag.TAG_GAIN, 0));
+        zone.setReversed (getBoolean (regionNode, OpXyTag.TAG_REVERSE));
+        zone.setStart (getInt (regionNode, OpXyTag.TAG_SAMPLE_START, 0));
+        zone.setStop (getInt (regionNode, OpXyTag.TAG_SAMPLE_END, -1));
+
+        if (getBoolean (regionNode, OpXyTag.TAG_LOOP_ENABLED))
+        {
+            final ISampleLoop loop = new DefaultSampleLoop ();
+            loop.setType (LoopType.FORWARDS);
+            loop.setStart (getInt (regionNode, OpXyTag.TAG_LOOP_START, 0));
+            loop.setEnd (getInt (regionNode, OpXyTag.TAG_LOOP_END, zone.getStop ()));
+            loop.setCrossfadeInSamples (getInt (regionNode, OpXyTag.TAG_LOOP_CROSSFADE, 0));
+            loop.setLoopUntilRelease (getBoolean (regionNode, OpXyTag.TAG_LOOP_ON_RELEASE));
+            zone.getLoops ().add (loop);
+        }
+
+        return zone;
+    }
+
+
+    /**
+     * Apply the settings which the device stores for the whole preset to all zones.
+     *
+     * @param root The parsed JSON document
+     * @param group The group which contains the zones
+     */
+    private static void applyGlobals (final JsonNode root, final IGroup group)
+    {
+        final JsonNode engineNode = root.get (OpXyTag.TAG_ENGINE);
+        final int bendRange = engineNode == null ? -1 : (int) Math.round (OpXyTag.toFactor (getInt (engineNode, OpXyTag.TAG_BEND_RANGE, -1)) * OpXyTag.MAX_BEND_RANGE);
+
+        final JsonNode envelopeNode = root.get (OpXyTag.TAG_ENVELOPE);
+        final JsonNode ampNode = envelopeNode == null ? null : envelopeNode.get (OpXyTag.TAG_AMP);
+
+        for (final ISampleZone zone: group.getSampleZones ())
+        {
+            if (bendRange >= 0)
+            {
+                zone.setBendUp (bendRange * 100);
+                zone.setBendDown (-bendRange * 100);
+            }
+
+            if (ampNode != null)
+            {
+                final IEnvelope envelope = zone.getAmplitudeEnvelopeModulator ().getSource ();
+                envelope.setAttackTime (OpXyTag.toEnvelopeTime (getInt (ampNode, OpXyTag.TAG_ATTACK, 0)));
+                envelope.setDecayTime (OpXyTag.toEnvelopeTime (getInt (ampNode, OpXyTag.TAG_DECAY, 0)));
+                envelope.setSustainLevel (OpXyTag.toFactor (getInt (ampNode, OpXyTag.TAG_SUSTAIN, OpXyTag.MAX_VALUE)));
+                envelope.setReleaseTime (OpXyTag.toEnvelopeTime (getInt (ampNode, OpXyTag.TAG_RELEASE, 0)));
+            }
+        }
+    }
+
+
+    /**
+     * Get the name of the preset from the name of its folder, which ends with '.preset'.
+     *
+     * @param presetFolder The folder of the preset
+     * @return The name
+     */
+    private static String getPresetName (final File presetFolder)
+    {
+        final String folderName = presetFolder.getName ();
+        return folderName.toLowerCase ().endsWith (OpXyTag.PRESET_ENDING) ? folderName.substring (0, folderName.length () - OpXyTag.PRESET_ENDING.length ()) : folderName;
+    }
+
+
+    private static int getInt (final JsonNode node, final String name, final int defaultValue)
+    {
+        final JsonNode valueNode = node.get (name);
+        return valueNode == null ? defaultValue : valueNode.asInt (defaultValue);
+    }
+
+
+    private static boolean getBoolean (final JsonNode node, final String name)
+    {
+        final JsonNode valueNode = node.get (name);
+        return valueNode != null && valueNode.asBoolean (false);
+    }
+
+
+    private static String getText (final JsonNode node, final String name, final String defaultValue)
+    {
+        final JsonNode valueNode = node.get (name);
+        return valueNode == null ? defaultValue : valueNode.asText (defaultValue);
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyTag.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyTag.java
@@ -1,0 +1,175 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.format.teenage.opxy;
+
+/**
+ * Constants of the Teenage Engineering OP-XY preset format. A preset is a folder with the ending
+ * <i>.preset</i> which contains the description file <i>patch.json</i> and all samples as WAV
+ * files.
+ *
+ * @author Jürgen Moßgraber
+ */
+public class OpXyTag
+{
+    /** The name of the description file of a preset. */
+    public static final String PATCH_FILE            = "patch.json";
+    /** The ending of a preset folder. */
+    public static final String PRESET_ENDING         = ".preset";
+
+    /** The type of a multi-sample preset. */
+    public static final String TYPE_MULTISAMPLER     = "multisampler";
+    /** The platform of the device. */
+    public static final String PLATFORM              = "OP-XY";
+
+    /** The type attribute. */
+    public static final String TAG_TYPE              = "type";
+    /** The platform attribute. */
+    public static final String TAG_PLATFORM          = "platform";
+    /** The version attribute. */
+    public static final String TAG_VERSION           = "version";
+    /** The octave attribute. */
+    public static final String TAG_OCTAVE            = "octave";
+    /** The regions which map the samples. */
+    public static final String TAG_REGIONS           = "regions";
+
+    /** The engine section. */
+    public static final String TAG_ENGINE            = "engine";
+    /** The pitch bend range of the engine. */
+    public static final String TAG_BEND_RANGE        = "bendrange";
+    /** The play mode of the engine. */
+    public static final String TAG_PLAYMODE          = "playmode";
+    /** The transpose of the engine. */
+    public static final String TAG_TRANSPOSE         = "transpose";
+    /** The volume of the engine. */
+    public static final String TAG_VOLUME            = "volume";
+
+    /** The envelope section. */
+    public static final String TAG_ENVELOPE          = "envelope";
+    /** The amplitude envelope. */
+    public static final String TAG_AMP               = "amp";
+    /** The filter envelope. */
+    public static final String TAG_FILTER            = "filter";
+    /** The attack of an envelope. */
+    public static final String TAG_ATTACK            = "attack";
+    /** The decay of an envelope. */
+    public static final String TAG_DECAY             = "decay";
+    /** The sustain of an envelope. */
+    public static final String TAG_SUSTAIN           = "sustain";
+    /** The release of an envelope. */
+    public static final String TAG_RELEASE           = "release";
+
+    /** The sample file name of a region. */
+    public static final String TAG_SAMPLE            = "sample";
+    /** The lowest key of a region. */
+    public static final String TAG_LOW_KEY           = "lokey";
+    /** The highest key of a region. */
+    public static final String TAG_HIGH_KEY          = "hikey";
+    /** The root key of a region. */
+    public static final String TAG_KEY_CENTER        = "pitch.keycenter";
+    /** The number of frames of the sample of a region. */
+    public static final String TAG_FRAME_COUNT       = "framecount";
+    /** The play start of a region. */
+    public static final String TAG_SAMPLE_START      = "sample.start";
+    /** The play end of a region. */
+    public static final String TAG_SAMPLE_END        = "sample.end";
+    /** Is the loop enabled? */
+    public static final String TAG_LOOP_ENABLED      = "loop.enabled";
+    /** Does the loop run until the key is released? */
+    public static final String TAG_LOOP_ON_RELEASE   = "loop.onrelease";
+    /** The start of the loop. */
+    public static final String TAG_LOOP_START        = "loop.start";
+    /** The end of the loop. */
+    public static final String TAG_LOOP_END          = "loop.end";
+    /** The cross-fade of the loop. */
+    public static final String TAG_LOOP_CROSSFADE    = "loop.crossfade";
+    /** The gain of a region. */
+    public static final String TAG_GAIN              = "gain";
+    /** The tuning of a region in semitones. */
+    public static final String TAG_TUNE              = "tune";
+    /** Is the sample of the region played backwards? */
+    public static final String TAG_REVERSE           = "reverse";
+
+    /** The play mode which plays several notes at once. */
+    public static final String PLAYMODE_POLY         = "poly";
+    /** The play mode which plays one note at a time. */
+    public static final String PLAYMODE_MONO         = "mono";
+    /** The play mode which plays one note at a time without re-triggering the envelope. */
+    public static final String PLAYMODE_LEGATO       = "legato";
+
+    /** The maximum value of the normalized parameters of the device. */
+    public static final int    MAX_VALUE             = 32767;
+    /** The value of a bipolar parameter at its center. */
+    public static final int    CENTER_VALUE          = 16384;
+
+    /**
+     * The longest time of an envelope in seconds. The envelope parameters are stored normalized to
+     * {@link #MAX_VALUE} and mapped with a square taper, which puts the default decay of a new
+     * preset (20295) at about 3.8 seconds.
+     */
+    public static final double ENVELOPE_MAX_TIME     = 10.0;
+    /** The exponent of the envelope taper. */
+    public static final double ENVELOPE_TIME_EXPONENT = 2.0;
+    /** The maximum pitch bend range of the device in semitones. */
+    public static final int    MAX_BEND_RANGE        = 24;
+
+
+    /**
+     * Private constructor for utility class.
+     */
+    private OpXyTag ()
+    {
+        // Intentionally empty
+    }
+
+
+    /**
+     * Convert a normalized device value into a factor in the range of [0..1].
+     *
+     * @param value The value to convert
+     * @return The factor
+     */
+    public static double toFactor (final int value)
+    {
+        return Math.clamp (value / (double) MAX_VALUE, 0, 1);
+    }
+
+
+    /**
+     * Convert a factor in the range of [0..1] into a normalized device value.
+     *
+     * @param factor The factor to convert
+     * @return The value
+     */
+    public static int fromFactor (final double factor)
+    {
+        return (int) Math.round (Math.clamp (factor, 0, 1) * MAX_VALUE);
+    }
+
+
+    /**
+     * Convert a normalized envelope value into a time in seconds.
+     *
+     * @param value The value to convert
+     * @return The time in seconds
+     */
+    public static double toEnvelopeTime (final int value)
+    {
+        return ENVELOPE_MAX_TIME * Math.pow (toFactor (value), ENVELOPE_TIME_EXPONENT);
+    }
+
+
+    /**
+     * Convert a time in seconds into a normalized envelope value.
+     *
+     * @param time The time in seconds
+     * @return The value
+     */
+    public static int fromEnvelopeTime (final double time)
+    {
+        if (time < 0)
+            return -1;
+        return fromFactor (Math.pow (time / ENVELOPE_MAX_TIME, 1.0 / ENVELOPE_TIME_EXPONENT));
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyTag.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyTag.java
@@ -113,6 +113,8 @@ public class OpXyTag
     public static final double ENVELOPE_TIME_EXPONENT = 2.0;
     /** The maximum pitch bend range of the device in semitones. */
     public static final int    MAX_BEND_RANGE        = 24;
+    /** The longest sample the device plays, in seconds. */
+    public static final double MAX_SAMPLE_SECONDS    = 20.0;
 
 
     /**

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -208,6 +208,7 @@ IDS_EIII_DEVICE_ESI=ESI-32/2000/4000 (esi)
 IDS_OPXY_NOT_A_MULTISAMPLE=Not a multi-sample preset: %1\n
 IDS_OPXY_NO_REGIONS=The preset contains no regions: %1\n
 IDS_OPXY_DROPPED_VELOCITY_LAYERS=Dropped %1 zone(s) which cover an already mapped key range, the format maps only across the keyboard.\n
+IDS_OPXY_SAMPLE_TOO_LONG=%1 sample(s) are longer than the %2 seconds which the device plays; use the processing option to trim them.\n
 IDS_OPXY_TOO_MANY_REGIONS=The preset has %1 regions but the device plays at most %2, the rest is dropped.\n
 
 IDS_DS_UNKNOWN_TRIGGER=Unknown trigger type: %1\n

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -205,6 +205,11 @@ IDS_EIII_TARGET_DEVICE=Target Device
 IDS_EIII_DEVICE_EMULATOR_3X=Emulator IIIX (e3x)
 IDS_EIII_DEVICE_ESI=ESI-32/2000/4000 (esi)
 
+IDS_OPXY_NOT_A_MULTISAMPLE=Not a multi-sample preset: %1\n
+IDS_OPXY_NO_REGIONS=The preset contains no regions: %1\n
+IDS_OPXY_DROPPED_VELOCITY_LAYERS=Dropped %1 zone(s) which cover an already mapped key range, the format maps only across the keyboard.\n
+IDS_OPXY_TOO_MANY_REGIONS=The preset has %1 regions but the device plays at most %2, the rest is dropped.\n
+
 IDS_DS_UNKNOWN_TRIGGER=Unknown trigger type: %1\n
 IDS_DS_OPTIONS=Options
 IDS_DS_MULTISAMPLE_PER_GROUP=Create one multi-sample per group


### PR DESCRIPTION
The multi-sample presets of the OP-XY are open, as #72 describes: a preset is a folder with the ending `.preset` which holds all samples as WAV files and a `patch.json` with the mapping and the settings of the engine. The example of that file in the issue was the starting point.

**Reading** gives the key range, root key, tuning, gain, play range and loop of every region, plus the amplitude envelope and the pitch bend range, which the device stores once for the whole preset.

**Writing** creates such a folder, which only needs to be copied to the device.

Three limits which the device manual states are handled explicitly:

* A preset holds at most **24 zones**; a source with more reports how many were dropped.
* Multiple velocities are not supported, so of several zones which cover the same keys the one which plays at the highest velocity is kept.
* A sample may be at most **20 seconds** long. Those are reported rather than truncated silently, so the trim processing option can be used deliberately.

The regions are written the way the device expects them and the way the community tools produce them: covering the keyboard without gaps, each region ending at its own upper key and starting one key above the previous one.

Verified by converting an E-mu Emulator X bank of 509 presets - 5152 regions, no structural problems, no key range gaps and no duplicate ranges, every referenced sample present - and by reading all 509 written presets back, which reproduces their key ranges and root keys unchanged. Not tested on the device itself.

The feature matrix has the two rows for the format.