### PR TITLE
Teenage Engineering OP-XY: fix the loop release mode and the cross-fade scaling, convert the velocity sensitivity (#317)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Many thanks to Douglas Carmichael for plenty of contributions and fixes!
 * New: Added support for the FL Studio DirectWave format (reading of DWP programs with their key/velocity ranges, gain, panning, loops, amplitude envelope, filter and the pitch and volume LFOs, including monolithic programs which carry all their samples inside of the file; the mapping of DWB banks and of sampled plug-ins is reconstructed from the names of their sample files; written programs are always monolithic, i.e. one self-contained file per instrument which stores all of its samples as FLAC compressed audio).
-* New: Added support for the Teenage Engineering OP-XY multi-sample preset format (reading and writing of the *.preset folders with their patch.json description file).
+* New: Added support for the Teenage Engineering OP-XY multi-sample preset format (reading and writing of the *.preset folders with their patch.json description file, including the loop with its release behavior and cross-fade and the velocity sensitivity of the engine).
 * New: Added support for the Casio FZ-1/FZ-10M/FZ-20M format (reading of floppy disk images (IMG, HFE) and bare dump files (FZF, FZV, FZB - including the head-less layout of the 'fzdump' utility, in which the circulating libraries like the factory library come) with banks, voices, loops, envelopes and filters; writing creates a ready-to-use floppy disk image with a full dump, e.g. for a Gotek/HxC floppy emulator - not yet verified on real hardware).
 * User Interface
   * New: The folder/file history does now remember the selected source format for the folder/file and restores it on selection.

--- a/documentation/README-FORMATS.md
+++ b/documentation/README-FORMATS.md
@@ -902,9 +902,9 @@ file and stores all samples in a sub-folder by the same name. The samples of the
 
 The OP-XY is a portable sampler and sequencer from Teenage Engineering. Its multi-sample presets are open: a preset is a folder with the ending *.preset* which contains all samples as WAV files and a *patch.json* file with the mapping and the settings of the synthesizer engine.
 
-Reading a preset gives the key range, root key, tuning, gain, play range and loop of every region, plus the amplitude envelope and the pitch bend range which the device stores once for the whole preset.
+Reading a preset gives the key range, root key, tuning, gain, play range and loop (with its cross-fade and release behavior) of every region, plus the amplitude envelope, the velocity sensitivity and the pitch bend range which the device stores once for the whole preset.
 
-Writing creates such a folder, which only needs to be copied to the device. Note the limits which the device manual states: a preset holds at most 24 zones, a sample may be at most 20 seconds long (longer ones are reported), and multiple velocities are not supported - of several zones which cover the same keys only the one which plays at the highest velocity is kept. The regions are written as the device expects them, i.e. covering the keyboard without gaps: a region ends at its own upper key and starts one key above the previous one. Samples are written as 16 bit WAV files with at most 44.1 kHz.
+Writing creates such a folder, which only needs to be copied to the device. Note the limits which the device manual states: a preset holds at most 24 zones, a sample may be at most 20 seconds long (longer ones are reported), and multiple velocities are not supported - of several zones which cover the same keys only the one which plays at the highest velocity is kept. The regions are written as the device expects them, i.e. covering the keyboard without gaps: a region ends at its own upper key and starts one key above the previous one. Samples are written as 16 bit WAV files with at most 44.1 kHz. The velocity sensitivity is filled from the source; if the source states nothing, the default of the device (displayed as 64) is used.
 
 ## Waldorf Quantum MkI, MkII / Iridium / Iridium Core
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyCreator.java
@@ -183,6 +183,11 @@ public class OpXyCreator extends AbstractWavCreator<WavChunkSettingsUI>
         engine.put (OpXyTag.TAG_PLAYMODE, OpXyTag.PLAYMODE_POLY);
         engine.put (OpXyTag.TAG_TRANSPOSE, 0);
         engine.put (OpXyTag.TAG_VOLUME, OpXyTag.CENTER_VALUE);
+        // Full depth is the neutral state of the model; the velocity response of the device is
+        // much steeper than e.g. amp_veltrack=100% of SFZ, therefore that case gets the default
+        // of the device instead of the maximum
+        final double velocityDepth = firstZone.getAmplitudeVelocityModulator ().getDepth ();
+        engine.put (OpXyTag.TAG_VELOCITY_SENSITIVITY, velocityDepth >= 1 ? OpXyTag.DEFAULT_VELOCITY_SENSITIVITY : OpXyTag.fromFactor (velocityDepth));
         final int bendUp = firstZone.getBendUp ();
         if (bendUp > 0)
             engine.put (OpXyTag.TAG_BEND_RANGE, OpXyTag.fromFactor (bendUp / 100.0 / OpXyTag.MAX_BEND_RANGE));
@@ -249,8 +254,10 @@ public class OpXyCreator extends AbstractWavCreator<WavChunkSettingsUI>
             final ISampleLoop loop = loops.get (0);
             region.put (OpXyTag.TAG_LOOP_START, Math.clamp (loop.getStart (), 0, frames));
             region.put (OpXyTag.TAG_LOOP_END, Math.clamp (loop.getEnd (), 0, frames));
-            region.put (OpXyTag.TAG_LOOP_CROSSFADE, Math.max (0, loop.getCrossfadeInSamples ()));
-            region.put (OpXyTag.TAG_LOOP_ON_RELEASE, loop.isLoopUntilRelease ());
+            // The device relates its cross-fade percentage to the whole sample, not to the loop
+            region.put (OpXyTag.TAG_LOOP_CROSSFADE, (int) Math.round (loop.getCrossfade () * frames));
+            // True keeps the loop running after note-off, false plays the part behind the loop
+            region.put (OpXyTag.TAG_LOOP_ON_RELEASE, !loop.isLoopUntilRelease ());
         }
         else
         {

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyDetector.java
@@ -154,8 +154,15 @@ public class OpXyDetector extends AbstractDetector<MetadataSettingsUI>
             loop.setType (LoopType.FORWARDS);
             loop.setStart (getInt (regionNode, OpXyTag.TAG_LOOP_START, 0));
             loop.setEnd (getInt (regionNode, OpXyTag.TAG_LOOP_END, zone.getStop ()));
-            loop.setCrossfadeInSamples (getInt (regionNode, OpXyTag.TAG_LOOP_CROSSFADE, 0));
-            loop.setLoopUntilRelease (getBoolean (regionNode, OpXyTag.TAG_LOOP_ON_RELEASE));
+            // The device relates its cross-fade percentage to the whole sample, not to the loop
+            final int crossfade = getInt (regionNode, OpXyTag.TAG_LOOP_CROSSFADE, 0);
+            final int frameCount = getInt (regionNode, OpXyTag.TAG_FRAME_COUNT, 0);
+            if (frameCount > 0)
+                loop.setCrossfade (crossfade / (double) frameCount);
+            else
+                loop.setCrossfadeInSamples (crossfade);
+            // True keeps the loop running after note-off, false plays the part behind the loop
+            loop.setLoopUntilRelease (!getBoolean (regionNode, OpXyTag.TAG_LOOP_ON_RELEASE));
             zone.getLoops ().add (loop);
         }
 
@@ -173,6 +180,7 @@ public class OpXyDetector extends AbstractDetector<MetadataSettingsUI>
     {
         final JsonNode engineNode = root.get (OpXyTag.TAG_ENGINE);
         final int bendRange = engineNode == null ? -1 : (int) Math.round (OpXyTag.toFactor (getInt (engineNode, OpXyTag.TAG_BEND_RANGE, -1)) * OpXyTag.MAX_BEND_RANGE);
+        final int velocitySensitivity = engineNode == null ? -1 : getInt (engineNode, OpXyTag.TAG_VELOCITY_SENSITIVITY, -1);
 
         final JsonNode envelopeNode = root.get (OpXyTag.TAG_ENVELOPE);
         final JsonNode ampNode = envelopeNode == null ? null : envelopeNode.get (OpXyTag.TAG_AMP);
@@ -184,6 +192,9 @@ public class OpXyDetector extends AbstractDetector<MetadataSettingsUI>
                 zone.setBendUp (bendRange * 100);
                 zone.setBendDown (-bendRange * 100);
             }
+
+            if (velocitySensitivity >= 0)
+                zone.getAmplitudeVelocityModulator ().setDepth (OpXyTag.toFactor (velocitySensitivity));
 
             if (ampNode != null)
             {

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyTag.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/teenage/opxy/OpXyTag.java
@@ -44,6 +44,8 @@ public class OpXyTag
     public static final String TAG_TRANSPOSE         = "transpose";
     /** The volume of the engine. */
     public static final String TAG_VOLUME            = "volume";
+    /** The velocity sensitivity of the engine. */
+    public static final String TAG_VELOCITY_SENSITIVITY = "velocity.sensitivity";
 
     /** The envelope section. */
     public static final String TAG_ENVELOPE          = "envelope";
@@ -76,13 +78,21 @@ public class OpXyTag
     public static final String TAG_SAMPLE_END        = "sample.end";
     /** Is the loop enabled? */
     public static final String TAG_LOOP_ENABLED      = "loop.enabled";
-    /** Does the loop run until the key is released? */
+    /**
+     * Does the loop keep running after the key is released (the '&infin;' mode of the device)? If
+     * false, the part of the sample behind the loop is played on release.
+     */
     public static final String TAG_LOOP_ON_RELEASE   = "loop.onrelease";
     /** The start of the loop. */
     public static final String TAG_LOOP_START        = "loop.start";
     /** The end of the loop. */
     public static final String TAG_LOOP_END          = "loop.end";
-    /** The cross-fade of the loop. */
+    /**
+     * The cross-fade of the loop. The device relates its cross-fade percentage to the whole
+     * sample, not to the loop: the stored value is 'percent * framecount' (the device displays a
+     * stored 29368 of 166606 frames as 17%; existing presets hold exact integer percentages of
+     * their frame count, up to the manual limit of 75%).
+     */
     public static final String TAG_LOOP_CROSSFADE    = "loop.crossfade";
     /** The gain of a region. */
     public static final String TAG_GAIN              = "gain";
@@ -102,6 +112,8 @@ public class OpXyTag
     public static final int    MAX_VALUE             = 32767;
     /** The value of a bipolar parameter at its center. */
     public static final int    CENTER_VALUE          = 16384;
+    /** The velocity sensitivity to use when the source states nothing. The device shows 64. */
+    public static final int    DEFAULT_VELOCITY_SENSITIVITY = 21299;
 
     /**
      * The longest time of an envelope in seconds. The envelope parameters are stored normalized to


### PR DESCRIPTION
Fixes #317 - all three findings, verified against the attached complexOutput files.

**Loop release mode was inverted.** `loop.onrelease: true` is the '∞' mode of the device: the loop keeps running after note-off. The code treated the flag as a sustain loop ('loop until release'), which is exactly the opposite, so Ableton's '⇥' became '∞' and Ableton's 'OFF' became '⇥'. Creator and detector now invert the flag, and the tag documentation states the actual meaning. Re-converting the files from the issue now yields `loop.onrelease: false` for complexOutput1 ('⇥') and `true` for complexOutput2 ('OFF').

**The cross-fade percentage of the device relates to the whole sample, not to the loop.** The direct evidence is in the issue itself: the value 29368 which was written for complexOutput3 (a 166606-frame sample) is displayed as 17% by the device - exactly 29368 / 166606. A commercial pack of presets in this format corroborates the law (the pack is shipped for the Elektron Tonverk, whose multi-sampled instruments use the same patch.json format - the files declare platform "OP-XY"): every one of its 17 cross-faded regions stores exactly 'display percent × framecount' (73%, 49%, 75%, 32%, 20%, ... - all exact integer percentages of the frame count, the largest being exactly the 75% manual limit of the OP-XY hardware). The stored values regularly exceed both the loop length and the audio available before the loop start, so they cannot be a plain frame count of the fade. The creator therefore writes `crossfade fraction × framecount` and the detector reads the fraction back symmetrically. For complexOutput3 (100% cross-fade in Ableton, which stores 29368 frames of its 30163-frame loop) the written value changes from 29368 (displayed as 17%) to 162215, which displays as ~97% - matching the source.

**The velocity sensitivity of the engine is now converted.** Written from the amplitude-velocity modulation depth of the source when it states one (the Ableton files carry `VolumeVelScale` 0.35 and now produce `velocity.sensitivity: 11468`), and read back by the detector. When the source states nothing, the suggested default 21299 (displayed as 64) is written - full model depth maps to this default as well, since the velocity response of the device at 32767 is much steeper than the neutral 100% velocity tracking of e.g. SFZ.

Verified with a build: the three Ableton files from the issue convert to the expected values above, an OP-XY to OP-XY round trip of the results is stable in all loop fields and the sensitivity, and a plain WAV source receives the 21299 default.

@johnnywagner: the loop-type and cross-fade values should now land as you described. One thing only the hardware can answer: with the new scaling, does a converted 100% Ableton cross-fade also *sound* like the Ableton original (fade over roughly the whole loop), or does the device fade a shorter region? That would tell whether the engine maps the percentage onto the loop or onto absolute frames, and I will gladly adjust the law if you hear a difference.
