### PR TITLE
Roland MC-707 and ZEN-Core: read and write the pitch key follow of a partial

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -31,6 +31,10 @@
 * NI Kontakt
   * Fixed: Fixed a null pointer exception reading Kontakt 1 NKIs which was introduced in 20.2.
   * Fixed: Prevent adding duplicated website info to metadata description (reading Kontakt 2 - 4.2).
+* Roland MC-707/MC-101
+  * New: The pitch key follow of a partial (100 = chromatic, 0 = the same pitch on every key) is read and written, and the keys of a written drum kit which play a zone without key tracking all get the pitch of its root key.
+* Roland ZEN-Core
+  * New: The pitch key follow of a partial is read and written - the same field as on the MC-707, 100 = chromatic in all templates. A drum zone was converted as chromatic and written to follow the keyboard.
 * SFZ
   * New: Opcode groups are now aggregated to group and global level.
   * Fixed: Unused opcodes were not logged.

--- a/documentation/SupportedFeaturesSampleFormats.fods
+++ b/documentation/SupportedFeaturesSampleFormats.fods
@@ -8148,7 +8148,11 @@
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>End point</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce25" table:number-columns-repeated="3"/>
+     <table:table-cell table:style-name="ce25"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
+      <text:p>Partial key follow (+0x22)</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce25"/>
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>Level</text:p>
      </table:table-cell>
@@ -8220,7 +8224,11 @@
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>End point</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce25" table:number-columns-repeated="3"/>
+     <table:table-cell table:style-name="ce25"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
+      <text:p>Partial key follow (+0x22)</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce25"/>
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>Level</text:p>
      </table:table-cell>
@@ -8951,7 +8959,10 @@
      <table:table-cell table:style-name="ce43" office:value-type="string" calcext:value-type="string">
       <text:p>Fine tune</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce25" table:number-columns-repeated="2"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
+      <text:p>Partial key follow (0xEA)</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce25"/>
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>Level</text:p>
      </table:table-cell>
@@ -9059,7 +9070,11 @@
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>End point</text:p>
      </table:table-cell>
-     <table:table-cell table:style-name="ce25" table:number-columns-repeated="3"/>
+     <table:table-cell table:style-name="ce25"/>
+     <table:table-cell table:style-name="ce16" office:value-type="string" calcext:value-type="string">
+      <text:p>Partial key follow (0xEA)</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="ce25"/>
      <table:table-cell table:style-name="ce5" office:value-type="string" calcext:value-type="string">
       <text:p>Level</text:p>
      </table:table-cell>

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mc707/MC707Creator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mc707/MC707Creator.java
@@ -83,6 +83,8 @@ public class MC707Creator extends AbstractCreator<MC707CreatorUI>
     private static final int                    OSC_FINE_TUNE        = 0x03;
     // signed, -64 = hard left, 0 = centre, +63 = hard right
     private static final int                    OSC_PAN              = 0x06;
+    // s16, -200 to +200, 100 = chromatic, 0 = the same pitch on every key
+    private static final int                    OSC_KEY_FOLLOW       = 0x22;
     // 0 = ROM, 2 = user sample
     private static final int                    OSC_WAVE_GROUP       = 0x17;
     // 0x08 for ROM waves, 0 for user samples
@@ -275,7 +277,7 @@ public class MC707Creator extends AbstractCreator<MC707CreatorUI>
 
         writeToneFilter (toneRecord, zone);
         writeToneEnvelope (toneRecord, zone);
-        writeToneLevelPitchAndPan (toneRecord, zone.getTuning (), zone.getPanning ());
+        writeToneLevelPitchAndPan (toneRecord, zone.getTuning (), zone.getPanning (), zone.getKeyTracking ());
 
         System.arraycopy (toneRecord, 0, project.getData (), project.getUserToneOffset (slot), MC707Project.TONE_SIZE);
         return true;
@@ -357,9 +359,9 @@ public class MC707Creator extends AbstractCreator<MC707CreatorUI>
         final ISampleZone representative = zones.get (0);
         writeToneFilter (toneRecord, representative);
         writeToneEnvelope (toneRecord, representative);
-        // The partial plays the whole map, so only tuning and panning shared by all zones can be
-        // applied to it.
-        writeToneLevelPitchAndPan (toneRecord, multisampleSource.getGlobalTuning ().orElse (Double.valueOf (0)).doubleValue (), multisampleSource.getGlobalPanning ().orElse (Double.valueOf (0)).doubleValue ());
+        // The partial plays the whole map, so only tuning, panning and key tracking shared by all
+        // zones can be applied to it.
+        writeToneLevelPitchAndPan (toneRecord, multisampleSource.getGlobalTuning ().orElse (Double.valueOf (0)).doubleValue (), multisampleSource.getGlobalPanning ().orElse (Double.valueOf (0)).doubleValue (), getSharedKeyTracking (zones));
 
         System.arraycopy (toneRecord, 0, project.getData (), project.getUserToneOffset (slot), MC707Project.TONE_SIZE);
         return true;
@@ -426,7 +428,8 @@ public class MC707Creator extends AbstractCreator<MC707CreatorUI>
             final int keyOffset = project.getUserKitKeyOffset (slot, keyIndex);
             System.arraycopy (ZenCoreUtil.padName (pool.get (sampleSlot.intValue ()).name, MC707Project.NAME_LENGTH), 0, data, keyOffset, MC707Project.NAME_LENGTH);
             data[keyOffset + KEY_LEVEL] = (byte) levelFromGain (best.getGain ());
-            data[keyOffset + KEY_PITCH] = (byte) Math.clamp (0x3CL + key - rootKey, 0, 127);
+            // A zone without key tracking, e.g. a drum, plays at its root pitch on every key
+            data[keyOffset + KEY_PITCH] = (byte) (best.getKeyTracking () == 0 ? 0x3C : Math.clamp (0x3CL + key - rootKey, 0, 127));
             System.arraycopy (KEY_MODE_USER_SAMPLE, 0, data, keyOffset + KEY_MODE, KEY_MODE_USER_SAMPLE.length);
             ZenCoreUtil.writeUnsigned32 (data, keyOffset + KEY_WAVE_NUMBER, sampleSlot.intValue () + 1L, false);
             hasKeys = true;
@@ -638,14 +641,33 @@ public class MC707Creator extends AbstractCreator<MC707CreatorUI>
      * @param toneRecord The tone record
      * @param tuning The tuning in semi-tones
      * @param panning The panning in the range of [-1..1]
+     * @param keyTracking The pitch key tracking in the range of [0..1], 0 plays the same pitch on
+     *            every key
      */
-    private static void writeToneLevelPitchAndPan (final byte [] toneRecord, final double tuning, final double panning)
+    private static void writeToneLevelPitchAndPan (final byte [] toneRecord, final double tuning, final double panning, final double keyTracking)
     {
         putU16 (toneRecord, PARTIAL_BLOCK + OSC_LEVEL, 127);
         final int coarseTune = Math.clamp ((long) tuning, -48, 48);
         toneRecord[PARTIAL_BLOCK + OSC_COARSE_TUNE] = (byte) coarseTune;
         toneRecord[PARTIAL_BLOCK + OSC_FINE_TUNE] = (byte) Math.clamp (Math.round ((tuning - coarseTune) * 100.0), -50, 50);
         toneRecord[PARTIAL_BLOCK + OSC_PAN] = (byte) Math.clamp (Math.round (panning * 64.0), -64, 63);
+        putU16 (toneRecord, PARTIAL_BLOCK + OSC_KEY_FOLLOW, (int) Math.round (Math.clamp (keyTracking, 0, 1) * 100.0));
+    }
+
+
+    /**
+     * Get the pitch key tracking which all zones share: 0 if none of them tracks the key (e.g. the
+     * pads of a drum kit), otherwise the full chromatic tracking.
+     *
+     * @param zones The zones
+     * @return The key tracking in the range of [0..1]
+     */
+    private static double getSharedKeyTracking (final List<ISampleZone> zones)
+    {
+        for (final ISampleZone zone: zones)
+            if (zone.getKeyTracking () != 0)
+                return 1;
+        return zones.isEmpty () ? 1 : 0;
     }
 
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mc707/MC707Detector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/mc707/MC707Detector.java
@@ -59,6 +59,8 @@ public class MC707Detector extends AbstractDetector<MetadataSettingsUI>
     private static final int OSC_COARSE_TUNE = 0x02;
     private static final int OSC_FINE_TUNE   = 0x03;
     private static final int OSC_PAN         = 0x06;
+    // s16, 100 = chromatic, 0 = the same pitch on every key
+    private static final int OSC_KEY_FOLLOW  = 0x22;
     private static final int OSC_WAVE_GROUP  = 0x17;
     private static final int OSC_WAVE_NUMBER = 0x1A;
     private static final int OSC_FILTER_TYPE = 0x24;
@@ -281,9 +283,11 @@ public class MC707Detector extends AbstractDetector<MetadataSettingsUI>
         final int coarseTune = data[partialOffset + OSC_COARSE_TUNE];
         final int fineTune = data[partialOffset + OSC_FINE_TUNE];
         final int panning = data[partialOffset + OSC_PAN];
+        // The pitch key follow of the partial: 100 = chromatic, 0 = the same pitch on every key
+        final int keyFollow = (short) ZenCoreUtil.readUnsigned16 (data, partialOffset + OSC_KEY_FOLLOW, false);
         // The partial level scales the level of the sample slot, both are linear 0-127 volumes.
         final double gain = MathUtils.valueToDb (Math.max (level, 1) / 127.0);
-        signature.append ("/P").append (level).append (':').append (coarseTune).append (':').append (fineTune).append (':').append (panning);
+        signature.append ("/P").append (level).append (':').append (coarseTune).append (':').append (fineTune).append (':').append (panning).append (':').append (keyFollow);
 
         final int tvaOffset = offset + TONE_TVA + partial * TONE_TVA_STRIDE;
         final IEnvelope amplitudeEnvelope = new DefaultEnvelope ();
@@ -315,6 +319,7 @@ public class MC707Detector extends AbstractDetector<MetadataSettingsUI>
             zone.setGain (zone.getGain () + gain);
             zone.setTuning (coarseTune + fineTune / 100.0);
             zone.setPanning (Math.clamp (panning / 64.0, -1, 1));
+            zone.setKeyTracking (Math.clamp (keyFollow / 100.0, 0, 1));
             zone.getAmplitudeEnvelopeModulator ().setSource (amplitudeEnvelope);
             if (type != null)
                 zone.setFilter (new DefaultFilter (type, 4, MathUtils.denormalizeCutoff (cutoff / 1023.0), resonance / 1023.0));

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreCreator.java
@@ -530,6 +530,9 @@ public class ZenCoreCreator extends AbstractCreator<ShortNameSettingsUI>
 
     private static void applyToneParameters (final SvzInstrument instrument, final ISampleZone zone, final double minOnsetEdge)
     {
+        // A zone without key tracking, e.g. a drum, plays at its root pitch on every key
+        instrument.keyFollow = (int) Math.round (Math.clamp (zone.getKeyTracking (), 0, 1) * 100.0);
+
         final Optional<IFilter> optFilter = zone.getFilter ();
         if (optFilter.isPresent ())
         {

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreDetector.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreDetector.java
@@ -178,6 +178,7 @@ public class ZenCoreDetector extends AbstractDetector<MetadataSettingsUI>
             final ISampleZone zone = zones.get (i);
             if (panning != 0)
                 zone.setPanning (Math.clamp (zone.getPanning () + panning, -1, 1));
+            zone.setKeyTracking (Math.clamp (partial.keyFollow / 100.0, 0, 1));
             if (hasVelocityWindow)
             {
                 zone.setVelocityLow (partial.velLow);

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/roland/zencore/ZenCoreSvz.java
@@ -129,6 +129,11 @@ public final class ZenCoreSvz
     private static final int     PAT_WAVE_GROUP        = 0xDF;
     /** Partial pan: signed byte, -64 = hard left, 0 = centre, +63 = hard right. OSC stride. */
     private static final int     PAT_PAN               = 0xCE;
+    /**
+     * Partial pitch key follow: s16, 100 = chromatic, 0 = the same pitch on every key (the
+     * templates hold 100). OSC stride. Corpus-verified on the MC-707, which shares the record.
+     */
+    private static final int     PAT_KEY_FOLLOW        = 0xEA;
     /** Velocity range lower (1-127). Keyboard-table stride. */
     private static final int     PAT_VEL_LOW           = 0xA0;
     /** Velocity range upper (1-127). Keyboard-table stride. */
@@ -241,6 +246,8 @@ public final class ZenCoreSvz
         public int waveRight;
         /** Pan -64 (hard left) .. 0 (centre) .. +63 (hard right). */
         public int pan;
+        /** Pitch key follow, 100 = chromatic, 0 = the same pitch on every key. */
+        public int keyFollow = 100;
         /** Velocity range lower 1-127. */
         public int velLow  = 1;
         /** Velocity range upper 1-127. */
@@ -289,6 +296,8 @@ public final class ZenCoreSvz
         // ----------------------------------------------------------------------------------------
         // Optional Partial-1 tone parameters taken from the source; -1 keeps the template default
 
+        /** Pitch key follow: 100 = chromatic, 0 = the same pitch on every key (-1 = keep template). */
+        public int                        keyFollow        = -1;
         /** Filter type: 1=LPF, 2=BPF, 3=HPF (-1 = keep template). */
         public int                        filterType       = -1;
         /** Filter cutoff 0-1023. */
@@ -546,6 +555,8 @@ public final class ZenCoreSvz
     private static void writePartialShaping (final byte [] aRecord, final int p, final SvzInstrument instrument)
     {
         final int filterBase = p * PAT_PARTIAL_STRIDE;
+        if (instrument.keyFollow >= 0)
+            putU16LE (aRecord, PAT_KEY_FOLLOW + filterBase, instrument.keyFollow);
         if (instrument.filterType >= 1)
         {
             putU16LE (aRecord, PAT_FILTER_TYPE + filterBase, instrument.filterType * 0x100);
@@ -869,6 +880,7 @@ public final class ZenCoreSvz
             partial.waveLeft = ZenCoreUtil.readUnsigned16 (file, r + PAT_WAVE_L + oscBase, false);
             partial.waveRight = ZenCoreUtil.readUnsigned16 (file, r + PAT_WAVE_R + oscBase, false);
             partial.pan = file[r + PAT_PAN + oscBase];
+            partial.keyFollow = (short) ZenCoreUtil.readUnsigned16 (file, r + PAT_KEY_FOLLOW + oscBase, false);
 
             final int kbdBase = p * PAT_KBD_STRIDE;
             final int velLow = file[r + PAT_VEL_LOW + kbdBase] & 0xFF;


### PR DESCRIPTION
The pitch key follow of a partial - `+0x22` of the partial block, s16, 100 = chromatic, 0 = the same pitch on every key; corpus-verified on the MC-707 and 100 in all four partial slots of the ZEN-Core templates - was neither read nor written. A drum zone was converted as a chromatic instrument and written to follow the keyboard, and a tone with a non-chromatic key follow read as chromatic.

Both readers now set the key tracking of the zones from it. Both creators write it from the zone: the ZEN-Core creator from the representative zone of the tone, the MC-707 tone from its zone and the MC-707 multi-tone from what all its zones share. The keys of a written MC-707 drum kit which play a zone without key tracking all get the pitch of its root key instead of a chromatic run.

Test: an SFZ drum kit with `pitch_keytrack=0` written to an MC-707 project and to an SVZ - the SVZ reads back with 'Key tracking: 0 %', the kit with every key at its own root; the MC-707 project corpus and the FANTOM-0 device exports read unchanged.
