### PR TITLE
Waldorf Quantum/Iridium: the cutoff of the filter was written with the normalized value as its display text

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -46,6 +46,8 @@
 * Synclavier Regen
   * Fixed: Partials which are muted in the editor were converted as layers. The editor keeps the samples of a muted partial in the timbre, so e.g. the switched-off sub-octave pulse of 'Prodigy Pad' (Starsky's Prodigy) became the first layer - and since it has no release time, destinations with one amplitude envelope per preset (e.g. Waldorf Iridium/Quantum) got an instant release instead of the 3.5 seconds of the pad. Only the active partials are converted now - those which carry a volume line, which is also how the device builds the active-partial mask of its timbre index.
   * Fixed: The contour of the note filter envelope was lost: only its peak level was read, the start level and the end level which the release heads to were ignored, and no sustain level was set - so destinations which default a missing sustain to the full level (e.g. Waldorf Iridium/Quantum) kept the filter at its peak for the whole note; none of the 26 filter envelopes of 'Starsky's Prodigy' ever decayed there. The three levels are octaves relative to the cutoff, which is the sustain level of the contour (Regen manual, 'Filter Envelope'); they are now read and written completely, and a contour which reaches below the cutoff is re-based so that the envelope of the model can carry it.
+* Waldorf Quantum/Iridium
+  * Fixed: The cutoff of the filter was written with the normalized parameter value as its display text, so the device listed a patch with a cutoff of e.g. 61.7 Hz as '0.2592 Hz'. A cutoff at the top of the range of the model (20,000 Hz) also wrote a parameter value slightly above the 1.0 the device expects; it is now limited to the 19,912.2 Hz of the device.
 
 ## 20.2.0
 

--- a/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
+++ b/src/main/java/de/mossgrabers/convertwithmoss/format/waldorf/qpat/WaldorfQpatCreator.java
@@ -102,6 +102,10 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
     private static final double                                DECLICK_SECONDS        = 0.07;
     /** The share of the peak level at which a step in the audio becomes audible as a click. */
     private static final double                                AUDIBLE_STEP_RATIO     = 0.02;
+    /** The lowest cutoff frequency of the filter of the device, the value 0 of Filter1CutOff. */
+    private static final double                                MIN_CUTOFF_FREQUENCY   = 8.1758;
+    /** The highest cutoff frequency of the filter of the device, the value 1 of Filter1CutOff. */
+    private static final double                                MAX_CUTOFF_FREQUENCY   = 19912.2;
 
     /**
      * The modulation matrix slot which routes the low frequency oscillator of the vibrato. The
@@ -1084,8 +1088,9 @@ public class WaldorfQpatCreator extends AbstractWavCreator<WaldorfQpatCreatorUI>
         parameters.add (new WaldorfQpatParameter ("Filter12Type", (is24 ? "24" : "12") + filterName, pos));
 
         // Filter1CutOff: [0.00] "8.1758 Hz" ... [1.00] "19912.2 Hz"
-        final double cutoff = Math.log (filter.getCutoff () / 8.1758) / (Math.log (2) * 11.25);
-        parameters.add (new WaldorfQpatParameter ("Filter1CutOff", StringUtils.formatDouble (cutoff, 4, " Hz"), (float) cutoff));
+        final double cutoffFrequency = Math.clamp (filter.getCutoff (), MIN_CUTOFF_FREQUENCY, MAX_CUTOFF_FREQUENCY);
+        final double cutoff = Math.log (cutoffFrequency / MIN_CUTOFF_FREQUENCY) / (Math.log (2) * 11.25);
+        parameters.add (new WaldorfQpatParameter ("Filter1CutOff", StringUtils.formatDouble (cutoffFrequency, 4, " Hz"), (float) cutoff));
 
         // Filter1Reso: [0.00] "0.00 %" ... [1.00] "100.00 %"
         final double resonance = filter.getResonance ();


### PR DESCRIPTION
`WaldorfQpatCreator` wrote the *normalized* parameter value into the display text of `Filter1CutOff`, so a patch with a cutoff of 61.7 Hz reached the device labelled `0.2592 Hz`:

```
Filter1CutOff   0.259171   "0.2592 Hz"     <- before
Filter1CutOff   0.259171   "61.6930 Hz"    <- after
```

The float itself was always right and the device decodes the float, so this is the hint text only - but it is what anyone reading a written patch sees, and every QPAT ConvertWithMoss writes carries it. The other parameters all fill the hint with the value as the device displays it, so this one was simply out of line.

The same two lines now also limit the cutoff to the range of the device. `IFilter.MAX_FREQUENCY` is 20,000 Hz while `Filter1CutOff` reaches 19,912.2 Hz at 1.0, so a source at the top of the range of the model wrote 1.00057 into a parameter the device expects in 0..1.

The two frequencies of the law are named constants now instead of literals in the expression.
