### PR TITLE
ISLA S2400: remove the unused pitchFineCents local in the creator

### DIFF
--- a/src/main/java/de/mossgrabers/convertwithmoss/format/isla/s2400/S2400Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/isla/s2400/S2400Creator.java
@@ -175,7 +175,6 @@ public class S2400Creator extends AbstractWavCreator<WavChunkSettingsUI>
         final boolean stereo = audioMetadata.getChannels () > 1;
 
         final int gainDb = (int) Math.round (zone.getGain ());
-        final int pitchFineCents = (int) Math.round (zone.getTuning () * 100.0);
         final int chokeGroup = Math.max (0, zone.getExclusiveGroup ());
         final int gate = zone.isOneShot () ? 0 : 1;
         final int mixdown = stereo ? S2400Constants.MIXDOWN_STEREO : S2400Constants.MIXDOWN_MONO_LR;
@@ -223,6 +222,7 @@ public class S2400Creator extends AbstractWavCreator<WavChunkSettingsUI>
     private static void writeMainSlot (final ByteArrayOutputStream out, final ISampleZone zone, final int frames, final double durationSeconds)
     {
         final int end = Math.max (0, frames - 1);
+        final int pitchFineCents = (int) Math.round (zone.getTuning () * 100.0);
 
         int filterMode = S2400Constants.FILTER_LOW_PASS;
         int resonance = 0;
@@ -245,7 +245,7 @@ public class S2400Creator extends AbstractWavCreator<WavChunkSettingsUI>
         writeU32Record (out, S2400Constants.FIELD_FILTER_MODE, filterMode);
         writeU32Record (out, S2400Constants.FIELD_FILTER_RESONANCE, resonance);
         writeU32Record (out, S2400Constants.FIELD_FILTER_CUTOFF, cutoffHertz);
-        writeI32Record (out, S2400Constants.FIELD_PITCH_FINE, (int) Math.round (zone.getTuning () * 100.0));
+        writeI32Record (out, S2400Constants.FIELD_PITCH_FINE, pitchFineCents);
         writeU32Record (out, S2400Constants.FIELD_SLICE_START, 0);
         writeU32Record (out, S2400Constants.FIELD_SLICE_END, end);
         writeU32Record (out, S2400Constants.FIELD_RESERVED_34, 0);


### PR DESCRIPTION
`writeTrack` computed `pitchFineCents` but never used it: `writeMainSlot` recomputed the same expression inline when writing `FIELD_PITCH_FINE`, so the fine tune was already written correctly and the local was a leftover. This moves the local into `writeMainSlot` and writes the field from it.

Verified: a 2-zone SFZ with `tune=37` / `tune=-22` converted to a kit with this branch and with `main` gives byte-identical `.kit` and `.wav` files, and the kit converted back to SFZ returns `tune=37` / `tune=-22`.

Fixes #376
