### PR TITLE
CLI: optionally write the conversion progress in a machine-readable form (#141)

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -13,6 +13,8 @@
   * Fixed: Contents dialog: Using 'Select All' on filtered content did still select all presets not only the filtered ones.
   * Fixed: Tabbing in dialogs did not work.
   * Fixed: Processing dialog: the Enable option could not be reached with tab.
+* Command Line Interface
+  * New: The new option '-P' additionally writes the progress of a conversion to the error output in a machine-readable form ('CWM_PROGRESS pct=<0..100> phase=<token> detail=<text>'), so that an application which runs ConvertWithMoss as a child process can display it - the progress dots of the normal output cannot be turned into a percentage. The percentage moves with the finished source files and, inside of a source file, with its loaded samples, which keeps a single large instrument moving as well. Setting the environment variable CWM_MACHINE_PROGRESS to 1 has the same effect, for hosts which cannot add options to the command line. Without the option nothing is written and nothing is changed.
 * 1010music bento
   * Fixed: On macOS and Linux the patches of a performance were written into a single folder whose name literally contains the backslashes of the device path ('UserPatches\SampInst\') instead of the nested UserPatches/SampInst folders; such a folder cannot even be copied onto the FAT32/exFAT card of the device. The paths inside of the project file were and are correct.
 * 1010music blackbox, bento

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -149,7 +149,7 @@ First display all of the available attributes by typing:
 The following output is displayed (the processing parameters are omitted):
 
 ```
-Usage: ConvertWithMoss [-afhV] -d=DESTINATION [-l=LIBRARY]
+Usage: ConvertWithMoss [-afhPV] -d=DESTINATION [-l=LIBRARY]
                        -s=SOURCE [-t=TYPE] [-p[=KEY=VALUE...]]...
                        SOURCE... DESTINATION_FOLDER
       SOURCE... DESTINATION_FOLDER
@@ -166,6 +166,13 @@ Usage: ConvertWithMoss [-afhV] -d=DESTINATION [-l=LIBRARY]
   -l, --library=LIBRARY    Name for the library. Set to create a library.
   -p=[KEY=VALUE...]        Key-value pairs in the form -pkey1=value1,
                              key2=value2,...
+  -P, --machine-progress   If present, the progress of the conversion is
+                             additionally written to the error output in a
+                             machine-readable form ('CWM_PROGRESS pct=<0..100>
+                             phase=<token> detail=<text>'), which allows a
+                             hosting application to display it. Can also be
+                             requested by setting the environment variable
+                             CWM_MACHINE_PROGRESS to 1.
   -s, --source=SOURCE      The source format.
   -t, --type=TYPE          Set to either 'preset' (the default if absent) or
                              'performance' (without the quotes).
@@ -216,3 +223,33 @@ Finally, an example for creating a library of performances:
 A destination format which cannot hold what was asked for - a library of several presets, or performances at all - is reported as an error and nothing is converted. The user interface only offers the output types which the chosen destination supports; the command line accepts '-l' and '-t performance' for every destination, so they are checked before the detection starts.
 
 Additionally, there are several parameters for processing the samples as well. They use 2 letters and always start with a 'Z'. Note that processing needs to be enabled by adding '-Ze'.
+
+## Machine-readable progress
+
+The output of a conversion is written for a human: the progress of a file is a row of dots. An application which runs ConvertWithMoss as a child process - e.g. to offer the conversion from inside of its own user interface - cannot derive a percentage from those dots. Adding '-P' therefore additionally writes the progress to the **error output** in a form which is easy to parse. The normal output is not changed by this, so both can be used at the same time. If the hosting application cannot add options to the command line, the environment variable `CWM_MACHINE_PROGRESS` can be set to '1' or 'true' instead, which has the same effect.
+
+Each event is one line which is terminated with a line separator and flushed immediately:
+
+```
+CWM_PROGRESS pct=<0..100> phase=<token> detail=<text>
+```
+
+* **pct**: the percentage which is reached, 0 to 100.
+* **phase**: one of `start` (the run begins), `convert` (a source file was started or finished), `sample` (a sample file of the current source file was loaded) and `done` (the run ended - if it was cancelled the percentage is the one which was reached and not 100).
+* **detail**: the rest of the line, which may contain spaces since it is a file name or a path. It is reduced to printable ASCII characters, so that both processes do not need to agree on a character encoding; all other characters are replaced by a question mark.
+
+Any line which is not understood should be ignored, which keeps the protocol open for further phases. Here is a shortened example of a conversion of two Kontakt instruments:
+
+```
+CWM_PROGRESS pct=0 phase=start detail=D:\MySampler\Kontakt
+CWM_PROGRESS pct=0 phase=convert detail=Enigma.nki
+CWM_PROGRESS pct=2 phase=sample detail=Kick_01.wav
+CWM_PROGRESS pct=4 phase=sample detail=Snare_02.wav
+CWM_PROGRESS pct=50 phase=convert detail=Enigma.nki
+CWM_PROGRESS pct=50 phase=convert detail=Prophecy.nki
+CWM_PROGRESS pct=52 phase=sample detail=Pad_C2.wav
+CWM_PROGRESS pct=100 phase=convert detail=Prophecy.nki
+CWM_PROGRESS pct=100 phase=done detail=
+```
+
+The percentage range is split into one slice per source file, which is why a finished file reports the start of the next one. How many samples a source file contains is only known once it was read, therefore the progress inside of a slice approaches the end of the slice with every loaded sample but only reaches it when the file is finished. This keeps a single large instrument - a Kontakt library often is one file with several hundred samples - moving instead of standing at the same percentage for minutes. Formats which do not read their samples from separate files, e.g. the disk images of the hardware samplers, only report the `convert` events.

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/CLIBackend.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/CLIBackend.java
@@ -100,6 +100,7 @@ public class CLIBackend implements INotifier
             spec.addOption (OptionSpec.builder ("-f", "--flat").paramLabel ("FLAT").description ("If present, the folder structure is not recreated in the output folder.").build ());
             spec.addOption (OptionSpec.builder ("-l", "--library").paramLabel ("LIBRARY").type (String.class).description ("Name for the library. Set to create a library.").build ());
             spec.addOption (OptionSpec.builder ("-p").paramLabel ("KEY=VALUE").description ("Key-value pairs in the form -pkey1=value1,key2=value2,...").required (false).arity ("0..*").type (Map.class).auxiliaryTypes (String.class, String.class).defaultValue (null).build ());
+            spec.addOption (OptionSpec.builder ("-P", "--machine-progress").paramLabel ("MACHINE_PROGRESS").description ("If present, the progress of the conversion is additionally written to the error output in a machine-readable form ('CWM_PROGRESS pct=<0..100> phase=<token> detail=<text>'), which allows a hosting application to display it. Can also be requested by setting the environment variable CWM_MACHINE_PROGRESS to 1.").build ());
 
             // Processing parameters
             spec.addOption (OptionSpec.builder ("-Ze", "--ProcessEnable").paramLabel ("PROCESS_ENABLE").type (Boolean.class).description ("Enables processing if set to true.").build ());
@@ -135,6 +136,9 @@ public class CLIBackend implements INotifier
         final Integer helpExitCode = CommandLine.executeHelpRequest (parseResult);
         if (helpExitCode != null)
             return helpExitCode.intValue ();
+
+        if (parseResult.matchedOptionValue ('P', null) != null)
+            MachineProgressReporter.activate ();
 
         // Basic setup
         final String sourceFormat = parseResult.matchedOptionValue ('s', "");

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/MachineProgressReporter.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/MachineProgressReporter.java
@@ -1,0 +1,258 @@
+// Written by Jürgen Moßgraber - mossgrabers.de
+// (c) 2019-2026
+// Licensed under LGPLv3 - http://www.gnu.org/licenses/lgpl-3.0.txt
+
+package de.mossgrabers.convertwithmoss.core;
+
+import java.io.File;
+
+
+/**
+ * Reports the progress of a conversion in a machine-readable form on the standard error stream, so
+ * that an application which runs ConvertWithMoss as a child process can drive a progress bar with
+ * it. The human readable output on the standard output stream is not changed by this - a conversion
+ * started from a console still writes only its progress dots there.
+ * <p>
+ * The protocol is off by default and must be requested, either with the '-P' option of the command
+ * line interface or by setting the environment variable CWM_MACHINE_PROGRESS to '1' or 'true' (for
+ * hosts which cannot add options to the command line). As long as it is off, all of the calls below
+ * do nothing but test one flag.
+ * <p>
+ * Each event is one line which is terminated with a line separator and flushed immediately:
+ *
+ * <pre>
+ * CWM_PROGRESS pct=&lt;0..100&gt; phase=&lt;token&gt; detail=&lt;text&gt;
+ * </pre>
+ *
+ * The phase is one of 'start' (the run begins), 'convert' (a source file was started or finished),
+ * 'sample' (a sample file of the current source file was loaded) and 'done' (the run ended; if it
+ * was cancelled the percentage is the one which was reached and not 100). The detail is the rest of
+ * the line and may contain spaces since it is a file name or a path. It is reduced to printable
+ * ASCII characters, so that the two processes do not need to agree on a character encoding. Any
+ * line which is not understood should be ignored.
+ * <p>
+ * All progress calls happen on the thread which executes the detection; only the activation happens
+ * before that thread is started.
+ *
+ * @author Jürgen Moßgraber
+ */
+public final class MachineProgressReporter
+{
+    /** The prefix which starts every line of the protocol. */
+    private static final String     PREFIX                = "CWM_PROGRESS";
+    /** The environment variable which activates the protocol instead of the command line option. */
+    private static final String     ENVIRONMENT_VARIABLE  = "CWM_MACHINE_PROGRESS";
+
+    private static final String     PHASE_START           = "start";
+    private static final String     PHASE_CONVERT         = "convert";
+    private static final String     PHASE_SAMPLE          = "sample";
+    private static final String     PHASE_DONE            = "done";
+
+    /**
+     * The number of loaded samples after which about 63% of the percentage range of the current
+     * source file is covered. How many samples a source file contains is not known before it was
+     * read, therefore the progress inside of a file can only approach the end of its range instead
+     * of walking towards it in known steps.
+     */
+    private static final double     SAMPLE_CURVE_SCALE    = 25.0;
+    /** The maximum length of the detail text. A longer text keeps its end, e.g. the file name. */
+    private static final int        MAX_DETAIL_LENGTH     = 180;
+
+    private static volatile boolean isActive              = isActivatedByEnvironment ();
+
+    private static boolean          isRunning             = false;
+    private static int              numberOfFiles         = 0;
+    private static int              numberOfFinishedFiles = 0;
+    private static int              numberOfSamplesOfFile = 0;
+
+
+    /**
+     * Constructor. Private due to utility class.
+     */
+    private MachineProgressReporter ()
+    {
+        // Intentionally empty
+    }
+
+
+    /**
+     * Activate the protocol. Called for the option of the command line interface; the environment
+     * variable is checked on its own.
+     */
+    public static void activate ()
+    {
+        isActive = true;
+    }
+
+
+    /**
+     * Is the protocol active?
+     *
+     * @return True if progress lines are written
+     */
+    public static boolean isActive ()
+    {
+        return isActive;
+    }
+
+
+    /**
+     * Report the start of a detection run.
+     *
+     * @param sourceFolder The folder which is processed
+     * @param numberOfSourceFiles The number of source files which will be processed. Set to 0 if
+     *            that number is unknown, the progress then only moves with the loaded samples.
+     */
+    public static void start (final File sourceFolder, final int numberOfSourceFiles)
+    {
+        if (!isActive)
+            return;
+
+        numberOfFiles = Math.max (0, numberOfSourceFiles);
+        numberOfFinishedFiles = 0;
+        numberOfSamplesOfFile = 0;
+        isRunning = true;
+
+        report (0, PHASE_START, sourceFolder == null ? "" : sourceFolder.getAbsolutePath ());
+    }
+
+
+    /**
+     * Report that the given source file is now read.
+     *
+     * @param sourceFile The source file
+     */
+    public static void startFile (final File sourceFile)
+    {
+        if (!isRunning)
+            return;
+
+        numberOfSamplesOfFile = 0;
+        report (calcPercent (), PHASE_CONVERT, sourceFile.getName ());
+    }
+
+
+    /**
+     * Report that the given source file was fully processed.
+     *
+     * @param sourceFile The source file
+     */
+    public static void finishFile (final File sourceFile)
+    {
+        if (!isRunning)
+            return;
+
+        numberOfFinishedFiles++;
+        numberOfSamplesOfFile = 0;
+        report (calcPercent (), PHASE_CONVERT, sourceFile.getName ());
+    }
+
+
+    /**
+     * Report that a sample file of the current source file was loaded.
+     *
+     * @param sampleFile The sample file
+     */
+    public static void reportSample (final File sampleFile)
+    {
+        if (!isRunning)
+            return;
+
+        numberOfSamplesOfFile++;
+        report (calcPercent (), PHASE_SAMPLE, sampleFile.getName ());
+    }
+
+
+    /**
+     * Report the end of the detection run.
+     *
+     * @param cancelled True if the run was cancelled; the reported percentage is then the one which
+     *            was reached instead of 100
+     */
+    public static void finish (final boolean cancelled)
+    {
+        if (!isRunning)
+            return;
+
+        isRunning = false;
+        report (cancelled ? calcPercent () : 100, PHASE_DONE, "");
+    }
+
+
+    /**
+     * Calculate the percentage which is currently reached. The full range is split into one slice
+     * per source file. Inside of a slice the progress approaches the end of the slice with the
+     * number of loaded samples but never reaches it, since the number of samples of a source file
+     * is only known once it was read - the end of a slice is therefore only reached by finishing
+     * the file. If more files are finished than were counted, the total is raised accordingly, so
+     * that the percentage never runs backwards or above 100.
+     *
+     * @return The percentage, 0-100
+     */
+    private static int calcPercent ()
+    {
+        final int total = Math.max (1, Math.max (numberOfFiles, numberOfFinishedFiles));
+        final int lowerBound = (int) (numberOfFinishedFiles * 100L / total);
+        final int upperBound = (int) Math.min (100L, (numberOfFinishedFiles + 1L) * 100L / total);
+        // The upper bound belongs to the next file, therefore stay 1 percent below it
+        final int span = Math.max (0, upperBound - 1 - lowerBound);
+        final double factor = 1.0 - Math.exp (-numberOfSamplesOfFile / SAMPLE_CURVE_SCALE);
+        return Math.min (100, lowerBound + (int) Math.round (span * factor));
+    }
+
+
+    /**
+     * Write one line of the protocol.
+     *
+     * @param percent The percentage, clipped to 0-100
+     * @param phase The phase
+     * @param detail The detail text
+     */
+    private static void report (final int percent, final String phase, final String detail)
+    {
+        final StringBuilder sb = new StringBuilder (PREFIX);
+        sb.append (" pct=").append (Math.max (0, Math.min (100, percent)));
+        sb.append (" phase=").append (phase);
+        sb.append (" detail=").append (sanitize (detail));
+        System.err.println (sb.toString ());
+        System.err.flush ();
+    }
+
+
+    /**
+     * Reduce the given text to one line of printable ASCII characters, so that a line of the
+     * protocol can always be parsed and no character encoding has to be agreed upon between the
+     * processes. All other characters are replaced by a question mark. A text which is too long
+     * keeps its end, which is the interesting part of a path.
+     *
+     * @param detail The text to sanitize
+     * @return The sanitized text
+     */
+    private static String sanitize (final String detail)
+    {
+        if (detail == null)
+            return "";
+
+        final StringBuilder sb = new StringBuilder (detail.length ());
+        for (int i = 0; i < detail.length (); i++)
+        {
+            final char c = detail.charAt (i);
+            sb.append (c >= 0x20 && c < 0x7F ? c : '?');
+        }
+
+        final String text = sb.toString ().trim ();
+        return text.length () > MAX_DETAIL_LENGTH ? text.substring (text.length () - MAX_DETAIL_LENGTH) : text;
+    }
+
+
+    /**
+     * Test if the protocol was activated by the environment variable.
+     *
+     * @return True if the variable is set to '1' or 'true'
+     */
+    private static boolean isActivatedByEnvironment ()
+    {
+        final String value = System.getenv (ENVIRONMENT_VARIABLE);
+        return "1".equals (value) || "true".equalsIgnoreCase (value);
+    }
+}

--- a/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/core/detector/AbstractDetector.java
@@ -41,6 +41,7 @@ import de.mossgrabers.convertwithmoss.core.IInstrumentSource;
 import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
 import de.mossgrabers.convertwithmoss.core.INotifier;
 import de.mossgrabers.convertwithmoss.core.IPerformanceSource;
+import de.mossgrabers.convertwithmoss.core.MachineProgressReporter;
 import de.mossgrabers.convertwithmoss.core.model.IFileBasedSampleData;
 import de.mossgrabers.convertwithmoss.core.model.IGroup;
 import de.mossgrabers.convertwithmoss.core.model.IMetadata;
@@ -362,6 +363,8 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
 
     private void handlePresetFile (final File file)
     {
+        MachineProgressReporter.startFile (file);
+
         try
         {
             for (final IMultisampleSource multisample: this.readPresetFile (file))
@@ -377,11 +380,17 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
         {
             this.notifier.logError (ex);
         }
+        finally
+        {
+            MachineProgressReporter.finishFile (file);
+        }
     }
 
 
     private void handlePerformanceFile (final File file)
     {
+        MachineProgressReporter.startFile (file);
+
         try
         {
             final List<IPerformanceSource> performances = this.readPerformanceFile (file);
@@ -400,6 +409,10 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
         catch (final RuntimeException ex)
         {
             this.notifier.logError (ex);
+        }
+        finally
+        {
+            MachineProgressReporter.finishFile (file);
         }
     }
 
@@ -430,6 +443,8 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
     @Override
     public void run ()
     {
+        MachineProgressReporter.start (this.sourceFolder, this.countSourceFiles ());
+
         try
         {
             if (this.sourceFiles.isEmpty ())
@@ -441,7 +456,66 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
         {
             this.notifier.logError (err);
         }
+
+        MachineProgressReporter.finish (this.isCancelled ());
         this.notifier.finished (this.isCancelled ());
+    }
+
+
+    /**
+     * Count the source files which this detection run will read. This is only needed to calculate
+     * the percentage of the machine-readable progress protocol and is therefore only counted if
+     * that protocol is active, since it walks the whole source folder a second time.
+     *
+     * @return The number of source files, 0 if that number cannot be told in advance
+     */
+    private int countSourceFiles ()
+    {
+        if (!MachineProgressReporter.isActive ())
+            return 0;
+        if (!this.sourceFiles.isEmpty ())
+            return this.sourceFiles.size ();
+        // A detector without file endings does not read files but folders
+        return this.fileEndings.length == 0 ? 0 : countFiles (this.sourceFolder, this.fileEndings);
+    }
+
+
+    /**
+     * Count all files in the given folder and its sub-folders which match one of the given file
+     * endings. This applies exactly the same criteria as the detection run itself.
+     *
+     * @param folder The folder to start counting
+     * @param endings The file endings to match, including the dot, e.g. '.wav'
+     * @return The number of matching files
+     */
+    private static int countFiles (final File folder, final String... endings)
+    {
+        final File [] children = folder.listFiles ();
+        if (children == null)
+            return 0;
+
+        int count = 0;
+        for (final File child: children)
+        {
+            if (child.isDirectory ())
+            {
+                count += countFiles (child, endings);
+                continue;
+            }
+
+            // Ignore MacOS crap
+            if (child.getName ().startsWith ("._"))
+                continue;
+
+            final String lower = child.getName ().toLowerCase (Locale.US);
+            for (final String ending: endings)
+                if (lower.endsWith (ending))
+                {
+                    count++;
+                    break;
+                }
+        }
+        return count;
     }
 
 
@@ -730,6 +804,23 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
      */
     protected ISampleData createSampleData (final File zipFile, final File sampleFile) throws IOException
     {
+        final ISampleData sampleData = loadSampleData (zipFile, sampleFile);
+        MachineProgressReporter.reportSample (sampleFile);
+        return sampleData;
+    }
+
+
+    /**
+     * Check the type of the source sample for compatibility and handle them accordingly. This
+     * method supports WAV, AIF, AIFF, OGG and FLAC files. The file is compressed in a ZIP file.
+     *
+     * @param zipFile The ZIP file which contains the sample file
+     * @param sampleFile The sample file for which to create sample metadata
+     * @return The matching sample metadata, support is WAV and AIFF
+     * @throws IOException Unsupported sample file type
+     */
+    private static ISampleData loadSampleData (final File zipFile, final File sampleFile) throws IOException
+    {
         final String fileEnding = sampleFile.getName ().toLowerCase ();
 
         if (fileEnding.endsWith (".wav"))
@@ -756,6 +847,23 @@ public abstract class AbstractDetector<T extends ICoreTaskSettings> extends Abst
      * @throws IOException Unsupported sample file type
      */
     public static IFileBasedSampleData createSampleData (final File sampleFile, final INotifier notifier) throws IOException
+    {
+        final IFileBasedSampleData sampleData = loadSampleData (sampleFile, notifier);
+        MachineProgressReporter.reportSample (sampleFile);
+        return sampleData;
+    }
+
+
+    /**
+     * Check the type of the source sample for compatibility and handle them accordingly. This
+     * method supports WAV, AIF, AIFF, OGG and FLAC files.
+     *
+     * @param sampleFile The sample file for which to create sample metadata
+     * @param notifier Where to report errors
+     * @return The matching sample metadata, support is WAV and AIFF
+     * @throws IOException Unsupported sample file type
+     */
+    private static IFileBasedSampleData loadSampleData (final File sampleFile, final INotifier notifier) throws IOException
     {
         if (!sampleFile.exists ())
             throw new FileNotFoundException (Functions.getMessage ("IDS_NOTIFY_ERR_SAMPLE_DOES_NOT_EXIST", sampleFile.getAbsolutePath ()));


### PR DESCRIPTION
Closes #141.

Implements the protocol proposed there, with the neutral `CWM_PROGRESS` prefix asked for in the issue.

## Why

The command line reports progress as a row of dots. An application which runs ConvertWithMoss as a child process cannot derive a percentage or a current item from those dots, so its own progress bar sits at 0% for as long as the conversion runs and then jumps to 100%. That is exactly the case #141 describes for a large Kontakt library, where one `.nki` with several hundred samples takes minutes.

## What

`-P` / `--machine-progress` additionally writes one line per event to **stderr**, flushed immediately:

```
CWM_PROGRESS pct=<0..100> phase=<token> detail=<text>
```

* `pct` - 0 to 100.
* `phase` - `start` (the run begins), `convert` (a source file was started or finished), `sample` (a sample file of the current source file was loaded), `done` (the run ended; if it was cancelled the percentage is the one which was reached and not 100).
* `detail` - the rest of the line, so it may contain spaces since it is a file name or a path. It is reduced to printable ASCII, so the two processes do not have to agree on a character encoding; everything else becomes a question mark.

The environment variable `CWM_MACHINE_PROGRESS=1` (or `true`) does the same, for hosts which cannot add options to the command line. Without either, nothing is written and nothing changes - the stdout of a run with and without `-P` is byte-identical.

Real output of a folder with 4 SFZ instruments of 28 samples each (the `sample` lines are cut down here):

```
CWM_PROGRESS pct=0 phase=start detail=/tmp/sfz
CWM_PROGRESS pct=0 phase=convert detail=A2 (2).sfz
CWM_PROGRESS pct=1 phase=sample detail=C2.wav
CWM_PROGRESS pct=2 phase=sample detail=D2.wav
CWM_PROGRESS pct=25 phase=convert detail=A2 (2).sfz
CWM_PROGRESS pct=25 phase=convert detail=A2 (3).sfz
...
CWM_PROGRESS pct=100 phase=convert detail=A2.sfz
CWM_PROGRESS pct=100 phase=done detail=
```

## The percentage

The range is split into one slice per source file, counted up-front with the same criteria the detection uses (matching file endings, recursive, `._*` skipped); when specific source files are given instead of a folder, it is simply their number. That count only runs when the protocol is active, since it walks the folder a second time.

How many samples a source file holds is only known once it was read, so inside a slice the progress approaches the end of the slice with every loaded sample (`1 - exp(-samples / 25)`) and only reaches it when the file is finished. That is what keeps one large instrument moving instead of standing still. If more files are finished than were counted, the total is raised accordingly, so the percentage never runs backwards or reaches 100 early.

## Changes

* New `core/MachineProgressReporter` - the emitter, plus the percentage model and the sanitizing. All calls do nothing but test one flag while the protocol is off.
* `CLIBackend` - the `-P` option.
* `AbstractDetector` - `start`/`finish` in `run()`, the file counter, `startFile`/`finishFile` in `handlePresetFile()` and `handlePerformanceFile()` (which both the folder walk and the "specific source files" path go through), and `reportSample` in both `createSampleData` methods. The two bodies moved into private `loadSampleData` methods unchanged, so the reporting has one place per method instead of one per `return`.
* Manual and changelog.

The GUI is untouched. `readSource()` (audition, contents) reports nothing, since events outside of `start`..`done` are ignored.

Note that formats which do not read their samples as separate files - the disk images of the hardware samplers, for instance - only report the `convert` events. Also, when a library is written (`-l`), `done` marks the end of the detection; the library itself is written afterwards. Emitting it later would race with the process exit.

## Tested

Built and run against SFZ sources: with `-P`, with `CWM_MACHINE_PROGRESS=1`, without either (nothing on stderr), a folder as the source, specific source files as the source (`-P` on 2 of 4 files gives 0/50/100), analyse mode (`-a`), library mode (`-l`, to sf2), and a preset named `Flöte Prüfung ‹ 日本語.sfz` (folded to `Fl?te Pr?fung ? ???.sfz`). stdout is identical with and without the option in every case.
