### PR TITLE
SFZ: read the transpose opcode and write whole semitones as transpose

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -34,6 +34,7 @@
 * SFZ
   * New: Opcode groups are now aggregated to group and global level.
   * Fixed: Unused opcodes were not logged.
+  * New: The 'transpose' opcode is read; it was ignored, so a region which is transposed by whole semitones played at the wrong pitch (75 of the 1,787 SFZ files on the test machine use it). When writing, whole semitones go into 'transpose' and only the remainder into 'tune', whose range the specification limits to one semitone.
 * SoundFont 2
   * Fixed: 24-bit samples were missing the padding byte in case that the number of samples were uneven. This made reading the created SF2 file fail in some tools (e.g. Polyphone).
   * Fixed: The specification version is now set to 2.04 if 24-bit samples are used otherwise it is still 2.01. This prevented 24-bit files to be loaded in Viena.

--- a/documentation/SupportedFeaturesSampleFormats.fods
+++ b/documentation/SupportedFeaturesSampleFormats.fods
@@ -9339,7 +9339,7 @@
       <text:p>sfz</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce41" table:number-columns-spanned="1" table:number-rows-spanned="2"/>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce14" office:value-type="string" calcext:value-type="string">
+     <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string" table:number-columns-repeated="2">
       <text:p>All (WAV)</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce23"/>
@@ -9399,7 +9399,7 @@
       <text:p>end</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
-      <text:p>tune</text:p>
+      <text:p>tune / transpose</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
       <text:p>pitch_keytrack</text:p>

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzCreator.java
@@ -369,7 +369,16 @@ public class SfzCreator extends AbstractWavCreator<SfzCreatorUI>
 
         final double tune = zone.getTuning ();
         if (tune != 0)
-            regionBuffer.append (addIntegerAttribute (SfzOpcode.TUNE, (int) Math.round (tune * 100), true));
+        {
+            // The whole semitones go into the transposition and the rest into the fine tuning,
+            // whose range is one semitone in the specification
+            final int transpose = (int) tune;
+            if (transpose != 0)
+                regionBuffer.append (addIntegerAttribute (SfzOpcode.TRANSPOSE, transpose, true));
+            final int cents = (int) Math.round ((tune - transpose) * 100);
+            if (cents != 0)
+                regionBuffer.append (addIntegerAttribute (SfzOpcode.TUNE, cents, true));
+        }
 
         final int keyTracking = (int) Math.round (zone.getKeyTracking () * 100.0);
         if (keyTracking != 100)

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzDetector.java
@@ -472,6 +472,8 @@ public class SfzDetector extends AbstractDetector<SfzDetectorUI>
         double tune = this.getDoubleValue (SfzOpcode.TUNE, 0);
         if (tune == 0)
             tune = this.getDoubleValue (SfzOpcode.PITCH, 0);
+        // The transposition in whole semitones adds to the fine tuning in cents
+        tune += this.getIntegerValue (SfzOpcode.TRANSPOSE, 0) * 100.0;
         sampleMetadata.setTuning (Math.clamp (tune, -3600, 3600) / 100.0);
 
         final double pitchKeytrack = this.getDoubleValue (SfzOpcode.PITCH_KEYTRACK, 100);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzOpcode.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/sfz/SfzOpcode.java
@@ -95,6 +95,8 @@ public class SfzOpcode
     public static final String PITCH                 = "pitch";
     /** SFZ v1. Defines how much the pitch changes with every note. */
     public static final String PITCH_KEYTRACK        = "pitch_keytrack";
+    /** SFZ v1. The transposition of the sample in semitones. */
+    public static final String TRANSPOSE             = "transpose";
 
     /** SFZ v1. The pitch bend up in cents (-9600 to 9600). */
     public static final String BEND_UP               = "bend_up";


### PR DESCRIPTION
The `transpose` opcode (SFZ v1, whole semitones) was not read: it was logged as unused and the region played at the wrong pitch. 75 of the 1,787 SFZ files on my machine use it. It is now added to the tuning, which carries whole semitones for the other formats already.

When writing, the whole semitones of a tuning go into `transpose` and only the remainder into `tune`, whose range the specification limits to one semitone - a tuning of -11.75 semitones was written as `tune=-1175` before, which not every player accepts.

Test: a zone with `transpose=-12 tune=25` reads as -11.75 semitones and is written back as `transpose=-11 tune=-75`.
