### PR TITLE
Elektron Tonverk: report a missing sample once per preset, and a preset without any found sample as skipped

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -25,6 +25,8 @@
 * E-mu Emulator III
   * Fixed: Forward/backward ('fwd/bkwd') loops of Emulator III banks were lost. The loop type of a sample is a 2 bit field - 0: off, 1: forward, 2: forward/backward - and only the forward bit was tested, so a forward/backward sample was converted as not looped at all. Such loops are now read as alternating loops, which destinations that support them play as intended (e.g. TAL Sampler as a ping-pong loop). The field layout was verified against the sampler's OS 2.42 firmware; only the original Emulator III knows this loop type, the Emulator IIIX and ESI have dropped it.
   * New: The 'Reverse Playback' flag of a sample is now read and applied to its zones.
+* Elektron Tonverk Preset
+  * Fixed: A sample which could not be found was reported once for every key-zone which is cut out of it - a Multi preset which spreads one WAV file across the keyboard gave a dozen identical lines. A missing sample is now reported once per preset, and a preset none of whose samples could be found is reported as skipped.
 * NI Kontakt
   * Fixed: Fixed a null pointer exception reading Kontakt 1 NKIs which was introduced in 20.2.
 * SoundFont 2

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/TonverkPresetDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/elektron/TonverkPresetDetector.java
@@ -9,8 +9,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 
 import de.mossgrabers.convertwithmoss.core.IMultisampleSource;
@@ -74,6 +76,9 @@ public class TonverkPresetDetector extends AbstractDetector<MetadataSettingsUI>
         FilterType.BAND_REJECTION
     };
 
+    /** The samples of the preset being read which were already reported as missing. */
+    private final Set<String>          reportedMissingSamples  = new HashSet<> ();
+
 
     /**
      * Constructor.
@@ -111,6 +116,8 @@ public class TonverkPresetDetector extends AbstractDetector<MetadataSettingsUI>
 
     private Optional<IMultisampleSource> convertPreset (final File sourceFile, final TonverkPresetFile preset) throws IOException
     {
+        this.reportedMissingSamples.clear ();
+
         final List<IGroup> groups;
         switch (preset.machine)
         {
@@ -130,7 +137,10 @@ public class TonverkPresetDetector extends AbstractDetector<MetadataSettingsUI>
         }
 
         if (groups.isEmpty ())
+        {
+            this.notifier.logError ("IDS_TONVERK_NO_SAMPLES", sourceFile.getName ());
             return Optional.empty ();
+        }
 
         final IMultisampleSource multisampleSource = this.createMultisampleSource (sourceFile, FileUtils.getNameWithoutType (sourceFile), groups);
 
@@ -211,7 +221,7 @@ public class TonverkPresetDetector extends AbstractDetector<MetadataSettingsUI>
         final Optional<File> sampleFile = resolveSample (sourceFile, preset.param (prefix + "_sample_slot"));
         if (sampleFile.isEmpty ())
         {
-            this.notifier.logError ("IDS_TONVERK_SAMPLE_NOT_FOUND", preset.param (prefix + "_sample_slot"));
+            this.reportMissingSample (preset.param (prefix + "_sample_slot"));
             return Collections.emptyList ();
         }
 
@@ -323,7 +333,7 @@ public class TonverkPresetDetector extends AbstractDetector<MetadataSettingsUI>
         final Optional<File> sampleFile = resolveSample (sourceFile, slot.sample);
         if (sampleFile.isEmpty ())
         {
-            this.notifier.logError ("IDS_TONVERK_SAMPLE_NOT_FOUND", slot.sample);
+            this.reportMissingSample (slot.sample);
             return Optional.empty ();
         }
 
@@ -452,6 +462,20 @@ public class TonverkPresetDetector extends AbstractDetector<MetadataSettingsUI>
         zone.setGain (volume <= 0 ? Double.NEGATIVE_INFINITY : 20.0 * Math.log10 (volume));
         final double panning = preset.paramDouble (prefix + "_pan", 0.5);
         zone.setPanning (Math.clamp ((panning - 0.5) * 2.0, -1.0, 1.0));
+    }
+
+
+    /**
+     * Report a sample which could not be found. A Multi or Drum preset references the same file
+     * from every key-zone which is cut out of it; a missing sample is therefore reported only once
+     * per preset. An empty slot references no sample and is not reported.
+     *
+     * @param devicePath The absolute device path of the sample
+     */
+    private void reportMissingSample (final String devicePath)
+    {
+        if (devicePath != null && !devicePath.isBlank () && this.reportedMissingSamples.add (devicePath))
+            this.notifier.logError ("IDS_TONVERK_SAMPLE_NOT_FOUND", devicePath);
     }
 
 

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -876,6 +876,7 @@ IDS_ELEKTRON_CONVERT_TO_24_48=Re-sample to 24bit/48kHz
 IDS_TONVERK_UNKNOWN_MACHINE=Unknown Tonverk generator machine '%1'. Only One-Shot, Multi, Drum and Grainer are supported.\n
 IDS_TONVERK_EMPTY_OR_CORRUPT=The Tonverk preset file is empty or corrupt and was skipped: %1\n
 IDS_TONVERK_SAMPLE_NOT_FOUND=Could not find the sample referenced by the preset: %1\n
+IDS_TONVERK_NO_SAMPLES=None of the samples of the preset '%1' could be found. Skipped.\n
 IDS_TONVERK_DRUM_LIMIT=The source has %1 drums but the Tonverk Drum machine only has %2 voices. The additional drums are dropped.\n
 IDS_TONVERK_OUTPUT_ENGINE=Output Engine
 IDS_TONVERK_ENGINE_MULTI=Multi-Sample


### PR DESCRIPTION
Found with a commercial Tonverk pack (Mirage, *Colors In Space*) whose download lacks the WAV files of two of its 89 instruments.

**One line per key-zone.** A Multi or Drum preset references the same WAV file from every key-zone which is cut out of it, and the detector reported a sample it could not find once per zone: *CIS-KEYS 03*, whose 14 key-zones all come from `Colors In Space 10/AWKWARD HOTSHOT.wav`, printed the same "Could not find the sample referenced by the preset" line 14 times, *CIS-SYNTH 15* printed it 22 times. The detector now keeps the paths it has already reported for the preset being read and reports each missing sample once. An empty sample slot references nothing and is not reported at all.

**Silent skip.** A preset none of whose samples could be found ended up without groups and was dropped without a word, so the repeated error above was its only trace. Such a preset is now reported as skipped: `None of the samples of the preset 'CIS-KEYS 03.tvpst' could be found. Skipped.`

Verified by analysing four Tonverk preset corpora (the factory library and the Mirage, Dissolve and EOH packs, 476 presets) with the build before and after the change: the Mirage log shrinks from 36 missing-sample lines to 2 plus the 2 skip lines, and the logs of the other three corpora are identical.
