### PR TITLE
Logic EXS24: read and write the 'Pitch' switch of a zone, read the transposition of the instrument

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -28,6 +28,8 @@
   * Fixed: Forward/backward ('fwd/bkwd') loops of Emulator III banks were lost. The loop type of a sample is a 2 bit field - 0: off, 1: forward, 2: forward/backward - and only the forward bit was tested, so a forward/backward sample was converted as not looped at all. Such loops are now read as alternating loops, which destinations that support them play as intended (e.g. TAL Sampler as a ping-pong loop). The field layout was verified against the sampler's OS 2.42 firmware; only the original Emulator III knows this loop type, the Emulator IIIX and ESI have dropped it.
 * Elektron Tonverk Preset
   * Fixed: A sample which could not be found was reported once for every key-zone which is cut out of it - a Multi preset which spreads one WAV file across the keyboard gave a dozen identical lines. A missing sample is now reported once per preset, and a preset none of whose samples could be found is reported as skipped.
+* Logic EXS24
+  * New: The 'Pitch' switch of a zone is read and written: a zone with the switch off plays its sample at the same pitch on every key (e.g. a drum) and was converted as a chromatic instrument - 644 of the 66,392 zones of the DSF E-mu Proteus library have it off - and every written zone had it on. The transposition of the instrument is read as well.
 * NI Kontakt
   * Fixed: Fixed a null pointer exception reading Kontakt 1 NKIs which was introduced in 20.2.
   * Fixed: Prevent adding duplicated website info to metadata description (reading Kontakt 2 - 4.2).

--- a/documentation/SupportedFeaturesSampleFormats.fods
+++ b/documentation/SupportedFeaturesSampleFormats.fods
@@ -5535,7 +5535,7 @@
       <text:p>exs</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce39"/>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce14" office:value-type="string" calcext:value-type="string">
+     <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string" table:number-columns-repeated="2">
       <text:p>All (AIFF)</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce23"/>
@@ -5591,10 +5591,10 @@
       <text:p>sampleEnd</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
-      <text:p>coarseTuning / fineTuning</text:p>
+      <text:p>coarseTuning / fineTuning / TRANSPOSE (read)</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
-      <text:p>pitch / oneshot</text:p>
+      <text:p>Zone pitch switch</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
       <text:p>reverse</text:p>
@@ -5676,7 +5676,7 @@
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
       <text:p>PARAM_FILTER1_TYPE</text:p>
      </table:table-cell>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce14" office:value-type="string" calcext:value-type="string">
+     <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string" table:number-columns-repeated="2">
       <text:p>PARAM_FILTER1_CUTOFF</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Creator.java
@@ -137,7 +137,8 @@ public class EXS24Creator extends AbstractWavCreator<WavChunkSettingsUI>
                 exs24Zone.reverse = zone.isReversed ();
                 exs24Zone.oneshot = zone.isOneShot ();
                 exs24Zone.volumeAdjust = (int) Math.round (zone.getGain ());
-                exs24Zone.pitch = true;
+                // The 'Pitch' switch: off plays the sample at the same pitch on every key
+                exs24Zone.pitch = zone.getKeyTracking () != 0;
                 final double tune = zone.getTuning ();
                 exs24Zone.coarseTuning = (int) Math.round (tune);
                 exs24Zone.fineTuning = (int) Math.round ((tune - exs24Zone.coarseTuning) * 100);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/exs/EXS24Detector.java
@@ -154,6 +154,8 @@ public class EXS24Detector extends AbstractDetector<MetadataWithSearchHeightSett
             zone.setReversed (exs24Zone.reverse);
             zone.setOneShot (exs24Zone.oneshot);
             zone.setGain (exs24Zone.volumeAdjust);
+            // A zone whose 'Pitch' switch is off plays its sample at the same pitch on every key
+            zone.setKeyTracking (exs24Zone.pitch ? 1 : 0);
 
             if (exs24Zone.pitch && (exs24Zone.coarseTuning != 0 || exs24Zone.fineTuning != 0))
                 zone.setTuning (exs24Zone.coarseTuning + exs24Zone.fineTuning / 100.0);
@@ -281,11 +283,14 @@ public class EXS24Detector extends AbstractDetector<MetadataWithSearchHeightSett
         if (monoLegato != null && monoLegato.intValue () > 0)
             multisampleSource.setMonophonicLegato (true);
 
+        // The transposition of the instrument in semitones adds to its coarse and fine tuning
+        final Integer globalTranspose = parameters.get (EXS24Parameters.TRANSPOSE);
+        final int transpose = globalTranspose == null ? 0 : globalTranspose.intValue ();
         final Integer globalCoarseTune = parameters.get (EXS24Parameters.COARSE_TUNE);
         final int coarseTune = globalCoarseTune == null ? 0 : globalCoarseTune.intValue ();
         final Integer globalFineTune = parameters.get (EXS24Parameters.FINE_TUNE);
         final int fineTune = globalFineTune == null ? 0 : globalFineTune.intValue ();
-        final double tuneOffset = coarseTune + fineTune / 100.0;
+        final double tuneOffset = transpose + coarseTune + fineTune / 100.0;
 
         final IEnvelope globalAmplitudeEnvelope = createEnvelope (parameters, 1);
         final Integer env1Velocity = parameters.get (EXS24Parameters.ENV1_VEL_SENS);


### PR DESCRIPTION
The 'Pitch' switch of a zone (zone options bit 1) was read only to decide whether the tuning applies, and was always written as on. A zone with the switch off plays its sample at the same pitch on every key: 644 of the 66,392 zones of the DSF E-mu Proteus EXS24 library have it off and were converted as chromatic instruments. The switch is now read into the key tracking of the zone and written from it.

The transposition of the instrument (parameter 0x2d, semitones) is read as well and added to the coarse and fine tuning offset. None of the 3,324 Proteus files sets it, so that corpus does not exercise it.

Test: an SFZ drum kit with `pitch_keytrack=0` written as EXS reads back with 'Key tracking: 0 %'; the Proteus 'Mo' Phatt' folder reads unchanged otherwise.
