### PR TITLE
Convert sample rates with a band-limited interpolation

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -9,6 +9,8 @@
   * New: Round-robin cycles which are stored as sample-select (selector) ranges - the only round-robin representation the Sampler of Live 10/11 has - are now read as round-robin groups instead of zones which all play at once. When writing, round-robin groups are stored as selector ranges whenever the native round-robin flag of Live 12 is not available (Ableton 11) or does not apply because only some of the groups alternate.
 * NI Kontakt
   * Fixed: The soloed groups of a Kontakt 4.2/5+ program were honored even when the program has group solo switched off. Kontakt keeps the solo flags of the groups when solo mode is left, so a program with such left-overs converted to those groups only and dropped every other group.
+* Processing
+  * Fixed: Changing the sample rate of the samples used a linear interpolation, which is not band-limited: reducing the rate folded all frequencies above the new Nyquist frequency back into the audible range (measured on a sweep which lies entirely above it: -9 dB instead of silence) and raising it left images of the source spectrum above the original Nyquist frequency. Both are now converted with a windowed sinc interpolation, which lowers the aliasing of that sweep by 92 dB and the images of a 32 kHz sample raised to 48 kHz from -41 dB to -84 dB.
 * WAV
   * New: WAV files which contain a complete Ogg stream instead of PCM data (marked with one of the Ogg Vorbis WAVE format codes, e.g. the samples of the legacy DirectWave packs of FL Studio) are read by de-compressing the embedded stream. They were rejected as an unsupported source format before.
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/algorithm/AudioSampleReducer.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/algorithm/AudioSampleReducer.java
@@ -330,7 +330,10 @@ public class AudioSampleReducer
 
 
     /**
-     * Re-sample frequency using linear interpolation.
+     * Re-sample frequency with a band-limited interpolation, see {@link SincResampler}. Linear
+     * interpolation was used before, which folds the frequencies above the new Nyquist frequency
+     * back into the audible range when down-sampling and leaves images of the source spectrum
+     * above the source Nyquist frequency when up-sampling.
      *
      * @param wavData The WAV data structure
      * @param targetRate The maximum sample rate
@@ -356,37 +359,33 @@ public class AudioSampleReducer
             final int bytesPerSample = (sampleSizeInBits + 7) / 8; // Support e.g. 12-bit
             final int frameSize = channels * bytesPerSample;
             final int sourceFrames = sourceData.length / frameSize;
-            final int targetFrames = (int) Math.round (sourceFrames * ratio);
 
-            final byte [] targetData = new byte [targetFrames * frameSize];
             final boolean bigEndian = sourceFormat.isBigEndian ();
 
-            for (int targetFrame = 0; targetFrame < targetFrames; targetFrame++)
+            // De-interleave, convert each channel on its own and interleave again
+            final double [] [] converted = new double [channels] [];
+            for (int channel = 0; channel < channels; channel++)
             {
-                final double sourcePos = targetFrame / ratio;
-                // Can theoretically equal sourceFrames on the last iteration due to floating-point
-                // rounding
-                final int sourceFrame1 = Math.min ((int) sourcePos, sourceFrames - 1);
-                final int sourceFrame2 = Math.min (sourceFrame1 + 1, sourceFrames - 1);
-                final double frac = sourcePos - sourceFrame1;
-
-                for (int ch = 0; ch < channels; ch++)
-                {
-                    final int offset1 = sourceFrame1 * frameSize + ch * bytesPerSample;
-                    final int offset2 = sourceFrame2 * frameSize + ch * bytesPerSample;
-
-                    final int sample1 = readSample (sourceData, offset1, sampleSizeInBits, bigEndian);
-                    final int sample2 = readSample (sourceData, offset2, sampleSizeInBits, bigEndian);
-
-                    final int interpolated = (int) (sample1 * (1 - frac) + sample2 * frac);
-
-                    final int targetOffset = targetFrame * frameSize + ch * bytesPerSample;
-                    writeSample (targetData, targetOffset, interpolated, sampleSizeInBits, bigEndian);
-                }
+                final double [] channelData = new double [sourceFrames];
+                for (int frame = 0; frame < sourceFrames; frame++)
+                    channelData[frame] = readSample (sourceData, frame * frameSize + channel * bytesPerSample, sampleSizeInBits, bigEndian);
+                converted[channel] = SincResampler.resample (channelData, (int) sourceRate, targetRate);
             }
 
+            final int convertedFrames = converted[0].length;
+            final byte [] targetData = new byte [convertedFrames * frameSize];
+            // The kernel overshoots at steep transients, therefore the result needs to be clipped
+            final int maximum = (1 << sampleSizeInBits - 1) - 1;
+            final int minimum = -(1 << sampleSizeInBits - 1);
+            for (int frame = 0; frame < convertedFrames; frame++)
+                for (int channel = 0; channel < channels; channel++)
+                {
+                    final int sample = (int) Math.clamp (Math.round (converted[channel][frame]), minimum, maximum);
+                    writeSample (targetData, frame * frameSize + channel * bytesPerSample, sample, sampleSizeInBits, bigEndian);
+                }
+
             final AudioFormat targetFormat = new AudioFormat (sourceFormat.getEncoding (), targetRate, sampleSizeInBits, channels, frameSize, targetRate, bigEndian);
-            return audioStreamToWavBytes (new AudioInputStream (new ByteArrayInputStream (targetData), targetFormat, targetFrames));
+            return audioStreamToWavBytes (new AudioInputStream (new ByteArrayInputStream (targetData), targetFormat, convertedFrames));
         }
     }
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/algorithm/SincResampler.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/algorithm/SincResampler.java
@@ -1,0 +1,187 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.core.algorithm;
+
+/**
+ * Converts the sample rate of one channel of audio with a band-limited interpolation: the samples
+ * are convolved with a sinc kernel which is limited to a number of zero crossings by a Kaiser
+ * window.
+ * <p>
+ * The kernel is stretched when down-sampling, which puts its cut-off frequency below the new
+ * Nyquist frequency and is what keeps the frequencies above it from folding back into the audible
+ * range. When up-sampling the kernel keeps the cut-off at the Nyquist frequency of the source,
+ * which is what keeps the images of the original spectrum out of the result.
+ *
+ * @author Jürgen Moßgraber
+ */
+public final class SincResampler
+{
+    /** The number of zero crossings of the sinc kernel on each side of its center. */
+    private static final int       ZERO_CROSSINGS     = 24;
+    /** The number of kernel values which are pre-calculated per zero crossing. */
+    private static final int       STEPS_PER_CROSSING = 128;
+    /** The beta parameter of the Kaiser window, which gives about -100 dB of stop band. */
+    private static final double    KAISER_BETA        = 9.0;
+    /**
+     * The cut-off is placed at this fraction of the Nyquist frequency instead of exactly at it. A
+     * filter of a finite length has a transition band, and centering that band on the Nyquist
+     * frequency lets the content just below it leak just above it. Measured on a 32 kHz sample
+     * converted to 48 kHz: the energy above the source Nyquist frequency is -56 dB at a factor of
+     * 1.0 and -79 dB at this one, at the cost of 1.8 dB of the content above 15.2 kHz.
+     */
+    private static final double    PASS_BAND          = 0.95;
+
+    private static final double [] KERNEL             = createKernel ();
+
+
+    /**
+     * Private due to helper class.
+     */
+    private SincResampler ()
+    {
+        // Intentionally empty
+    }
+
+
+    /**
+     * Convert the sample rate of one channel.
+     *
+     * @param input The input samples
+     * @param sourceRate The sample rate of the input
+     * @param targetRate The sample rate of the result
+     * @return The converted samples
+     */
+    public static double [] resample (final double [] input, final int sourceRate, final int targetRate)
+    {
+        final double ratio = targetRate / (double) sourceRate;
+        final int outputLength = (int) Math.round (input.length * ratio);
+        final double [] output = new double [outputLength];
+        if (outputLength == 0 || input.length == 0)
+            return output;
+
+        final double cutoff = Math.min (1.0, ratio) * PASS_BAND;
+        final double halfWidth = ZERO_CROSSINGS / cutoff;
+
+        // The position of an output sample in the input is index * step / period, therefore only
+        // 'period' different fractional positions occur and the weights of each of them are
+        // calculated once instead of once per output sample
+        final int divisor = gcd (sourceRate, targetRate);
+        final int step = sourceRate / divisor;
+        final int period = targetRate / divisor;
+
+        final int first = (int) Math.ceil (-halfWidth);
+        final int last = (int) Math.floor (1.0 + halfWidth);
+        final int taps = last - first + 1;
+        final double [] [] weights = new double [period] [taps];
+        final double [] weightSums = new double [period];
+        for (int phase = 0; phase < period; phase++)
+        {
+            final double fraction = phase / (double) period;
+            double sum = 0;
+            for (int tap = 0; tap < taps; tap++)
+            {
+                final double weight = kernelValue (cutoff * (fraction - (first + tap)));
+                weights[phase][tap] = weight;
+                sum += weight;
+            }
+            weightSums[phase] = sum;
+        }
+
+        final int length = input.length;
+        for (int index = 0; index < outputLength; index++)
+        {
+            final long scaled = (long) index * step;
+            final int base = (int) (scaled / period);
+            final int phase = (int) (scaled % period);
+            final double [] phaseWeights = weights[phase];
+
+            double sum = 0;
+            for (int tap = 0; tap < taps; tap++)
+            {
+                final int position = base + first + tap;
+                // Taps outside of the sample contribute nothing but still count towards the
+                // weight, which fades the very start and end instead of stepping at it
+                if (position >= 0 && position < length)
+                    sum += input[position] * phaseWeights[tap];
+            }
+            output[index] = weightSums[phase] == 0 ? 0 : sum / weightSums[phase];
+        }
+        return output;
+    }
+
+
+    /**
+     * Calculate the greatest common divisor.
+     *
+     * @param a The first value
+     * @param b The second value
+     * @return The greatest common divisor
+     */
+    private static int gcd (final int a, final int b)
+    {
+        return b == 0 ? a : gcd (b, a % b);
+    }
+
+
+    /**
+     * Look the kernel up at the given distance from its center.
+     *
+     * @param distance The distance in zero crossings
+     * @return The interpolated kernel value
+     */
+    private static double kernelValue (final double distance)
+    {
+        final double position = Math.abs (distance) * STEPS_PER_CROSSING;
+        final int index = (int) position;
+        if (index >= KERNEL.length - 1)
+            return 0;
+        return KERNEL[index] + (KERNEL[index + 1] - KERNEL[index]) * (position - index);
+    }
+
+
+    /**
+     * Pre-calculate one half of the windowed sinc kernel.
+     *
+     * @return The kernel values from its center outwards
+     */
+    private static double [] createKernel ()
+    {
+        final int length = ZERO_CROSSINGS * STEPS_PER_CROSSING + 1;
+        final double [] kernel = new double [length];
+        final double normalization = besselI0 (KAISER_BETA);
+        for (int i = 0; i < length; i++)
+        {
+            final double x = i / (double) STEPS_PER_CROSSING;
+            final double sinc = i == 0 ? 1.0 : Math.sin (Math.PI * x) / (Math.PI * x);
+            final double relative = x / ZERO_CROSSINGS;
+            final double window = besselI0 (KAISER_BETA * Math.sqrt (Math.max (0, 1.0 - relative * relative))) / normalization;
+            kernel[i] = sinc * window;
+        }
+        return kernel;
+    }
+
+
+    /**
+     * The modified Bessel function of the first kind and order zero, calculated from its series.
+     *
+     * @param x The parameter
+     * @return The value
+     */
+    private static double besselI0 (final double x)
+    {
+        double sum = 1.0;
+        double term = 1.0;
+        final double half = x / 2.0;
+        for (int i = 1; i < 64; i++)
+        {
+            term *= half / i;
+            final double square = term * term;
+            sum += square;
+            if (square < sum * 1e-17)
+                break;
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
The *Process* options convert the sample rate with a linear interpolation (`AudioSampleReducer.resampleFrequency`, its comment says so). Linear interpolation is not band-limited, so it fails in both directions:

* **Reducing** the rate folds every frequency above the new Nyquist frequency back into the audible range. A three second sweep from 12 to 21 kHz at 44.1 kHz - which lies entirely above the Nyquist frequency of 22.05 kHz and should therefore come out as near silence - is converted to **-9 dB RMS of audible garbage**.
* **Raising** the rate leaves images of the source spectrum above the original Nyquist frequency. A 32 kHz sample raised to 48 kHz gets **-41 dB** of energy above 16 kHz, where the source can hold nothing at all.

The second one is what led me here: a user compared the same converted instrument in two hosts and heard "more high end" in one of them. It turned out to be the resampler of that host leaving imaging above the Nyquist frequency of the 32 kHz source samples, and pre-converting the samples with ConvertWithMoss to avoid it would have made it *worse* than the host does.

This replaces the interpolation with a convolution against a windowed sinc kernel (Kaiser window, 24 zero crossings). When down-sampling the kernel is stretched so its cut-off lies below the new Nyquist frequency, which is what suppresses the aliasing. The cut-off sits at 95 % of the Nyquist frequency because the transition band of a filter of finite length would otherwise straddle it and let the content just below it leak just above; that costs 1.8 dB of the content above 15.2 kHz and buys 23 dB of stop band.

Measured, with `sox rate -v -s` as a reference for what a good converter achieves:

| | linear (before) | sinc (after) | sox |
|---|---|---|---|
| sweep entirely above the new Nyquist, down-sampled | -9.0 dB | **-100.6 dB** | - |
| images above 16 kHz, 32 kHz sample raised to 48 kHz | -41 dB | **-84 dB** | -88 dB |

**Speed**: the position of an output sample within the period of the rate ratio determines its kernel weights, and there are only as many distinct positions as the denominator of that ratio (147 for 48 to 44.1 kHz), so the weights are calculated once per period rather than once per sample. Converting 63 stereo samples of 13 seconds from 48 to 44.1 kHz takes about five seconds.

Verified that a conversion which does not resample is byte identical to before, and that the output of the sample rate conversion is unchanged by the weight caching (the positions are now derived from integer arithmetic rather than a division, which moves the result by -112 dB RMS against a -39 dB signal).

One observation I could not turn into a test: `AudioFileUtils.convertToWav` changes the sample rate through `AudioSystem` for the creators which cap it (Tonverk, OP-XY, 1010music, Disting EX, Bliss, YSFC, Korg KSF). I tried to make that path resample and could not get it to trigger, so I have no evidence either way about its quality and left it alone.
