### PR TITLE
Akai S-1000/S-3000: convert the octave shift, the stereo level and the stereo pan of a program

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Fixed: 32-bit float samples (e.g. the WAV files which DirectWave writes) were always converted to 16 bit, even though the log announced the 24 bit of the destination format. A float sample is now converted to the highest resolution the destination supports - 24 bit for e.g. SoundFont 2, Bliss, Tonverk, DirectWave and FLAC, 32 bit for ALAC - and keeps its float format for destinations without a restriction, e.g. when only the chunks of a WAV file are updated.
 * Fixed: Sample search did only search upwards but not downwards from the current directory.
 * Fixed: Ignore very short loops (1-2 samples) stored in WAV sample chunks.
+* Akai S-1000/S-3000
+  * New: The octave shift, the stereo level and the stereo pan of a program are converted (also for MESA S3P files). A program which is shifted by one or two octaves was converted at its unshifted pitch; the level (0-99) and the pan (-50..50) of the program in the stereo mix are applied on top of the levels and pans of its key-groups.
 * E-mu Emulator II
   * New: Writing of Emulator II disks (HFE, EMUIIFD): each multi-sample becomes a preset of the bank, several of them as a library on one disk, with the voices of the key ranges, second voices, loops and the companded audio at 27,777 Hz. The settings of the voices are not decoded and are taken from a voice of the factory library; the operating system is copied from a system file or a disk image named in the settings. Not yet verified on hardware.
   * New: Bank files (EII) are read: the bank memory alone, without the operating system, as the Sound Designer software of 1985 received it from the sampler, as the EMXP tools extract and write it and as Arturia's Emulator II V imports it.

--- a/documentation/SupportedFeaturesSampleFormats.fods
+++ b/documentation/SupportedFeaturesSampleFormats.fods
@@ -2594,7 +2594,7 @@
       <text:p>ISO</text:p>
      </table:table-cell>
      <table:covered-table-cell table:style-name="ce26"/>
-     <table:table-cell table:number-columns-repeated="2" table:style-name="ce14" office:value-type="string" calcext:value-type="string">
+     <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string" table:number-columns-repeated="2">
       <text:p>All (WAV)</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce23"/>
@@ -2637,17 +2637,17 @@
       <text:p>End</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
-      <text:p>semitone-tune / fine tune</text:p>
+      <text:p>semitone-tune / fine tune / Octave shift</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
       <text:p>Keytracking</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce39"/>
      <table:table-cell table:style-name="ce21" office:value-type="string" calcext:value-type="string">
-      <text:p>(relative) gain</text:p>
+      <text:p>(relative) gain / Stereo level</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce14" office:value-type="string" calcext:value-type="string">
-      <text:p>panning</text:p>
+      <text:p>panning / Stereo pan</text:p>
      </table:table-cell>
      <table:table-cell table:style-name="ce39"/>
      <table:table-cell table:style-name="ce25"/>

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s1000/AkaiS1000Program.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s1000/AkaiS1000Program.java
@@ -42,9 +42,8 @@ public class AkaiS1000Program
     // 0..7, 255=OFF
     @SuppressWarnings("unused")
     private byte                 auxOutputSelect;
-    // 0..99
-    @SuppressWarnings("unused")
-    private byte                 mixOutputSelect;
+    // 0..99, the level of the program in the stereo mix (STEREO in the Akai documentation)
+    private byte                 stereoLevel;
     // -50..50
     private byte                 mixPan;
     // 0..99
@@ -218,7 +217,7 @@ public class AkaiS1000Program
         this.highKey = image.readInt8 ();
         this.octaveShift = image.readInt8 ();
         this.auxOutputSelect = image.readInt8 ();
-        this.mixOutputSelect = image.readInt8 ();
+        this.stereoLevel = image.readInt8 ();
         this.mixPan = image.readInt8 ();
         this.volume = image.readInt8 ();
         this.velocityToVolume = image.readInt8 ();
@@ -352,6 +351,17 @@ public class AkaiS1000Program
     public byte getMixPan ()
     {
         return this.mixPan;
+    }
+
+
+    /**
+     * Get the level of the program in the stereo mix output, 0-99 with 99 being the full level.
+     *
+     * @return The stereo level
+     */
+    public byte getStereoLevel ()
+    {
+        return this.stereoLevel;
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s1000/AkaiS1000ProgramConverter.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/akai/s1000/AkaiS1000ProgramConverter.java
@@ -422,6 +422,15 @@ public class AkaiS1000ProgramConverter
         // Set global values
         final int pitchBendRange = program.getBendToPitch () & 0xFF;
         final double gain = scaledLoudnessToDecibel (program.getVolume () & 0xFF) - FULL_LEVEL * DECIBEL_PER_STEP;
+        // The program sits in the stereo mix at its stereo level (0-99, 99 is the full level, on
+        // the loudness scale like the program level) and at its stereo pan (-50..50), both on top
+        // of the level and the pan of the key-group samples
+        final double stereoLevel = scaledLoudnessToDecibel (program.getStereoLevel () & 0xFF) - FULL_LEVEL * DECIBEL_PER_STEP;
+        final double stereoPan = Math.clamp (program.getMixPan (), -50, 50) / 50.0;
+        // The octave shift transposes the whole program by up to two octaves: a key plays what is
+        // mapped an octave below or above it, so the key ranges move against the shift and the
+        // tuning moves with it
+        final int octaveShift = Math.clamp (program.getOctaveShift (), -2, 2) * 12;
         final double velocityToVolume = Math.clamp (program.getVelocityToVolume () / 50.0, -1.0, 1.0);
         // The native range of the key to volume intensity is [-50..50] which maps to the model
         // range of [-1..1]
@@ -430,7 +439,15 @@ public class AkaiS1000ProgramConverter
         {
             zone.setBendUp (pitchBendRange * 100);
             zone.setBendDown (-pitchBendRange * 100);
-            zone.setGain (zone.getGain () + gain);
+            zone.setGain (zone.getGain () + gain + stereoLevel);
+            if (stereoPan != 0)
+                zone.setPanning (Math.clamp (zone.getPanning () + stereoPan, -1, 1));
+            if (octaveShift != 0)
+            {
+                zone.setKeyLow (Math.max (0, zone.getKeyLow () - octaveShift));
+                zone.setKeyHigh (Math.min (127, zone.getKeyHigh () - octaveShift));
+                zone.setTuning (zone.getTuning () + octaveShift);
+            }
             zone.getAmplitudeVelocityModulator ().setDepth (velocityToVolume);
             zone.setAmplitudeKeyTracking (keyToVolume);
         }


### PR DESCRIPTION
Three fields of the program header were parsed and never applied: the octave shift (0x15, -2..2), the stereo level (0x17, 0-99, 99 = full) and the stereo pan (0x18, -50..50). A program which is shifted by an octave was converted at its unshifted pitch.

The octave shift moves the key ranges against the shift and the tuning with it, as the S-7xx reader does for its octave shift. The stereo level is converted with the loudness law of the program level - both are 0-99 loudness parameters of the same operating system - and added to the zone gains together with it; the pan is added to the pans of the key-group samples. MESA S3P files go through the same parser and converter. The field which held the stereo level was named `mixOutputSelect`; it is `stereoLevel` now.

Test: the 'Best Service XX Large Pads' CD-ROM read before and after: 1,465 zones are 0.7 dB lower, since the programs of that CD sit below the full stereo level; nothing else changes. No program of that CD is shifted or panned, so those two paths mirror the S-7xx code but are not exercised by it.
