### PR TITLE
Roland MV-8000: write the playback points which the hardware plays into the SMT slots

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -43,6 +43,9 @@
   * New: Added support for bank output (*.txbank). Select 'Preset Library' as destination output.
 * Fairlight CMI
   * Fixed: Reading a Voice file whose version is not recognized wrote a copy of that file into a hard-coded folder of the developer's machine which did crash the conversion.
+* Roland MV-8000
+  * Fixed: A written patch loaded on the device but was silent, and the device showed a start point, loop start and end point of 0 for every sample. The hardware plays - and displays - the three points which are stored in the SMT slot of a partial, not the ones of the sample parameter block, and only the latter were written. The slot points are written now; the 103 factory patches carry identical values in both places in all of their 1918 slots. Reading prefers the slot points as well, so a patch whose points were edited on the device converts with the points it actually plays.
+  * Fixed: The wave data of a written sample now keeps 2 frames behind its end point, as the device does for every sample it writes itself - none of the 1918 samples of the factory patches ends closer to the end of its data. A sample whose end point sat at the last frame of its data (a one-shot which plays to its very end, e.g. every sample of an Akai S1000 program whose end marker is its last frame) is padded with 2 frames of silence.
 * Teenage Engineering OP-XY
   * Fixed: The samples which do not make it into the written preset - the dropped velocity layers and the regions beyond the maximum of 24 - were still copied into the preset folder, although the description file does not reference them. They only occupied space on the device and could make the preset folder too big to load. Only the samples of the written regions are stored now.
 * Waldorf Quantum/Iridium

--- a/documentation/design/MV8000_FORMAT.md
+++ b/documentation/design/MV8000_FORMAT.md
@@ -193,8 +193,34 @@ patches matches the table defaults exactly.
 
 ## Not decoded / open
 
-- The hardware curve for envelope times (0-127 → seconds) and the LFO rate table;
-  they likely live in the sound-engine program (`MIAMI.PRG`), not in the main OS.
+- The hardware curve for envelope times (0-127 → seconds) and the LFO rate table.
+  The parameter block carries no unit: the partial descriptor table of MV-8000 OS
+  3.54 declares the four TVA and TVF times as plain 0-127 fields (defaults
+  0/10/10/10, min 0, max 127) and no code was found which converts them, so the
+  engine program `MIAMI.PRG` - loaded separately by the boot loader, never
+  published by Roland - is what interprets them.
+
+  What *is* in the OS is a **128 entry exponential table** at file offset 0x50538C
+  of the decompressed image (u16 big-endian, 30 → 65535, a constant ratio of
+  1.0624 per step, 11.45 steps per doubling, spanning 2184:1). The same value
+  sequence sits in the S-760 system disk (Roland's own "S-760 System Version 2.24"
+  download, `S760224.OUT` at offset 0xB63EE, u16 little-endian, stored descending):
+  all 127 overlapping entries are identical. Two further tables are shared - a 2:1
+  ramp which is a pitch/frequency ratio table and a linear normalisation ramp - and
+  the S-760 disk identifies itself as `S770 MR25A`, so the MV-8000 inherits the
+  S-7xx sound engine rather than the XV one whose category list it borrows.
+
+  A 128 entry table indexed 0-127 with that span is the natural candidate for the
+  envelope time law, and its range corroborates independently: the ZEN-Core law
+  which ConvertWithMoss measured on a FANTOM-0 spans 2150:1 (0.010 s to 21.5 s).
+  It is **not confirmed** - no code which indexes the table has been located in
+  either firmware, so the tick it counts, and with it the absolute times, are still
+  unknown. What is certain is that the S-7xx formula used today, `20 *
+  2^((v-127)/21)`, spans only 64:1 and cannot represent anything below 302 ms,
+  which no calibrated Roland law does.
+
+  Recording the hardware settles it: a patch which maps one looped sine to a row of
+  pads whose only difference is the envelope time under test gives the law directly.
 - The exact roles of the ±63 sensitivity params around the TVF/TVA envelopes, and the
   unit of the 8-bit sub-frame parts of the slot playback points (1/256 frame?).
 - Patch common bits 155-416 beyond category/level/pan/mute-group/tuning (contains at

--- a/documentation/design/MV8000_FORMAT.md
+++ b/documentation/design/MV8000_FORMAT.md
@@ -38,7 +38,7 @@ offset  size  content
               end in 0x7F 'L' / 0x7F 'R' (consecutive IDs, L first)
 20      4     u32 start point (frames)
 24      4     u32 loop start (frames)
-28      4     u32 end point (frames; wave data may extend past it)
+28      4     u32 end point (frames, exclusive; it is the loop end as well)
 32      1     0x27 (constant tag, same value appears in partial records)
 33      1     root key (MIDI note; 36 or 60 for unpitched material)
 34      4     u32 BPM × 100 (12000 = 120.00 in all factory samples)
@@ -46,6 +46,21 @@ offset  size  content
 
 `WAVE` payload: headerless 16-bit big-endian signed mono PCM. The device sample rate
 is fixed 44.1 kHz (no rate field exists).
+
+The wave data always extends past the end point: no factory sample ends closer than
+2 frames to the end of its data (1874 of 1918 samples keep more, 44 keep exactly 2),
+so a writer should keep that distance as well. The end point is exclusive: for a
+forward loop the frame *at* the end point continues the waveform at the loop start
+(tested on the 172 factory loops with integer loop points - the frame at `end`
+matches the loop start with a median error of 0.1 % of the level, the frames before
+and after it do not).
+
+**The three playback points are stored a second time in every SMT slot which
+references the sample (see the slot layout below), and the hardware plays and
+displays the slot copy.** In all 1918 slots of the factory patches both copies are
+identical. A slot whose points are left at zero is silent on the device (end point
+0), whatever the sample parameter block says - files written by ConvertWithMoss
+before 20.2.0 did exactly this.
 
 ## Patch PRM chunk (15862 bytes)
 
@@ -109,9 +124,9 @@ factory files).
 | [66..73)  | velocity fade lower (0-125, default 0) | |
 | [73..80)  | velocity range upper (2-127, default 127) | |
 | [80..87)  | velocity fade upper (0-125, default 0) | |
-| [87..119) | 32-bit value + [119..127) 8-bit value, defaults 0 | unknown (sample offsets?) |
-| [127..159)| 32-bit value + [159..167) 8-bit value, defaults 0 | unknown |
-| [167..199)| 32-bit value + [199..207) 8-bit value, defaults 0 | unknown; varies in beat kits |
+| [87..119) | **start point** (u32 frames) + [119..127) 8-bit sub-frame part | identical to the start point of the sample in all factory slots; the hardware plays these slot points |
+| [127..159)| **loop start** (u32 frames) + [159..167) 8-bit sub-frame part | identical to the loop start of the sample; the 8-bit part is non-zero in 680 of 1918 slots (loops tuned below one frame) |
+| [167..199)| **end point** (u32 frames, exclusive) + [199..207) 8-bit sub-frame part | identical to the end point of the sample; also the loop end |
 | [207..210)| **play mode**, 3 bits (0-4, default 1): 0 = loop [loopStart..endPoint], 1 = one-shot (ignores loop, plays to sample end); 2/4 = rare alternative loop modes (alternating/reverse?), 3 = rare one-shot variant. Uneven values do not loop | factory census: mode 1 ×1006, mode 0 ×899, mode 2 ×9, mode 3 ×4 |
 
 ### TVF / TVA / LFO block (record bits 993-1298, all (fw))
@@ -180,8 +195,8 @@ patches matches the table defaults exactly.
 
 - The hardware curve for envelope times (0-127 → seconds) and the LFO rate table;
   they likely live in the sound-engine program (`MIAMI.PRG`), not in the main OS.
-- The exact roles of the ±63 sensitivity params around the TVF/TVA envelopes and of
-  the three 32+8-bit values per SMT slot.
+- The exact roles of the ±63 sensitivity params around the TVF/TVA envelopes, and the
+  unit of the 8-bit sub-frame parts of the slot playback points (1/256 frame?).
 - Patch common bits 155-416 beyond category/level/pan/mute-group/tuning (contains at
   least one per-patch varying param around bits 317-325).
 - MV-8800: the partial descriptor table in the MV-8800 OS 1.01 firmware (decompressed

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Creator.java
@@ -49,6 +49,12 @@ public class MV8000Creator extends AbstractCreator<ShortNameSettingsUI>
         16
     }, MV8000Sample.SAMPLE_RATE, true);
 
+    /**
+     * The device keeps at least this number of frames of wave data behind the end point of a
+     * sample (no sample of the factory patches ends closer to the end of its data).
+     */
+    private static final int                    GUARD_FRAMES       = 2;
+
     private static final Map<String, Integer>   CATEGORY_MAP       = new HashMap<> ();
     static
     {
@@ -210,20 +216,24 @@ public class MV8000Creator extends AbstractCreator<ShortNameSettingsUI>
         final byte [] pcmData = waveFile.getDataChunk ().getData ();
         final int numFrames = pcmData.length / (2 * numChannels);
 
-        // Loop and playback range
+        // Loop and playback range. The end point is exclusive and is the loop end as well
         final List<ISampleLoop> loops = zone.getLoops ();
         // A one-shot slot ignores a note-off - and the loop - and plays the sample up to its end
         final boolean isOneShot = zone.isOneShot () || loops.isEmpty ();
         final boolean isKeyTracked = zone.getKeyTracking () != 0;
+        final int startPoint = Math.clamp (zone.getStart (), 0, numFrames);
         int loopStart = 0;
         int endPoint = zone.getStop () > 0 ? Math.min (zone.getStop (), numFrames) : numFrames;
         if (!loops.isEmpty ())
         {
             final ISampleLoop loop = loops.get (0);
             loopStart = Math.clamp (loop.getStart (), 0, numFrames);
-            if (loop.getEnd () > loopStart)
+            if (!isOneShot && loop.getEnd () > loopStart)
                 endPoint = Math.min (loop.getEnd (), numFrames);
         }
+        // Pad the wave data with silence to keep the distance behind the end point which the
+        // device keeps for its own samples
+        final int paddedFrames = Math.max (numFrames, endPoint + GUARD_FRAMES);
 
         // Split the tuning into the coarse and fine tune fields
         final double tuning = zone.getTuning ();
@@ -238,8 +248,7 @@ public class MV8000Creator extends AbstractCreator<ShortNameSettingsUI>
         int nextSampleId = sampleId;
         for (int channel = 0; channel < numSlots; channel++)
         {
-            final byte [] waveData = extractChannelBigEndian (pcmData, numChannels, channel);
-            final int startPoint = Math.clamp (zone.getStart (), 0, numFrames);
+            final byte [] waveData = extractChannelBigEndian (pcmData, numChannels, channel, paddedFrames);
 
             // Re-use an already written sample with identical content and parameters, e.g. when
             // the same sample is mapped to several key ranges. The root key does not matter for
@@ -269,6 +278,10 @@ public class MV8000Creator extends AbstractCreator<ShortNameSettingsUI>
 
             final MV8000Smt slot = partial.getSmtSlot (slotCounts[partialIndex]);
             slot.setSampleId (id.intValue ());
+            // The hardware plays the points of the slot, not the ones of the sample
+            slot.setStartPoint (startPoint);
+            slot.setLoopStart (loopStart);
+            slot.setEndPoint (endPoint);
             slot.setLevel (Math.clamp ((int) Math.round (Math.pow (10, zone.getGain () / 20.0) * 127.0), 0, 127));
             // The 2 mono halves of a stereo zone are hard-panned to re-create the stereo image
             if (isStereo)
@@ -437,10 +450,20 @@ public class MV8000Creator extends AbstractCreator<ShortNameSettingsUI>
     }
 
 
-    private static byte [] extractChannelBigEndian (final byte [] pcmData, final int numChannels, final int channel)
+    /**
+     * Extract one channel of interleaved 16-bit little-endian PCM data as big-endian data.
+     *
+     * @param pcmData The interleaved PCM data
+     * @param numChannels The number of channels in the PCM data
+     * @param channel The channel to extract
+     * @param outputFrames The number of frames of the result, padded with silence if it is larger
+     *            than the number of frames of the PCM data
+     * @return The channel data
+     */
+    private static byte [] extractChannelBigEndian (final byte [] pcmData, final int numChannels, final int channel, final int outputFrames)
     {
-        final int numFrames = pcmData.length / (2 * numChannels);
-        final byte [] channelData = new byte [numFrames * 2];
+        final int numFrames = Math.min (pcmData.length / (2 * numChannels), outputFrames);
+        final byte [] channelData = new byte [outputFrames * 2];
         for (int i = 0; i < numFrames; i++)
         {
             final int src = (i * numChannels + channel) * 2;

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Detector.java
@@ -222,8 +222,15 @@ public class MV8000Detector extends AbstractDetector<MetadataSettingsUI>
         zone.setVelocityHigh (slot.getVelocityHigh ());
         zone.setVelocityCrossfadeHigh (slot.getVelocityFadeHigh ());
 
-        zone.setStart (sample.getStartPoint ());
-        zone.setStop (sample.getEndPoint ());
+        // The hardware plays the points stored in the slot, which the device keeps identical to the
+        // ones of the sample. Files written by ConvertWithMoss before 20.2.0 left the slot points at
+        // zero, for those the points of the sample are used
+        final boolean hasSlotPoints = slot.getEndPoint () > 0;
+        final int startPoint = hasSlotPoints ? slot.getStartPoint () : sample.getStartPoint ();
+        final int loopStart = hasSlotPoints ? slot.getLoopStart () : sample.getLoopStart ();
+        final int endPoint = hasSlotPoints ? slot.getEndPoint () : sample.getEndPoint ();
+        zone.setStart (startPoint);
+        zone.setStop (endPoint);
         zone.setGain (MathUtils.valueToDb (slot.getLevel () / 127.0));
         // The slots of a combined stereo pair are hard-panned (left 32, right 96) to create the
         // stereo image which is already baked into the combined zone
@@ -258,8 +265,8 @@ public class MV8000Detector extends AbstractDetector<MetadataSettingsUI>
                 default -> LoopType.FORWARDS;
             };
             sampleLoop.setType (type);
-            sampleLoop.setStart (sample.getLoopStart ());
-            sampleLoop.setEnd (sample.getEndPoint ());
+            sampleLoop.setStart (loopStart);
+            sampleLoop.setEnd (endPoint);
             if (sampleLoop.getEnd () > sampleLoop.getStart ())
                 zone.getLoops ().add (sampleLoop);
         }

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Smt.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mv8000/MV8000Smt.java
@@ -6,7 +6,10 @@ package de.mossgrabers.convertwithmoss.format.roland.mv8000;
 
 /**
  * One of the 4 sample-mix-table (SMT) slots of a MV-8000 partial. Reads/writes the bit-packed
- * fields inside the 210 bit slot frame of a partial record.
+ * fields inside the 210 bit slot frame of a partial record. Besides the mixing parameters a slot
+ * stores the start point, the loop start and the end point of its sample: the hardware plays (and
+ * displays) these points and not the ones of the sample parameter block, which the device keeps
+ * identical to them.
  *
  * @author Jürgen Moßgraber
  */
@@ -27,6 +30,10 @@ public class MV8000Smt
     private static final int     OFFSET_FADE_LOW    = 66;
     private static final int     OFFSET_VELO_HIGH   = 73;
     private static final int     OFFSET_FADE_HIGH   = 80;
+    // Each of the 3 playback points is a 32 bit frame count followed by an 8 bit sub-frame part
+    private static final int     OFFSET_START_POINT = 87;
+    private static final int     OFFSET_LOOP_START  = 127;
+    private static final int     OFFSET_END_POINT   = 167;
     private static final int     OFFSET_PLAY_MODE   = 207;
 
     /** Pitch key-follow value for +100% (normal chromatic tracking). */
@@ -273,6 +280,72 @@ public class MV8000Smt
     public void setVelocityFadeHigh (final int fadeHigh)
     {
         this.bits.setBits (this.baseOffset + OFFSET_FADE_HIGH, 7, fadeHigh);
+    }
+
+
+    /**
+     * Get the start point of the playback in sample frames.
+     *
+     * @return The start point
+     */
+    public int getStartPoint ()
+    {
+        return this.bits.getBits (this.baseOffset + OFFSET_START_POINT, 32);
+    }
+
+
+    /**
+     * Set the start point of the playback in sample frames.
+     *
+     * @param startPoint The start point
+     */
+    public void setStartPoint (final int startPoint)
+    {
+        this.bits.setBits (this.baseOffset + OFFSET_START_POINT, 32, startPoint);
+    }
+
+
+    /**
+     * Get the loop start in sample frames.
+     *
+     * @return The loop start
+     */
+    public int getLoopStart ()
+    {
+        return this.bits.getBits (this.baseOffset + OFFSET_LOOP_START, 32);
+    }
+
+
+    /**
+     * Set the loop start in sample frames.
+     *
+     * @param loopStart The loop start
+     */
+    public void setLoopStart (final int loopStart)
+    {
+        this.bits.setBits (this.baseOffset + OFFSET_LOOP_START, 32, loopStart);
+    }
+
+
+    /**
+     * Get the end point of the playback in sample frames (exclusive). This is also the loop end.
+     *
+     * @return The end point, 0 if the slot does not carry the playback points
+     */
+    public int getEndPoint ()
+    {
+        return this.bits.getBits (this.baseOffset + OFFSET_END_POINT, 32);
+    }
+
+
+    /**
+     * Set the end point of the playback in sample frames (exclusive). This is also the loop end.
+     *
+     * @param endPoint The end point
+     */
+    public void setEndPoint (final int endPoint)
+    {
+        this.bits.setBits (this.baseOffset + OFFSET_END_POINT, 32, endPoint);
     }
 
 


### PR DESCRIPTION
An E-mu Emulator IV bank converted to MV-8000 loads on an MV-8800 but is silent: the device shows a start point, loop start and end point of `00000000` for every sample, and setting an end point by hand brings the sound back (report forwarded by mail, 2026-08-20, test files included).

**Cause.** The MV-8000 stores the three playback points of a sample twice: in the 38-byte sample parameter block and in every SMT slot which references the sample - the three 32+8-bit values per slot which the spec listed as "unknown, default 0". The hardware plays and displays the slot copy. ConvertWithMoss filled only the sample block, so every slot it ever wrote played `start 0 / loop 0 / end 0`.

Evidence from the 103 factory patches (Roland's official *MV-8000 Factory Patches* download):

- in all 1918 used slots the slot points are identical to the points of their sample (start up to 61946, loop start up to 311575, end 31..1171943 - the same ranges in both places);
- the 8-bit companions are sub-frame fine parts (non-zero in 680 loop starts and 729 end points);
- the end point is exclusive: for the 172 forward loops with integer points the frame *at* `end` continues the waveform at the loop start with a median error of 0.1 % of the level, the frames before and after it do not;
- no sample ends closer than 2 frames to the end of its wave data (44 at exactly 2, 1874 further away).

**Fix.**

- `MV8000Smt` gains the start point, loop start and end point; the creator writes them equal to the sample's and the detector reads them, falling back to the sample block for files written by earlier versions (their slot points are zero).
- The wave data keeps 2 frames behind the end point like every factory sample; a sample which ended right at its end point is padded with silence.
- A one-shot zone which also carries a loop plays to its stop instead of to the loop end (the slot ignores the loop anyway).
- `documentation/design/MV8000_FORMAT.md` updated: slot layout, end-point convention, guard frames.

**Verification.** The E-mu bank of the report (474 patches, 2992 samples) and the two Akai S1000 images (1245 patches, 5980 samples): every slot now carries the points of its sample, no sample ends with fewer than 2 guard frames. Round trip of all 103 factory patches through the detector and creator: the same fidelity as `main` - the same 68 files preserved in every compared attribute (PCM, points, velocity ranges, play modes, levels, pan, key follow, key ranges), the same 33 files differing in the same pre-existing ways (one-shot slots lose their unused loop start, the pan modes 97-102 are clamped to 96, stereo halves with different loop points take the left's, non-contiguous key runs are split into two partials).

**The second report - Akai S1000 conversions rejected by the MV-8800 as "Unknown file format" - is not explained by the content of those files.** Their header, chunk layout and every decoded field stay inside the ranges of the factory files, and the firmware's patch descriptor table accepts their category 0 ("No assign" is the first entry of its category list). Two differences against the E-mu conversions which the same device loaded: 2857 of their 5980 samples had the end point exactly one frame before the end of the wave data (the S1000 end marker is the last frame) - this PR removes that; and they sit one folder level deeper, in `DMJR.iso/<volume name>/`, while the E-mu patches sit in `B.007-ORBIT-PHATT/`. The reporter could tell whether the message appears when entering the `.iso` folder or when loading a patch, and whether the patches load from a plain folder.
