### PR TITLE
Roland MC-707: store the actual file name in the project name field

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -27,6 +27,8 @@
 * NI Kontakt
   * New: The velocity to volume modulator is now converted with its response curve: Kontakt maps its normalized volume to decibels with 60*log10(x), so the amplitude follows the cube of the velocity. Destinations which can express the curve reproduce this response, e.g. SFZ receives matching amp_velcurve_N points.
   * Fixed: The soloed groups of a Kontakt 4.2/5+ program were honored even when the program has group solo switched off. Kontakt keeps the solo flags of the groups when solo mode is left, so a program with such left-overs converted to those groups only and dropped every other group.
+* Roland MC-707/MC-101
+  * Fixed: The project name stored inside of a written MPJ file was the multi-sample name as-is; it is now the name of the written file, i.e. with illegal file name characters removed and including the number which is appended when the file already exists.
 * Roland S-7xx
   * Fixed: CD-ROM/hard-disk images: the audio data of the samples is now located through the file allocation table and the directory entries instead of assuming one contiguous block at the fixed start offset of S-760 formatted disks. Images formatted by an S-750/S-770 system (whose audio area starts 1 MB earlier) and disks which contain deleted or fragmented entries either failed with 'Referenced sample data is larger than the available data' (e.g. the SV-SP70-01 Library Preview Disc) or could silently assign wrong audio to the samples. Deleted entries between the entries in use are now skipped as well instead of shifting all following patch, partial and sample references.
 * Sample Files

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mc707/MC707Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mc707/MC707Creator.java
@@ -178,7 +178,9 @@ public class MC707Creator extends AbstractCreator<MC707CreatorUI>
         this.notifier.log ("IDS_MC707_WRITING_PROJECT", outputFile.getAbsolutePath (), Integer.toString (multisampleSources.size ()));
 
         final MC707Project project = MC707Project.createFromTemplate ();
-        project.setProjectName (name);
+        // Use the name of the written file, which may differ from the given name due to removed
+        // illegal file name characters and unique-name numbering
+        project.setProjectName (FileUtils.getNameWithoutType (outputFile));
 
         final List<MC707Sample> pool = new ArrayList<> ();
         final Map<Object, Integer> byContent = new HashMap<> ();


### PR DESCRIPTION
From the name audit after #321: `writeProject` sanitizes and uniquifies the FILE name but wrote the raw multi-sample name into the 16-byte project-name field of the MPJ, so the file and the name shown after restoring the project on the device could differ ("MLT_Rc Tn SAX.mpj" restoring as "MLT:Rc Tn SAX", and "Name (2).mpj" as plain "Name"). The field now receives the base name of the written file, same as the DirectWave creator does.

Verified by converting the S-7xx L701 disk before and after: the two MPJ files differ in exactly ONE byte - the ':' (0x3A) of the project-name field becomes '_' (0x5F); tone names and all sample data are untouched.
