### PR TITLE
Renoise: read and write the 'Map key to pitch' switch of a sample

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,6 +31,8 @@
 * NI Kontakt
   * Fixed: Fixed a null pointer exception reading Kontakt 1 NKIs which was introduced in 20.2.
   * Fixed: Prevent adding duplicated website info to metadata description (reading Kontakt 2 - 4.2).
+* Renoise
+  * New: The 'Map key to pitch' switch of a sample is read and written. A drum kit whose samples do not follow the key was converted as a chromatic instrument, and the switch was always written as on.
 * SFZ
   * New: Opcode groups are now aggregated to group and global level.
   * Fixed: Unused opcodes were not logged.

--- a/documentation/SupportedFeaturesSampleFormats.fods
+++ b/documentation/SupportedFeaturesSampleFormats.fods
@@ -7971,7 +7971,10 @@
      <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
       <text:p>Transpose / Finetune</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce25" table:number-columns-repeated="2"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
+      <text:p>MapKeyToPitch</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce25"/>
      <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string" table:number-columns-spanned="1" table:number-rows-spanned="2">
       <text:p>Volume</text:p>
      </table:table-cell>
@@ -8044,8 +8047,8 @@
      <table:table-cell table:style-name="ce6" office:value-type="string" calcext:value-type="string">
       <text:p>Write</text:p>
      </table:table-cell>
-     <table:covered-table-cell table:number-columns-repeated="2" table:style-name="ce26"/>
-     <table:covered-table-cell table:number-columns-repeated="2" table:style-name="ce16"/>
+     <table:covered-table-cell table:style-name="ce26" table:number-columns-repeated="2"/>
+     <table:covered-table-cell table:style-name="ce16" table:number-columns-repeated="2"/>
      <table:table-cell table:style-name="ce23"/>
      <table:table-cell table:style-name="ce43"/>
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
@@ -8062,13 +8065,16 @@
      <table:table-cell table:style-name="ce23"/>
      <table:table-cell table:style-name="ce39"/>
      <table:table-cell table:style-name="ce23"/>
-     <table:covered-table-cell table:number-columns-repeated="3" table:style-name="ce26"/>
+     <table:covered-table-cell table:style-name="ce26" table:number-columns-repeated="3"/>
      <table:table-cell table:style-name="ce25"/>
      <table:covered-table-cell table:style-name="ce26"/>
      <table:table-cell table:style-name="ce25" table:number-columns-repeated="3"/>
      <table:covered-table-cell table:style-name="ce26"/>
-     <table:table-cell table:style-name="ce25" table:number-columns-repeated="2"/>
-     <table:covered-table-cell table:number-columns-repeated="4" table:style-name="ce26"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
+      <text:p>MapKeyToPitch</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce25"/>
+     <table:covered-table-cell table:style-name="ce26" table:number-columns-repeated="4"/>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
       <text:p>OneShotTrigger</text:p>
      </table:table-cell>
@@ -8089,7 +8095,7 @@
      <table:table-cell table:style-name="ce38" table:number-columns-repeated="2"/>
      <table:table-cell table:style-name="ce5" table:number-columns-repeated="2"/>
      <table:table-cell table:style-name="ce26"/>
-     <table:covered-table-cell table:number-columns-repeated="2" table:style-name="ce26"/>
+     <table:covered-table-cell table:style-name="ce26" table:number-columns-repeated="2"/>
      <table:covered-table-cell table:style-name="ce8"/>
      <table:table-cell table:style-name="ce5"/>
      <table:covered-table-cell table:style-name="ce26"/>

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseCreator.java
@@ -243,7 +243,8 @@ public class RenoiseCreator extends AbstractCreator<EmptySettingsUI>
         XMLUtils.addTextElement (document, mappingElement, RenoiseTag.BASE_NOTE, Integer.toString (RenoiseValueConverter.clampNote (zone.getKeyRoot ())));
         XMLUtils.addTextElement (document, mappingElement, RenoiseTag.NOTE_START, Integer.toString (RenoiseValueConverter.clampNote (zone.getKeyLow ())));
         XMLUtils.addTextElement (document, mappingElement, RenoiseTag.NOTE_END, Integer.toString (RenoiseValueConverter.clampNote (limitToDefault (zone.getKeyHigh (), RenoiseValueConverter.MAX_NOTE))));
-        XMLUtils.addTextElement (document, mappingElement, RenoiseTag.MAP_KEY_TO_PITCH, TRUE);
+        // A zone without key tracking, e.g. a drum, plays at its root pitch on every key
+        XMLUtils.addTextElement (document, mappingElement, RenoiseTag.MAP_KEY_TO_PITCH, zone.getKeyTracking () == 0 ? FALSE : TRUE);
         XMLUtils.addTextElement (document, mappingElement, RenoiseTag.VELOCITY_START, Integer.toString (Math.clamp (zone.getVelocityLow (), 0, 127)));
         XMLUtils.addTextElement (document, mappingElement, RenoiseTag.VELOCITY_END, Integer.toString (Math.clamp (limitToDefault (zone.getVelocityHigh (), 127), 0, 127)));
         XMLUtils.addTextElement (document, mappingElement, RenoiseTag.MAP_VELOCITY_TO_VOLUME, TRUE);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/renoise/RenoiseDetector.java
@@ -254,6 +254,11 @@ public class RenoiseDetector extends AbstractDetector<MetadataSettingsUI>
 
             if (RenoiseTag.LAYER_NOTE_OFF.equals (XMLUtils.getChildElementContent (mapping, RenoiseTag.LAYER)))
                 zone.setTrigger (TriggerType.RELEASE);
+
+            // A sample whose mapping does not change its pitch plays at its root pitch on every
+            // key, e.g. the drums of a kit
+            if ("false".equalsIgnoreCase (XMLUtils.getChildElementContent (mapping, RenoiseTag.MAP_KEY_TO_PITCH)))
+                zone.setKeyTracking (0);
         }
 
         // Loop


### PR DESCRIPTION
The `MapKeyToPitch` switch of a sample mapping was never read and always written as `true`. A drum kit whose samples do not follow the key - e.g. the 'Karplus-Strong Snare Generator' and 'PSYBass' instruments of the Renoise 3.5 library - was converted as a chromatic instrument, and a drum zone of another format was written to follow the keyboard.

The switch is now read into the key tracking of the zone (off = fixed pitch) and written from it.

Test: the two library instruments read back with 'Key tracking: 0 %', and an SFZ drum kit with `pitch_keytrack=0` written as XRNI reads back the same.
