### PR TITLE
Audiomodern Soundbox: sanitize the preset and group names as well - the import creates files named after them (fixes the empty S-7xx library on Windows)

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/soundbox/SoundboxCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/soundbox/SoundboxCreator.java
@@ -138,6 +138,7 @@ public class SoundboxCreator extends AbstractWavCreator<WavChunkSettingsUI>
 
         final List<String> presetContents = new ArrayList<> ();
         final Set<String> usedGroupNames = new HashSet<> ();
+        final Set<String> usedPresetNames = new HashSet<> ();
 
         // The samples are written to the ZIP while the sound entries are created, so that
         // duplicated sample data can be detected by its content and stored only once. The
@@ -151,7 +152,9 @@ public class SoundboxCreator extends AbstractWavCreator<WavChunkSettingsUI>
 
             for (final IMultisampleSource multisampleSource: multisampleSources)
             {
-                final String presetName = multisampleSource.getName ();
+                // The import in Soundbox creates files named after the preset and its groups,
+                // therefore the names must not contain characters which are illegal in file names
+                final String presetName = createUniqueName (StringUtils.consolidateWhitespace (FileUtils.createSafeFilename (multisampleSource.getName ()).replace ('_', ' '), "Preset"), usedPresetNames);
                 final Element presetNameElement = XMLUtils.addElement (packDocument, presetsElement, SoundboxTag.PRESET_NAME);
                 presetNameElement.setAttribute (SoundboxTag.ATTR_NAME, presetName);
 


### PR DESCRIPTION
This finishes the name sanitizing your commit 60049956 started, and it explains the empty library you saw with the S-7xx input.

**Why the import shows no content on Windows:** when Soundbox imports a pack it creates real files named after the names inside the pack:

* the preset names from `pack.amx` become `Presets/Imported/<pack>/<preset name>.sbset`
* the group names become `Groups/<group name>.sbgrp`
* the entries of `<Sounds>` become the sample files

I verified this on disk with Soundbox 1.2.1. Your fix sanitized the pack name, but the preset and group names were still written raw, and the S-7xx patch names all carry a colon (`MLT:Rc Tn SAX` etc. from the `L701_1.OUT` disk). A colon is illegal in NTFS file names — and worse, `CreateFile ("MLT:Rc Tn SAX.sbset")` does not even fail: Windows interprets everything after the colon as an NTFS *alternate data stream* of a file named `MLT`, so the content is written invisibly. That is why the import finishes without an error and the library still shows nothing.

**The fix** runs the preset name through the same recipe as the pack name (`createSafeFilename` + underscores to spaces + `consolidateWhitespace`) and keeps it unique per pack. The group names and the `g0..g3` references derive from the preset name, so they are covered by the same line; the sample file names already went through `createSafeFilename`.

**Verified** with the L701 disk on macOS with Soundbox 1.2.1 (macOS accepts a colon in file names, so both versions import there — which is also why the problem is invisible on the Mac):

* before: the import wrote `MLT:Rc Tn SAX.sbset` / `MLT:Rc Tn SAX.sbgrp` (names taken over verbatim, nothing is sanitized on the Soundbox side)
* after: `MLT Rc Tn SAX.sbset` / `MLT Rc Tn SAX.sbgrp`, the preset shows up in the pack, loads and plays, and all seven packs of the disk pass an Analyze round trip through the Soundbox detector

One note on the test file: `L701_1.OUT` is diskette 1 of a 2-disk set, so a conversion of the ZIP content alone stops at "Could not find continuation disk 2 of 2" — for my tests I forged a second disk (the continuation only contributes raw sample bytes). With `L701_2.OUT` next to it, everything runs through as expected.