### PR TITLE
1010music: write the actually created folder names into the preset paths (illegal characters, unique numbering) and fix the silence sample references

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -13,6 +13,9 @@
   * Fixed: Contents dialog: Using 'Select All' on filtered content did still select all presets not only the filtered ones.
   * Fixed: Tabbing in dialogs did not work.
   * Fixed: Processing dialog: the Enable option could not be reached with tab.
+* 1010music blackbox, bento
+  * Fixed: The preset paths written into presets and performances used the multi-sample name as-is, but the actually created folders have illegal file name characters removed and a number appended when the name already exists. Such presets referenced non-existing folders (e.g. for sources with a ':' in their name, like Roland S-7xx patches). The written paths now always match the created folders.
+  * Fixed: blackbox: The silence workaround samples of a performance were referenced in the folder of the instrument but the sample is stored in the performance folder.
 * Akai MPC60, MPC2000/3000, S-9x0, S-1000, Ensoniq ASR/EPS, Roland S-5xx, S-7xx
   * New: Patches are now put in sub-folders with their image name. On the S-5xx, if it is a CD-ROM, the CD-ROM name is another sub-folder. S-1000 adds Volume names.
 * Ableton

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/bento/BentoCreator.java
@@ -7,6 +7,7 @@ package de.mossgrabers.convertwithmoss.format.music1010.bento;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -149,8 +150,25 @@ public class BentoCreator extends AbstractMusic1010Creator
             return;
         }
 
+        // Create the folders of the individual presets upfront, so that the project references
+        // their actual names, which may differ from the multi-sample names due to removed illegal
+        // file name characters and unique-name numbering. The patches folder uses the same
+        // (unique) name as the project folder.
+        final File presetFolder = new File (patchesFolder, performanceFolder.getName ());
+        final List<File> fullPresetFolders = new ArrayList<> ();
+        final List<String> presetFolderNames = new ArrayList<> ();
+        for (final IInstrumentSource instrumentSource: instrumentSources)
+        {
+            final String multisampleName = FileUtils.createSafeFilename (instrumentSource.getMultisampleSource ().getName ());
+            final File fullPresetFolder = this.createUniqueFilename (presetFolder, multisampleName, "");
+            if (!fullPresetFolder.mkdirs ())
+                this.notifier.logError (IDS_NOTIFY_FOLDER_COULD_NOT_BE_CREATED, fullPresetFolder.getAbsolutePath ());
+            fullPresetFolders.add (fullPresetFolder);
+            presetFolderNames.add (fullPresetFolder.getName ());
+        }
+
         // Create the overall performance preset
-        final Optional<String> xmlCode = this.createPreset (instrumentSources, trim, PATCHES_FOLDER + performanceFolderName + "\\", true);
+        final Optional<String> xmlCode = this.createPreset (instrumentSources, presetFolderNames, trim, PATCHES_FOLDER + performanceFolder.getName () + "\\", true);
         if (xmlCode.isPresent ())
         {
             final File performanceFile = new File (performanceFolder, "project.xml");
@@ -164,18 +182,13 @@ public class BentoCreator extends AbstractMusic1010Creator
         }
 
         // Create all samples in their sub-folders
-        final File presetFolder = new File (patchesFolder, performanceFolderName);
-        for (final IInstrumentSource instrumentSource: instrumentSources)
+        for (int i = 0; i < instrumentSources.size (); i++)
         {
-            final IMultisampleSource multisampleSource = instrumentSource.getMultisampleSource ();
-
-            final String multisampleName = FileUtils.createSafeFilename (multisampleSource.getName ());
-            final File fullPresetFolder = this.createUniqueFilename (presetFolder, multisampleName, "");
-            if (!fullPresetFolder.mkdirs ())
-            {
-                this.notifier.logError (IDS_NOTIFY_FOLDER_COULD_NOT_BE_CREATED, fullPresetFolder.getAbsolutePath ());
+            final File fullPresetFolder = fullPresetFolders.get (i);
+            if (!fullPresetFolder.exists ())
                 continue;
-            }
+
+            final IMultisampleSource multisampleSource = instrumentSources.get (i).getMultisampleSource ();
 
             // Store all samples
             if (resample)
@@ -203,7 +216,7 @@ public class BentoCreator extends AbstractMusic1010Creator
         }
 
         final IInstrumentSource instrumentSource = new DefaultInstrumentSource (multisampleSource, 0);
-        final Optional<String> metadata = this.createPreset (Collections.singletonList (instrumentSource), trim, "", false);
+        final Optional<String> metadata = this.createPreset (Collections.singletonList (instrumentSource), Collections.singletonList (presetFolder.getName ()), trim, "", false);
         if (metadata.isEmpty ())
             return;
 
@@ -230,13 +243,15 @@ public class BentoCreator extends AbstractMusic1010Creator
      * Create the text of the description file with 1 preset.
      *
      * @param instrumentSources The up to 16 instrument sources to add to the preset
+     * @param presetFolderNames The actual folder names of the individual presets, one for each
+     *            instrument source
      * @param trim Trim to start/end if true
      * @param subFolder The sub-folder inside of the Presets folder to write to
      * @param isPerformance True if the preset is part of a performance
      * @return The XML structure
      * @throws IOException Could not combine split-stereo files
      */
-    private Optional<String> createPreset (final List<IInstrumentSource> instrumentSources, final boolean trim, final String subFolder, final boolean isPerformance) throws IOException
+    private Optional<String> createPreset (final List<IInstrumentSource> instrumentSources, final List<String> presetFolderNames, final boolean trim, final String subFolder, final boolean isPerformance) throws IOException
     {
         final Optional<Pair<Document, Element>> sessionDocumentOpt = this.createSessionDocument ();
         if (sessionDocumentOpt.isEmpty ())
@@ -287,7 +302,7 @@ public class BentoCreator extends AbstractMusic1010Creator
             }
             for (final IGroup group: groups)
                 for (final ISampleZone zone: group.getSampleZones ())
-                    this.createSample (document, isPerformance ? subFolder + FileUtils.createSafeFilename (multisampleSource.getName ()) + "\\" : "", trackElement, zone, trim);
+                    this.createSample (document, isPerformance ? subFolder + presetFolderNames.get (i) + "\\" : "", trackElement, zone, trim);
             if (isPerformance)
             {
                 final int highestKey = multisampleSource.getHighestKey ();

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/music1010/blackbox/Music1010Creator.java
@@ -186,8 +186,23 @@ public class Music1010Creator extends AbstractMusic1010Creator
         for (final IInstrumentSource instrumentSource: instrumentSources)
             instrumentSource.clipKeyRange ();
 
+        // Create the folders of the individual presets upfront, so that the performance preset
+        // references their actual names, which may differ from the multi-sample names due to
+        // removed illegal file name characters and unique-name numbering
+        final List<File> presetFolders = new ArrayList<> ();
+        final List<String> presetFolderNames = new ArrayList<> ();
+        for (final IInstrumentSource instrumentSource: instrumentSources)
+        {
+            final String multisampleName = FileUtils.createSafeFilename (instrumentSource.getMultisampleSource ().getName ());
+            final File presetFolder = this.createUniqueFilename (folder, multisampleName, "");
+            if (!presetFolder.mkdir ())
+                this.notifier.logError (IDS_NOTIFY_FOLDER_COULD_NOT_BE_CREATED, presetFolder.getAbsolutePath ());
+            presetFolders.add (presetFolder);
+            presetFolderNames.add (presetFolder.getName ());
+        }
+
         // Create the overall performance preset
-        final Optional<String> xmlCode = this.createPreset (instrumentSources, trim, performanceFolder + "\\", true);
+        final Optional<String> xmlCode = this.createPreset (instrumentSources, presetFolderNames, trim, folder.getName () + "\\", true);
         if (xmlCode.isPresent ())
         {
             final File performanceFile = new File (folder, "preset.xml");
@@ -201,17 +216,13 @@ public class Music1010Creator extends AbstractMusic1010Creator
         }
 
         // Create all samples in their sub-folders
-        for (final IInstrumentSource instrumentSource: instrumentSources)
+        for (int i = 0; i < instrumentSources.size (); i++)
         {
-            final IMultisampleSource multisampleSource = instrumentSource.getMultisampleSource ();
-
-            final String multisampleName = FileUtils.createSafeFilename (multisampleSource.getName ());
-            final File presetFolder = this.createUniqueFilename (folder, multisampleName, "");
-            if (!presetFolder.mkdir ())
-            {
-                this.notifier.logError (IDS_NOTIFY_FOLDER_COULD_NOT_BE_CREATED, presetFolder.getAbsolutePath ());
+            final File presetFolder = presetFolders.get (i);
+            if (!presetFolder.exists ())
                 continue;
-            }
+
+            final IMultisampleSource multisampleSource = instrumentSources.get (i).getMultisampleSource ();
 
             // Store all samples
             if (resample)
@@ -239,7 +250,7 @@ public class Music1010Creator extends AbstractMusic1010Creator
         }
 
         final IInstrumentSource instrumentSource = new DefaultInstrumentSource (multisampleSource, 0);
-        final Optional<String> metadata = this.createPreset (Collections.singletonList (instrumentSource), trim, "", false);
+        final Optional<String> metadata = this.createPreset (Collections.singletonList (instrumentSource), Collections.singletonList (presetFolder.getName ()), trim, "", false);
         if (metadata.isEmpty ())
             return;
 
@@ -260,13 +271,15 @@ public class Music1010Creator extends AbstractMusic1010Creator
      * Create the text of the description file with 1 preset.
      *
      * @param instrumentSources The up to 16 instrument sources to add to the preset
+     * @param presetFolderNames The actual folder names of the individual presets, one for each
+     *            instrument source
      * @param trim Trim to start/end if true
      * @param subFolder The sub-folder inside of the Presets folder to write to
      * @param isPerformance True if the preset is part of a performance
      * @return The XML structure
      * @throws IOException Could not combine split-stereo files
      */
-    private Optional<String> createPreset (final List<IInstrumentSource> instrumentSources, final boolean trim, final String subFolder, final boolean isPerformance) throws IOException
+    private Optional<String> createPreset (final List<IInstrumentSource> instrumentSources, final List<String> presetFolderNames, final boolean trim, final String subFolder, final boolean isPerformance) throws IOException
     {
         final Optional<Pair<Document, Element>> sessionDocumentOpt = this.createSessionDocument ();
         if (sessionDocumentOpt.isEmpty ())
@@ -276,6 +289,9 @@ public class Music1010Creator extends AbstractMusic1010Creator
         final Element sessionElement = sessionDocument.getValue ();
 
         // No metadata at all -> can optionally be written to BEXT chunk
+
+        // The silence workaround sample is written to the top of the performance folder
+        final String silencePath = subFolder.isEmpty () ? "" : "\\Presets\\" + subFolder.substring (0, subFolder.length () - 1);
 
         final int numInstruments = instrumentSources.size ();
         final List<Element> activeSlots = this.createSlots (document, sessionElement, numInstruments);
@@ -291,7 +307,7 @@ public class Music1010Creator extends AbstractMusic1010Creator
                 continue;
 
             final Element slotElement = activeSlots.get (i);
-            final String presetPath = "\\Presets\\" + subFolder + multisampleSource.getName ();
+            final String presetPath = "\\Presets\\" + subFolder + presetFolderNames.get (i);
             slotElement.setAttribute (Music1010Tag.ATTR_FILENAME, presetPath);
             // 0 = Off, 1..16 are the MIDI channels 1..16 whereby MIDI-channel 1 acts as the OMNI
             // mode. Therefore, OMNI (-1) is written as MIDI-channel 1 as well - writing 'Off'
@@ -309,7 +325,7 @@ public class Music1010Creator extends AbstractMusic1010Creator
                 if (lowestKey > 0)
                 {
                     final ISampleZone silentZone = new DefaultSampleZone ("Silence24bit48kHz", 0, lowestKey - 1);
-                    createSample (document, presetPath, sessionElement, silentZone, sampleIndex, i, false);
+                    createSample (document, silencePath, sessionElement, silentZone, sampleIndex, i, false);
                     sampleIndex++;
                 }
             }
@@ -325,7 +341,7 @@ public class Music1010Creator extends AbstractMusic1010Creator
                 if (highestKey < 127)
                 {
                     final ISampleZone silentZone = new DefaultSampleZone ("Silence24bit48kHz", highestKey + 1, 127);
-                    createSample (document, presetPath, sessionElement, silentZone, sampleIndex, i, false);
+                    createSample (document, silencePath, sessionElement, silentZone, sampleIndex, i, false);
                     sampleIndex++;
                 }
             }


### PR DESCRIPTION
Follow-up from the Soundbox name investigation (#321): I audited all creators for places where a path written *into* the output derives from a different value than the file/folder actually created. The 1010music creators had the only real mismatches.

**1. Preset paths used the raw multi-sample name.** The folders on disk are created from `createSafeFilename (…)` plus the unique-name numbering of `createUniqueFilename`, but the `filename` attributes in the XML embedded the name as-is. Two ways to hit it:

* a source name with an illegal character — e.g. every Roland S-7xx patch (`MLT:Rc Tn SAX`): the folder becomes `MLT_Rc Tn SAX`, the preset referenced `\Presets\MLT:Rc Tn SAX`
* two sources with the same name (or converting into the same output folder twice): the folder becomes `Name (2)`, the reference stayed `Name`

Both creators now create the preset folders first and write the actual folder names into the XML, so the references always match — including the `(2)` numbering (the blackbox performance/preset paths, and the patch paths of a bento project; bento already sanitized the name but missed the numbering, blackbox missed both).

**2. blackbox: the silence workaround samples of a performance were referenced in the instrument folder** (`\Presets\<performance>\<instrument>\Silence24bit48kHz.wav`) **but the sample is written once at the top of the performance folder.** The references now point there.

**Verified** by converting the S-7xx L701 disk to blackbox presets (references match the sanitized folders; a second run into the same output produces `… (2)` folders and matching references), and by a direct harness around `createPerformance` for both creators with three instruments — two of them sharing the name `MLT:Rc Tn SAX` — which yields `MLT_Rc Tn SAX` and `MLT_Rc Tn SAX (2)` folders and slot/sample references that match 1:1, plus the silence sample referenced at its real location.

One pre-existing quirk I deliberately did not touch: bento's `PATCHES_FOLDER` constant (`"UserPatches\\SampInst\\"`) is used both as the host path and as the device path, so on macOS/Linux the performance output creates a single folder literally named `UserPatches\SampInst\` instead of two nested ones. If you want, I can make the host side use `File` children while keeping the backslash form in the XML - that felt like a separate change.